### PR TITLE
added missing compsets from featureCESM2.1.0-OsloDevelopment

### DIFF
--- a/bld/namelist_files/use_cases/1850_cam6_noresm_aer2014_frc2.xml
+++ b/bld/namelist_files/use_cases/1850_cam6_noresm_aer2014_frc2.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<!--micro_do_sb_physics>   .true.   </micro_do_sb_physics-->
+<!--do_tms>                .false.  </do_tms-->
+<!--do_beljaars>           .true.   </do_beljaars-->
+
+<!-- Solar constant -->
+<solar_irrad_data_file     >   'atm/cam/solar/SolarForcingCMIP6piControl_c160921.nc'   </solar_irrad_data_file>
+<solar_data_ymd      >   18500101                                                </solar_data_ymd>
+<solar_data_type     >    FIXED                                                  </solar_data_type>
+
+<!-- 1850 GHG values Taken from Meinshausen et al., 2017 -->
+<co2vmr>   284.32e-6  </co2vmr>
+<ch4vmr>   808.25e-9  </ch4vmr>
+<n2ovmr>   273.02e-9  </n2ovmr>
+<f11vmr>   32.11e-12  </f11vmr>
+<f12vmr>   0.0        </f12vmr>
+
+<!-- 1850 ozone data -->
+<prescribed_ozone_cycle_yr>   1850                                                          </prescribed_ozone_cycle_yr>
+<prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                     </prescribed_ozone_datapath>
+<prescribed_ozone_file    >   'ozone_strataero_cyclical_WACCM6_L70_CMIP6-piControl.001_y21-50avg_zm_5day_c180802.nc'  </prescribed_ozone_file>
+<prescribed_ozone_name    >   'O3'                                                          </prescribed_ozone_name>
+<prescribed_ozone_type    >   'CYCLICAL'                                                    </prescribed_ozone_type>
+
+<!-- Prescribed oxidants for aerosol chemistry -->
+<tracer_cnst_cycle_yr >   1850                                                             </tracer_cnst_cycle_yr>
+<tracer_cnst_datapath >   'atm/cam/tracer_cnst'                                            </tracer_cnst_datapath>
+<tracer_cnst_file     >   'tracer_cnst_WACCM6_halons_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc' </tracer_cnst_file>
+<tracer_cnst_specifier>   'O3','OH','NO3','HO2'                                            </tracer_cnst_specifier>
+<tracer_cnst_type     >   'CYCLICAL'                                                       </tracer_cnst_type>
+<tracer_cnst_filelist >   ''                                                               </tracer_cnst_filelist>
+
+<!-- Surface emissions for MAMOslo -->
+<srf_emis_type>     CYCLICAL   </srf_emis_type>
+<srf_emis_cycle_yr> 1850       </srf_emis_cycle_yr>
+
+<!-- External forcing for MAMOslo -->
+<ext_frc_type>      CYCLICAL   </ext_frc_type>
+<ext_frc_cycle_yr>  1850       </ext_frc_cycle_yr>
+
+<!-- surface emissions -->
+<srf_emis_specifier hgrid="0.9x1.25">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_AX_all_surface_2014_date_1850_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_N_all_surface_2014_date_1850_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_OM_NI_all_surface_2014_date_1850_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO2_all_surface_2014_date_1850_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO4_PR_all_surface_2014_date_1850_0.9x1.25_version20190808.nc'
+</srf_emis_specifier>
+<srf_emis_specifier hgrid="1.9x2.5">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_AX_all_surface_2014_date_1850_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_N_all_surface_2014_date_1850_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_OM_NI_all_surface_2014_date_1850_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO2_all_surface_2014_date_1850_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO4_PR_all_surface_2014_date_1850_1.9x2.5_version20190808.nc'
+</srf_emis_specifier>
+
+<!-- 3D emissions -->
+<ext_frc_specifier hgrid="0.9x1.25">
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_AX_all_vertical_2014_date_1850_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_N_all_vertical_2014_date_1850_0.9x1.25_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_NI_all_vertical_2014_date_1850_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_OM_NI_all_vertical_2014_date_1850_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO2_all_vertical_2014_date_1850_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO4_PR_all_vertical_2014_date_1850_0.9x1.25_version20190808.nc'
+</ext_frc_specifier>
+<ext_frc_specifier hgrid="1.9x2.5">
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_AX_all_vertical_2014_date_1850_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_N_all_vertical_2014_date_1850_1.9x2.5_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_NI_all_vertical_2014_date_1850_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_OM_NI_all_vertical_2014_date_1850_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO2_all_vertical_2014_date_1850_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO4_PR_all_vertical_2014_date_1850_1.9x2.5_version20190808.nc'
+</ext_frc_specifier>
+
+<!--use_gw_oro               >   .false.   </use_gw_oro-->
+<!--use_gw_rdg_beta          >   .true.    </use_gw_rdg_beta-->
+<!--zmconv_num_cin           >   1         </zmconv_num_cin-->
+
+<!--prescribed_strataero_cycle_yr>  1850          </prescribed_strataero_cycle_yr-->
+
+<clubb_gamma_coef hgrid="0.9x1.25">0.286</clubb_gamma_coef>
+<clubb_gamma_coef hgrid="1.9x2.5" >0.264</clubb_gamma_coef>
+
+<!-- dyn_fv-->
+<fv_high_order_top> .false. </fv_high_order_top>
+<fv_am_geom_crrct> .true. </fv_am_geom_crrct>
+<fv_am_correction> .true. </fv_am_correction>
+<fv_am_fixer>      .true. </fv_am_fixer>
+<fv_am_fix_lbl>    .true. </fv_am_fix_lbl>
+<fv_am_diag>       .true. </fv_am_diag>
+
+<!--diagnostics-->
+<do_circulation_diags> .true. </do_circulation_diags>
+
+<!--phys_ctl_nl-->
+<dme_energy_adjust> .true. </dme_energy_adjust>
+  
+<!--zmconv_nl-->
+<zmconv_c0_lnd> 0.0200D0 </zmconv_c0_lnd>
+<zmconv_c0_ocn> 0.0200D0 </zmconv_c0_ocn>
+
+<zmconv_ke>     8.0E-6 </zmconv_ke>
+<zmconv_ke_lnd> 8.0E-6 </zmconv_ke_lnd>
+
+
+<!--micro_mg_nl-->
+<micro_mg_dcs hgrid="0.9x1.25">5.5e-4</micro_mg_dcs>
+<micro_mg_dcs hgrid="1.9x2.5" >5.0e-4</micro_mg_dcs>
+
+<!--gw_drag_nl-->
+<tau_0_ubc>  .true.   </tau_0_ubc>
+
+<!--cldfrc_nl-->
+<cldfrc_iceopt hgrid="1.9x2.5"> 4 </cldfrc_iceopt>
+
+<!--cldfrc2m_nl-->
+<cldfrc2m_rhmini hgrid="0.9x1.25">0.90D0</cldfrc2m_rhmini>
+
+<!--Options for megan -->
+<megan_specifier>'isoprene = isoprene','monoterp = myrcene + sabinene + limonene+ carene_3 + ocimene_t_b + pinene_b + pinene_a'</megan_specifier>
+
+<!--set SOA emissions since reading emissions from MEGAN -->
+<isoprene_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_isopr_1850_2000_zero.nc </isoprene_oslo_emis_file>
+<monoterp_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_monoterp_1850_2000_zero.nc </monoterp_oslo_emis_file>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850</sim_year>
+
+<!-- CMIP6 climatological volcanic background forcing -->
+<!--prescribed_strataero_file>' '</prescribed_strataero_file-->
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>CMIP_CAM6_radiation_average_v3_reformatted.nc</prescribed_volcaero_file>
+<prescribed_volcaero_cycle_yr>1850</prescribed_volcaero_cycle_yr>
+<prescribed_volcaero_type>CYCLICAL</prescribed_volcaero_type>
+<rad_climate>'A:Q:H2O','N:O2:O2','N:CO2:CO2','N:ozone:O3','N:N2O:N2O','N:CH4:CH4','N:CFC11:CFC11','N:CFC12:CFC12'</rad_climate>
+
+</namelist_defaults>

--- a/bld/namelist_files/use_cases/1850_cam6_noresm_aeronly.xml
+++ b/bld/namelist_files/use_cases/1850_cam6_noresm_aeronly.xml
@@ -2,44 +2,36 @@
 
 <namelist_defaults>
 
-<!--bnd_topo hgrid="0.9x1.25">noresm-only/inputForNudging/ERA_f09f09_32L_days/ERA_bnd_topo.nc</bnd_topo-->
-<bnd_topo hgrid="0.9x1.25">/work/olivie/topography-era/ERA_bnd_topo_noresm2_20191023.nc</bnd_topo>
-<met_rlx_time>6</met_rlx_time>
-<met_nudge_only_uvps>.true.</met_nudge_only_uvps>
-<met_nudge_temp>.false.</met_nudge_temp>
-<met_srf_land>.false.</met_srf_land>
-<met_data_file dyn="fv"  hgrid="0.9x1.25">$INPUTDATA_ROOT/noresm-only/inputForNudging/ERA_f09f09_32L_days/2001-01-01.nc</met_data_file>
-<met_filenames_list dyn="fv"  hgrid="0.9x1.25">noresm-only/inputForNudging/ERA_f09f09_32L_days/fileList2001-2015.txt</met_filenames_list>
-
 <!--micro_do_sb_physics>   .true.   </micro_do_sb_physics-->
 <!--do_tms>                .false.  </do_tms-->
 <!--do_beljaars>           .true.   </do_beljaars-->
 
 <!-- Solar constant -->
-<!--solar_data_file          >   'atm/cam/solar/SolarForcingCMIP6_18500101-22991231_c160830.nc'    </solar_data_file-->
-<solar_irrad_data_file    >   'atm/cam/solar/SolarForcingCMIP6_18491230-22991231_c171031.nc'</solar_irrad_data_file>
+<solar_irrad_data_file     >   'atm/cam/solar/SolarForcingCMIP6piControl_c160921.nc'   </solar_irrad_data_file>
+<solar_data_ymd      >   18500101                                                </solar_data_ymd>
+<solar_data_type     >    FIXED                                                  </solar_data_type>
 
-<!-- GHG values -->
-<scenario_ghg            >    'CHEM_LBC_FILE'   </scenario_ghg>
- <!-- use waccm LBC file -->  
-<flbc_file>atm/waccm/lb/LBC_1750-2015_CMIP6_GlobAnnAvg_c180926.nc</flbc_file>
-<flbc_type>'SERIAL'</flbc_type>
-<flbc_list>'CO2','CH4','N2O','CFC11eq','CFC12'</flbc_list>
-  <!--scenario_ghg            >    RAMPED                                       </scenario_ghg-->
-  <!--bndtvghg                >    atm/cam/ggas/ghg_hist_1765-2005_c091218.nc   </bndtvghg-->
+<!-- 1850 GHG values Taken from Meinshausen et al., 2017 -->
+<co2vmr>   284.32e-6  </co2vmr>
+<ch4vmr>   808.25e-9  </ch4vmr>
+<n2ovmr>   273.02e-9  </n2ovmr>
+<f11vmr>   32.11e-12  </f11vmr>
+<f12vmr>   0.0        </f12vmr>
 
-<!-- ozone data -->
-<prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                          </prescribed_ozone_datapath>
-<prescribed_ozone_file    >   'ozone_strataero_WACCM_L70_zm5day_18500101-20150103_CMIP6ensAvg_c180923.nc'   </prescribed_ozone_file>
-<prescribed_ozone_name    >   'O3'                                                      </prescribed_ozone_name>
-<prescribed_ozone_type    >   'SERIAL'                                                  </prescribed_ozone_type>
+<!-- 1850 ozone data -->
+<prescribed_ozone_cycle_yr>   1850                                                          </prescribed_ozone_cycle_yr>
+<prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                     </prescribed_ozone_datapath>
+<prescribed_ozone_file    >   'ozone_strataero_cyclical_WACCM6_L70_CMIP6-piControl.001_y21-50avg_zm_5day_c180802.nc'  </prescribed_ozone_file>
+<prescribed_ozone_name    >   'O3'                                                          </prescribed_ozone_name>
+<prescribed_ozone_type    >   'CYCLICAL'                                                    </prescribed_ozone_type>
 
 <!-- Prescribed oxidants for aerosol chemistry -->
-<tracer_cnst_datapath     >   'atm/cam/tracer_cnst'                                          </tracer_cnst_datapath>
-<tracer_cnst_file         >   'tracer_cnst_halons_3D_L70_1849-2015_CMIP6ensAvg_c180927.nc'    </tracer_cnst_file>
-<tracer_cnst_specifier    >   'O3','OH','NO3','HO2'                                     </tracer_cnst_specifier>
-<tracer_cnst_type         >   'INTERP_MISSING_MONTHS'                                                  </tracer_cnst_type>
-<tracer_cnst_filelist     >   ''                                                        </tracer_cnst_filelist>
+<tracer_cnst_cycle_yr >   1850                                                             </tracer_cnst_cycle_yr>
+<tracer_cnst_datapath >   'atm/cam/tracer_cnst'                                            </tracer_cnst_datapath>
+<tracer_cnst_file     >   'tracer_cnst_WACCM6_halons_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc' </tracer_cnst_file>
+<tracer_cnst_specifier>   'O3','OH','NO3','HO2'                                            </tracer_cnst_specifier>
+<tracer_cnst_type     >   'CYCLICAL'                                                       </tracer_cnst_type>
+<tracer_cnst_filelist >   ''                                                               </tracer_cnst_filelist>
 
 <!-- Surface emissions for  MAMOslo -->
 <srf_emis_type            >    INTERP_MISSING_MONTHS  </srf_emis_type>
@@ -65,7 +57,7 @@
 
 <!-- 3D emissions -->
 <ext_frc_specifier hgrid="0.9x1.25">
-  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_1849-2015_CMIP6ensAvg_c180927.nc',
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/perturbations/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_date_0000_5000_c180802.nc',
   'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_airALL_vertical_1849-2015_0.9x1.25_version20180512.nc',
   'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_anthroprofALL_vertical_1849-2015_0.9x1.25_version20180512.nc',
   'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_airALL_vertical_1849-2015_0.9x1.25_version20180512.nc',
@@ -84,7 +76,7 @@
   'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_volcALL_vertical_1849-2015_0.9x1.25_version20180512.nc'
 </ext_frc_specifier>
 <ext_frc_specifier hgrid="1.9x2.5">
-  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_1849-2015_CMIP6ensAvg_c180927.nc',
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/perturbations/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_date_0000_5000_c180802.nc',
   'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_airALL_vertical_1849-2015_1.9x2.5_version20180512.nc',
   'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_anthroprofALL_vertical_1849-2015_1.9x2.5_version20180512.nc',
   'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_airALL_vertical_1849-2015_1.9x2.5_version20180512.nc',
@@ -108,9 +100,6 @@
 <!--zmconv_num_cin           >   1         </zmconv_num_cin-->
 
 <!--prescribed_strataero_cycle_yr>  1850          </prescribed_strataero_cycle_yr-->
-
-<srf_emis_type            >    INTERP_MISSING_MONTHS  </srf_emis_type>
-<ext_frc_type             >    INTERP_MISSING_MONTHS  </ext_frc_type>
 
 <clubb_gamma_coef hgrid="0.9x1.25">0.286</clubb_gamma_coef>
 <clubb_gamma_coef hgrid="1.9x2.5" >0.264</clubb_gamma_coef>
@@ -163,7 +152,9 @@
 <!-- CMIP6 climatological volcanic background forcing -->
 <!--prescribed_strataero_file>' '</prescribed_strataero_file-->
 <prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
-<prescribed_volcaero_file>CMIP_CAM6_radiation_v3_reformatted.nc</prescribed_volcaero_file>
+<prescribed_volcaero_file>CMIP_CAM6_radiation_average_v3_reformatted.nc</prescribed_volcaero_file>
+<prescribed_volcaero_cycle_yr>1850</prescribed_volcaero_cycle_yr>
+<prescribed_volcaero_type>CYCLICAL</prescribed_volcaero_type>
 <rad_climate>'A:Q:H2O','N:O2:O2','N:CO2:CO2','N:ozone:O3','N:N2O:N2O','N:CH4:CH4','N:CFC11:CFC11','N:CFC12:CFC12'</rad_climate>
 
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/1850_cam6_noresm_aeroxid2014_frc2.xml
+++ b/bld/namelist_files/use_cases/1850_cam6_noresm_aeroxid2014_frc2.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<!--micro_do_sb_physics>   .true.   </micro_do_sb_physics-->
+<!--do_tms>                .false.  </do_tms-->
+<!--do_beljaars>           .true.   </do_beljaars-->
+
+<!-- Solar constant -->
+<solar_irrad_data_file     >   'atm/cam/solar/SolarForcingCMIP6piControl_c160921.nc'   </solar_irrad_data_file>
+<solar_data_ymd      >   18500101                                                </solar_data_ymd>
+<solar_data_type     >    FIXED                                                  </solar_data_type>
+
+<!-- 1850 GHG values Taken from Meinshausen et al., 2017 -->
+<co2vmr>   284.32e-6  </co2vmr>
+<ch4vmr>   808.25e-9  </ch4vmr>
+<n2ovmr>   273.02e-9  </n2ovmr>
+<f11vmr>   32.11e-12  </f11vmr>
+<f12vmr>   0.0        </f12vmr>
+
+<!-- 1850 ozone data -->
+<prescribed_ozone_cycle_yr>   1850                                                          </prescribed_ozone_cycle_yr>
+<prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                     </prescribed_ozone_datapath>
+<prescribed_ozone_file    >   'ozone_strataero_cyclical_WACCM6_L70_CMIP6-piControl.001_y21-50avg_zm_5day_c180802.nc'  </prescribed_ozone_file>
+<prescribed_ozone_name    >   'O3'                                                          </prescribed_ozone_name>
+<prescribed_ozone_type    >   'CYCLICAL'                                                    </prescribed_ozone_type>
+
+<!-- Prescribed oxidants for aerosol chemistry -->
+<tracer_cnst_cycle_yr >   1850                                                             </tracer_cnst_cycle_yr>
+<tracer_cnst_datapath >   'noresm-only/atm/cam/tracer_cnst'                                </tracer_cnst_datapath>
+<tracer_cnst_file     >   'tracer_cnst_halons_3D_L70_2014_date1850_CMIP6ensAvg_c180927.nc' </tracer_cnst_file>
+<tracer_cnst_specifier>   'O3','OH','NO3','HO2'                                            </tracer_cnst_specifier>
+<tracer_cnst_type     >   'CYCLICAL'                                                       </tracer_cnst_type>
+<tracer_cnst_filelist >   ''                                                               </tracer_cnst_filelist>
+
+<!-- Surface emissions for MAMOslo -->
+<srf_emis_type>     CYCLICAL   </srf_emis_type>
+<srf_emis_cycle_yr> 1850       </srf_emis_cycle_yr>
+
+<!-- External forcing for MAMOslo -->
+<ext_frc_type>      CYCLICAL   </ext_frc_type>
+<ext_frc_cycle_yr>  1850       </ext_frc_cycle_yr>
+
+<!-- surface emissions -->
+<srf_emis_specifier hgrid="0.9x1.25">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_AX_all_surface_2014_date_1850_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_N_all_surface_2014_date_1850_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_OM_NI_all_surface_2014_date_1850_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO2_all_surface_2014_date_1850_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO4_PR_all_surface_2014_date_1850_0.9x1.25_version20190808.nc'
+</srf_emis_specifier>
+<srf_emis_specifier hgrid="1.9x2.5">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_AX_all_surface_2014_date_1850_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_N_all_surface_2014_date_1850_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_OM_NI_all_surface_2014_date_1850_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO2_all_surface_2014_date_1850_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO4_PR_all_surface_2014_date_1850_1.9x2.5_version20190808.nc'
+</srf_emis_specifier>
+
+<!-- 3D emissions -->
+<ext_frc_specifier hgrid="0.9x1.25">
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_AX_all_vertical_2014_date_1850_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_N_all_vertical_2014_date_1850_0.9x1.25_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_NI_all_vertical_2014_date_1850_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_OM_NI_all_vertical_2014_date_1850_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO2_all_vertical_2014_date_1850_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO4_PR_all_vertical_2014_date_1850_0.9x1.25_version20190808.nc'
+</ext_frc_specifier>
+<ext_frc_specifier hgrid="1.9x2.5">
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_AX_all_vertical_2014_date_1850_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_N_all_vertical_2014_date_1850_1.9x2.5_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_BC_NI_all_vertical_2014_date_1850_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_OM_NI_all_vertical_2014_date_1850_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO2_all_vertical_2014_date_1850_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/perturbations/emissions_cmip6_noresm2_SO4_PR_all_vertical_2014_date_1850_1.9x2.5_version20190808.nc'
+</ext_frc_specifier>
+
+<!--use_gw_oro               >   .false.   </use_gw_oro-->
+<!--use_gw_rdg_beta          >   .true.    </use_gw_rdg_beta-->
+<!--zmconv_num_cin           >   1         </zmconv_num_cin-->
+
+<!--prescribed_strataero_cycle_yr>  1850          </prescribed_strataero_cycle_yr-->
+
+<clubb_gamma_coef hgrid="0.9x1.25">0.286</clubb_gamma_coef>
+<clubb_gamma_coef hgrid="1.9x2.5" >0.264</clubb_gamma_coef>
+
+<!-- dyn_fv-->
+<fv_high_order_top> .false. </fv_high_order_top>
+<fv_am_geom_crrct> .true. </fv_am_geom_crrct>
+<fv_am_correction> .true. </fv_am_correction>
+<fv_am_fixer>      .true. </fv_am_fixer>
+<fv_am_fix_lbl>    .true. </fv_am_fix_lbl>
+<fv_am_diag>       .true. </fv_am_diag>
+
+<!--diagnostics-->
+<do_circulation_diags> .true. </do_circulation_diags>
+
+<!--phys_ctl_nl-->
+<dme_energy_adjust> .true. </dme_energy_adjust>
+  
+<!--zmconv_nl-->
+<zmconv_c0_lnd> 0.0200D0 </zmconv_c0_lnd>
+<zmconv_c0_ocn> 0.0200D0 </zmconv_c0_ocn>
+
+<zmconv_ke>     8.0E-6 </zmconv_ke>
+<zmconv_ke_lnd> 8.0E-6 </zmconv_ke_lnd>
+
+
+<!--micro_mg_nl-->
+<micro_mg_dcs hgrid="0.9x1.25">5.5e-4</micro_mg_dcs>
+<micro_mg_dcs hgrid="1.9x2.5" >5.0e-4</micro_mg_dcs>
+
+<!--gw_drag_nl-->
+<tau_0_ubc>  .true.   </tau_0_ubc>
+
+<!--cldfrc_nl-->
+<cldfrc_iceopt hgrid="1.9x2.5"> 4 </cldfrc_iceopt>
+
+<!--cldfrc2m_nl-->
+<cldfrc2m_rhmini hgrid="0.9x1.25">0.90D0</cldfrc2m_rhmini>
+
+<!--Options for megan -->
+<megan_specifier>'isoprene = isoprene','monoterp = myrcene + sabinene + limonene+ carene_3 + ocimene_t_b + pinene_b + pinene_a'</megan_specifier>
+
+<!--set SOA emissions since reading emissions from MEGAN -->
+<isoprene_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_isopr_1850_2000_zero.nc </isoprene_oslo_emis_file>
+<monoterp_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_monoterp_1850_2000_zero.nc </monoterp_oslo_emis_file>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850</sim_year>
+
+<!-- CMIP6 climatological volcanic background forcing -->
+<!--prescribed_strataero_file>' '</prescribed_strataero_file-->
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>CMIP_CAM6_radiation_average_v3_reformatted.nc</prescribed_volcaero_file>
+<prescribed_volcaero_cycle_yr>1850</prescribed_volcaero_cycle_yr>
+<prescribed_volcaero_type>CYCLICAL</prescribed_volcaero_type>
+<rad_climate>'A:Q:H2O','N:O2:O2','N:CO2:CO2','N:ozone:O3','N:N2O:N2O','N:CH4:CH4','N:CFC11:CFC11','N:CFC12:CFC12'</rad_climate>
+
+</namelist_defaults>

--- a/bld/namelist_files/use_cases/1850_cam6_noresm_co22014.xml
+++ b/bld/namelist_files/use_cases/1850_cam6_noresm_co22014.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<!--micro_do_sb_physics>   .true.   </micro_do_sb_physics-->
+<!--do_tms>                .false.  </do_tms-->
+<!--do_beljaars>           .true.   </do_beljaars-->
+
+<!-- Solar constant -->
+<solar_irrad_data_file     >   'atm/cam/solar/SolarForcingCMIP6piControl_c160921.nc'   </solar_irrad_data_file>
+<solar_data_ymd      >   18500101                                                </solar_data_ymd>
+<solar_data_type     >    FIXED                                                  </solar_data_type>
+
+<!-- 1850 GHG values Taken from Meinshausen et al., 2017 -->
+<co2vmr>   397.55e-6  </co2vmr>
+<ch4vmr>   808.25e-9  </ch4vmr>
+<n2ovmr>   273.02e-9  </n2ovmr>
+<f11vmr>   32.11e-12  </f11vmr>
+<f12vmr>   0.0        </f12vmr>
+
+<!-- 1850 ozone data -->
+<prescribed_ozone_cycle_yr>   1850                                                          </prescribed_ozone_cycle_yr>
+<prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                     </prescribed_ozone_datapath>
+<prescribed_ozone_file    >   'ozone_strataero_cyclical_WACCM6_L70_CMIP6-piControl.001_y21-50avg_zm_5day_c180802.nc'  </prescribed_ozone_file>
+<prescribed_ozone_name    >   'O3'                                                          </prescribed_ozone_name>
+<prescribed_ozone_type    >   'CYCLICAL'                                                    </prescribed_ozone_type>
+
+<!-- Prescribed oxidants for aerosol chemistry -->
+<tracer_cnst_cycle_yr >   1850                                                             </tracer_cnst_cycle_yr>
+<tracer_cnst_datapath >   'atm/cam/tracer_cnst'                                            </tracer_cnst_datapath>
+<tracer_cnst_file     >   'tracer_cnst_WACCM6_halons_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc' </tracer_cnst_file>
+<tracer_cnst_specifier>   'O3','OH','NO3','HO2'                                            </tracer_cnst_specifier>
+<tracer_cnst_type     >   'CYCLICAL'                                                       </tracer_cnst_type>
+<tracer_cnst_filelist >   ''                                                               </tracer_cnst_filelist>
+
+<!-- Surface emissions for MAMOslo -->
+<srf_emis_type>     CYCLICAL   </srf_emis_type>
+<srf_emis_cycle_yr> 1850       </srf_emis_cycle_yr>
+
+<!-- External forcing for MAMOslo -->
+<ext_frc_type>      CYCLICAL   </ext_frc_type>
+<ext_frc_cycle_yr>  1850       </ext_frc_cycle_yr>
+
+<!-- surface emissions -->
+<srf_emis_specifier hgrid="0.9x1.25">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_anthrosurfAGRTRADOMSOLWSTSHP_surface_1850_0.9x1.25_version20180512.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_anthrosurfAGRTRADOMSOLWSTSHP_surface_1850_0.9x1.25_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_anthrosurfAGRTRADOMSOLWSTSHP_surface_1850_0.9x1.25_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_anthrosurfAGRTRADOMSOLWSTSHP_surface_1850_0.9x1.25_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_anthrosurfAGRTRADOMSOLWSTSHP_surface_1850_0.9x1.25_version20180512.nc'
+</srf_emis_specifier>
+<srf_emis_specifier hgrid="1.9x2.5">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_anthrosurfALL_surface_1850_1.9x2.5_version20180512.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_anthrosurfALL_surface_1850_1.9x2.5_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_anthrosurfALL_surface_1850_1.9x2.5_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_anthrosurfALL_surface_1850_1.9x2.5_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_anthrosurfALL_surface_1850_1.9x2.5_version20180512.nc'
+</srf_emis_specifier>
+
+<!-- 3D emissions -->
+<ext_frc_specifier hgrid="0.9x1.25">
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_airALL_vertical_1850_0.9x1.25_version20180512.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_anthroprofENEIND_vertical_1850_0.9x1.25_version20180512.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_airALL_vertical_1850_0.9x1.25_version20180512.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_anthroprofENEIND_vertical_1850_0.9x1.25_version20180512.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_NI_bbAGRIBORFDEFOPEATSAVATEMF_vertical_1850_0.9x1.25_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_airALL_vertical_1850_0.9x1.25_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_anthroprofENEIND_vertical_1850_0.9x1.25_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_bbAGRIBORFDEFOPEATSAVATEMF_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_airALL_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_anthroprofENEIND_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_bbAGRIBORFDEFOPEATSAVATEMF_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_volcCONTEXPL_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_airALL_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_anthroprofENEIND_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_bbAGRIBORFDEFOPEATSAVATEMF_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_volcCONTEXPL_vertical_1850_0.9x1.25_version20180512.nc'
+</ext_frc_specifier>
+<ext_frc_specifier hgrid="1.9x2.5">
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_airALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_anthroprofALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_airALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_anthroprofALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_NI_bbALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_airALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_anthroprofALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_bbALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_airALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_anthroprofALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_bbALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_volcALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_airALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_anthroprofALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_bbALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_volcALL_vertical_1850_1.9x2.5_version20180512.nc'
+</ext_frc_specifier>
+
+<!--use_gw_oro               >   .false.   </use_gw_oro-->
+<!--use_gw_rdg_beta          >   .true.    </use_gw_rdg_beta-->
+<!--zmconv_num_cin           >   1         </zmconv_num_cin-->
+
+<!--prescribed_strataero_cycle_yr>  1850          </prescribed_strataero_cycle_yr-->
+
+<clubb_gamma_coef hgrid="0.9x1.25">0.286</clubb_gamma_coef>
+<clubb_gamma_coef hgrid="1.9x2.5" >0.264</clubb_gamma_coef>
+
+<!-- dyn_fv-->
+<fv_high_order_top> .false. </fv_high_order_top>
+<fv_am_geom_crrct> .true. </fv_am_geom_crrct>
+<fv_am_correction> .true. </fv_am_correction>
+<fv_am_fixer>      .true. </fv_am_fixer>
+<fv_am_fix_lbl>    .true. </fv_am_fix_lbl>
+<fv_am_diag>       .true. </fv_am_diag>
+
+<!--diagnostics-->
+<do_circulation_diags> .true. </do_circulation_diags>
+
+<!--phys_ctl_nl-->
+<dme_energy_adjust> .true. </dme_energy_adjust>
+  
+<!--zmconv_nl-->
+<zmconv_c0_lnd> 0.0200D0 </zmconv_c0_lnd>
+<zmconv_c0_ocn> 0.0200D0 </zmconv_c0_ocn>
+
+<zmconv_ke>     8.0E-6 </zmconv_ke>
+<zmconv_ke_lnd> 8.0E-6 </zmconv_ke_lnd>
+
+
+<!--micro_mg_nl-->
+<micro_mg_dcs hgrid="0.9x1.25">5.5e-4</micro_mg_dcs>
+<micro_mg_dcs hgrid="1.9x2.5" >5.0e-4</micro_mg_dcs>
+
+<!--gw_drag_nl-->
+<tau_0_ubc>  .true.   </tau_0_ubc>
+
+<!--cldfrc_nl-->
+<cldfrc_iceopt hgrid="1.9x2.5"> 4 </cldfrc_iceopt>
+
+<!--cldfrc2m_nl-->
+<cldfrc2m_rhmini hgrid="0.9x1.25">0.90D0</cldfrc2m_rhmini>
+
+<!--Options for megan -->
+<megan_specifier>'isoprene = isoprene','monoterp = myrcene + sabinene + limonene+ carene_3 + ocimene_t_b + pinene_b + pinene_a'</megan_specifier>
+
+<!--set SOA emissions since reading emissions from MEGAN -->
+<isoprene_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_isopr_1850_2000_zero.nc </isoprene_oslo_emis_file>
+<monoterp_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_monoterp_1850_2000_zero.nc </monoterp_oslo_emis_file>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850</sim_year>
+
+<!-- CMIP6 climatological volcanic background forcing -->
+<!--prescribed_strataero_file>' '</prescribed_strataero_file-->
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>CMIP_CAM6_radiation_average_v3_reformatted.nc</prescribed_volcaero_file>
+<prescribed_volcaero_cycle_yr>1850</prescribed_volcaero_cycle_yr>
+<prescribed_volcaero_type>CYCLICAL</prescribed_volcaero_type>
+<rad_climate>'A:Q:H2O','N:O2:O2','N:CO2:CO2','N:ozone:O3','N:N2O:N2O','N:CH4:CH4','N:CFC11:CFC11','N:CFC12:CFC12'</rad_climate>
+
+</namelist_defaults>

--- a/bld/namelist_files/use_cases/1850_cam6_noresm_oxid2014_frc2.xml
+++ b/bld/namelist_files/use_cases/1850_cam6_noresm_oxid2014_frc2.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<!--micro_do_sb_physics>   .true.   </micro_do_sb_physics-->
+<!--do_tms>                .false.  </do_tms-->
+<!--do_beljaars>           .true.   </do_beljaars-->
+
+<!-- Solar constant -->
+<solar_irrad_data_file     >   'atm/cam/solar/SolarForcingCMIP6piControl_c160921.nc'   </solar_irrad_data_file>
+<solar_data_ymd      >   18500101                                                </solar_data_ymd>
+<solar_data_type     >    FIXED                                                  </solar_data_type>
+
+<!-- 1850 GHG values Taken from Meinshausen et al., 2017 -->
+<co2vmr>   284.32e-6  </co2vmr>
+<ch4vmr>   808.25e-9  </ch4vmr>
+<n2ovmr>   273.02e-9  </n2ovmr>
+<f11vmr>   32.11e-12  </f11vmr>
+<f12vmr>   0.0        </f12vmr>
+
+<!-- 1850 ozone data -->
+<prescribed_ozone_cycle_yr>   1850                                                          </prescribed_ozone_cycle_yr>
+<prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                     </prescribed_ozone_datapath>
+<prescribed_ozone_file    >   'ozone_strataero_cyclical_WACCM6_L70_CMIP6-piControl.001_y21-50avg_zm_5day_c180802.nc'  </prescribed_ozone_file>
+<prescribed_ozone_name    >   'O3'                                                          </prescribed_ozone_name>
+<prescribed_ozone_type    >   'CYCLICAL'                                                    </prescribed_ozone_type>
+
+<!-- Prescribed oxidants for aerosol chemistry -->
+<tracer_cnst_cycle_yr >   1850                                                             </tracer_cnst_cycle_yr>
+<tracer_cnst_datapath >   'noresm-only/atm/cam/tracer_cnst'                                </tracer_cnst_datapath>
+<tracer_cnst_file     >   'tracer_cnst_halons_3D_L70_2014_date1850_CMIP6ensAvg_c180927.nc' </tracer_cnst_file>
+<tracer_cnst_specifier>   'O3','OH','NO3','HO2'                                            </tracer_cnst_specifier>
+<tracer_cnst_type     >   'CYCLICAL'                                                       </tracer_cnst_type>
+<tracer_cnst_filelist >   ''                                                               </tracer_cnst_filelist>
+
+<!-- Surface emissions for MAMOslo -->
+<srf_emis_type>     CYCLICAL   </srf_emis_type>
+<srf_emis_cycle_yr> 1850       </srf_emis_cycle_yr>
+
+<!-- External forcing for MAMOslo -->
+<ext_frc_type>      CYCLICAL   </ext_frc_type>
+<ext_frc_cycle_yr>  1850       </ext_frc_cycle_yr>
+
+<!-- surface emissions -->
+<srf_emis_specifier hgrid="0.9x1.25">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_BC_AX_all_surface_1850_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_BC_N_all_surface_1850_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_OM_NI_all_surface_1850_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_SO2_all_surface_1850_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_SO4_PR_all_surface_1850_0.9x1.25_version20190808.nc'
+</srf_emis_specifier>
+<srf_emis_specifier hgrid="1.9x2.5">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_BC_AX_all_surface_1850_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_BC_N_all_surface_1850_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_OM_NI_all_surface_1850_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_SO2_all_surface_1850_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_SO4_PR_all_surface_1850_1.9x2.5_version20190808.nc'
+</srf_emis_specifier>
+
+<!-- 3D emissions -->
+<ext_frc_specifier hgrid="0.9x1.25">
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_BC_AX_all_vertical_1850_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_BC_N_all_vertical_1850_0.9x1.25_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_BC_NI_all_vertical_1850_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_OM_NI_all_vertical_1850_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_SO2_all_vertical_1850_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_SO4_PR_all_vertical_1850_0.9x1.25_version20190808.nc'
+</ext_frc_specifier>
+<ext_frc_specifier hgrid="1.9x2.5">
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_BC_AX_all_vertical_1850_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_BC_N_all_vertical_1850_1.9x2.5_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_BC_NI_all_vertical_1850_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_OM_NI_all_vertical_1850_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_SO2_all_vertical_1850_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_SO4_PR_all_vertical_1850_1.9x2.5_version20190808.nc'
+</ext_frc_specifier>
+
+<!--use_gw_oro               >   .false.   </use_gw_oro-->
+<!--use_gw_rdg_beta          >   .true.    </use_gw_rdg_beta-->
+<!--zmconv_num_cin           >   1         </zmconv_num_cin-->
+
+<!--prescribed_strataero_cycle_yr>  1850          </prescribed_strataero_cycle_yr-->
+
+<clubb_gamma_coef hgrid="0.9x1.25">0.286</clubb_gamma_coef>
+<clubb_gamma_coef hgrid="1.9x2.5" >0.264</clubb_gamma_coef>
+
+<!-- dyn_fv-->
+<fv_high_order_top> .false. </fv_high_order_top>
+<fv_am_geom_crrct> .true. </fv_am_geom_crrct>
+<fv_am_correction> .true. </fv_am_correction>
+<fv_am_fixer>      .true. </fv_am_fixer>
+<fv_am_fix_lbl>    .true. </fv_am_fix_lbl>
+<fv_am_diag>       .true. </fv_am_diag>
+
+<!--diagnostics-->
+<do_circulation_diags> .true. </do_circulation_diags>
+
+<!--phys_ctl_nl-->
+<dme_energy_adjust> .true. </dme_energy_adjust>
+  
+<!--zmconv_nl-->
+<zmconv_c0_lnd> 0.0200D0 </zmconv_c0_lnd>
+<zmconv_c0_ocn> 0.0200D0 </zmconv_c0_ocn>
+
+<zmconv_ke>     8.0E-6 </zmconv_ke>
+<zmconv_ke_lnd> 8.0E-6 </zmconv_ke_lnd>
+
+
+<!--micro_mg_nl-->
+<micro_mg_dcs hgrid="0.9x1.25">5.5e-4</micro_mg_dcs>
+<micro_mg_dcs hgrid="1.9x2.5" >5.0e-4</micro_mg_dcs>
+
+<!--gw_drag_nl-->
+<tau_0_ubc>  .true.   </tau_0_ubc>
+
+<!--cldfrc_nl-->
+<cldfrc_iceopt hgrid="1.9x2.5"> 4 </cldfrc_iceopt>
+
+<!--cldfrc2m_nl-->
+<cldfrc2m_rhmini hgrid="0.9x1.25">0.90D0</cldfrc2m_rhmini>
+
+<!--Options for megan -->
+<megan_specifier>'isoprene = isoprene','monoterp = myrcene + sabinene + limonene+ carene_3 + ocimene_t_b + pinene_b + pinene_a'</megan_specifier>
+
+<!--set SOA emissions since reading emissions from MEGAN -->
+<isoprene_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_isopr_1850_2000_zero.nc </isoprene_oslo_emis_file>
+<monoterp_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_monoterp_1850_2000_zero.nc </monoterp_oslo_emis_file>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850</sim_year>
+
+<!-- CMIP6 climatological volcanic background forcing -->
+<!--prescribed_strataero_file>' '</prescribed_strataero_file-->
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>CMIP_CAM6_radiation_average_v3_reformatted.nc</prescribed_volcaero_file>
+<prescribed_volcaero_cycle_yr>1850</prescribed_volcaero_cycle_yr>
+<prescribed_volcaero_type>CYCLICAL</prescribed_volcaero_type>
+<rad_climate>'A:Q:H2O','N:O2:O2','N:CO2:CO2','N:ozone:O3','N:N2O:N2O','N:CH4:CH4','N:CFC11:CFC11','N:CFC12:CFC12'</rad_climate>
+
+</namelist_defaults>

--- a/bld/namelist_files/use_cases/1850_cam6_noresm_oxidonly.xml
+++ b/bld/namelist_files/use_cases/1850_cam6_noresm_oxidonly.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<!--micro_do_sb_physics>   .true.   </micro_do_sb_physics-->
+<!--do_tms>                .false.  </do_tms-->
+<!--do_beljaars>           .true.   </do_beljaars-->
+
+<!-- Solar constant -->
+<solar_irrad_data_file     >   'atm/cam/solar/SolarForcingCMIP6piControl_c160921.nc'   </solar_irrad_data_file>
+<solar_data_ymd      >   18500101                                                </solar_data_ymd>
+<solar_data_type     >    FIXED                                                  </solar_data_type>
+
+<!-- 1850 GHG values Taken from Meinshausen et al., 2017 -->
+<co2vmr>   284.32e-6  </co2vmr>
+<ch4vmr>   808.25e-9  </ch4vmr>
+<n2ovmr>   273.02e-9  </n2ovmr>
+<f11vmr>   32.11e-12  </f11vmr>
+<f12vmr>   0.0        </f12vmr>
+
+<!-- 1850 ozone data -->
+<prescribed_ozone_cycle_yr>   1850                                                          </prescribed_ozone_cycle_yr>
+<prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                     </prescribed_ozone_datapath>
+<prescribed_ozone_file    >   'ozone_strataero_cyclical_WACCM6_L70_CMIP6-piControl.001_y21-50avg_zm_5day_c180802.nc'  </prescribed_ozone_file>
+<prescribed_ozone_name    >   'O3'                                                          </prescribed_ozone_name>
+<prescribed_ozone_type    >   'CYCLICAL'                                                    </prescribed_ozone_type>
+
+<!-- Prescribed oxidants for aerosol chemistry -->
+<tracer_cnst_datapath     >   'atm/cam/tracer_cnst'                                          </tracer_cnst_datapath>
+<tracer_cnst_file         >   'tracer_cnst_halons_3D_L70_1849-2015_CMIP6ensAvg_c180927.nc'    </tracer_cnst_file>
+<tracer_cnst_specifier    >   'O3','OH','NO3','HO2'                                     </tracer_cnst_specifier>
+<tracer_cnst_type         >   'INTERP_MISSING_MONTHS'                                                  </tracer_cnst_type>
+<tracer_cnst_filelist     >   ''                                                        </tracer_cnst_filelist>
+
+<!-- Surface emissions for MAMOslo -->
+<srf_emis_type>     CYCLICAL   </srf_emis_type>
+<srf_emis_cycle_yr> 1850       </srf_emis_cycle_yr>
+
+<!-- External forcing for MAMOslo -->
+<ext_frc_type>      CYCLICAL   </ext_frc_type>
+<ext_frc_cycle_yr>  1850       </ext_frc_cycle_yr>
+
+<!-- surface emissions -->
+<srf_emis_specifier hgrid="0.9x1.25">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_anthrosurfAGRTRADOMSOLWSTSHP_surface_1850_0.9x1.25_version20180512.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_anthrosurfAGRTRADOMSOLWSTSHP_surface_1850_0.9x1.25_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_anthrosurfAGRTRADOMSOLWSTSHP_surface_1850_0.9x1.25_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_anthrosurfAGRTRADOMSOLWSTSHP_surface_1850_0.9x1.25_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_anthrosurfAGRTRADOMSOLWSTSHP_surface_1850_0.9x1.25_version20180512.nc'
+</srf_emis_specifier>
+<srf_emis_specifier hgrid="1.9x2.5">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_anthrosurfALL_surface_1850_1.9x2.5_version20180512.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_anthrosurfALL_surface_1850_1.9x2.5_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_anthrosurfALL_surface_1850_1.9x2.5_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_anthrosurfALL_surface_1850_1.9x2.5_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_anthrosurfALL_surface_1850_1.9x2.5_version20180512.nc'
+</srf_emis_specifier>
+
+<!-- 3D emissions -->
+<ext_frc_specifier hgrid="0.9x1.25">
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_airALL_vertical_1850_0.9x1.25_version20180512.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_anthroprofENEIND_vertical_1850_0.9x1.25_version20180512.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_airALL_vertical_1850_0.9x1.25_version20180512.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_anthroprofENEIND_vertical_1850_0.9x1.25_version20180512.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_NI_bbAGRIBORFDEFOPEATSAVATEMF_vertical_1850_0.9x1.25_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_airALL_vertical_1850_0.9x1.25_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_anthroprofENEIND_vertical_1850_0.9x1.25_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_bbAGRIBORFDEFOPEATSAVATEMF_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_airALL_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_anthroprofENEIND_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_bbAGRIBORFDEFOPEATSAVATEMF_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_volcCONTEXPL_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_airALL_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_anthroprofENEIND_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_bbAGRIBORFDEFOPEATSAVATEMF_vertical_1850_0.9x1.25_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_volcCONTEXPL_vertical_1850_0.9x1.25_version20180512.nc'
+</ext_frc_specifier>
+<ext_frc_specifier hgrid="1.9x2.5">
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_airALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_AX_anthroprofALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_airALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_N_anthroprofALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_BC_NI_bbALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_airALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_anthroprofALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_OM_NI_bbALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_airALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_anthroprofALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_bbALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO2_volcALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_airALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_anthroprofALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_bbALL_vertical_1850_1.9x2.5_version20180512.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/emissions_cmip6_noresm2_SO4_PR_volcALL_vertical_1850_1.9x2.5_version20180512.nc'
+</ext_frc_specifier>
+
+<!--use_gw_oro               >   .false.   </use_gw_oro-->
+<!--use_gw_rdg_beta          >   .true.    </use_gw_rdg_beta-->
+<!--zmconv_num_cin           >   1         </zmconv_num_cin-->
+
+<!--prescribed_strataero_cycle_yr>  1850          </prescribed_strataero_cycle_yr-->
+
+<clubb_gamma_coef hgrid="0.9x1.25">0.286</clubb_gamma_coef>
+<clubb_gamma_coef hgrid="1.9x2.5" >0.264</clubb_gamma_coef>
+
+<!-- dyn_fv-->
+<fv_high_order_top> .false. </fv_high_order_top>
+<fv_am_geom_crrct> .true. </fv_am_geom_crrct>
+<fv_am_correction> .true. </fv_am_correction>
+<fv_am_fixer>      .true. </fv_am_fixer>
+<fv_am_fix_lbl>    .true. </fv_am_fix_lbl>
+<fv_am_diag>       .true. </fv_am_diag>
+
+<!--diagnostics-->
+<do_circulation_diags> .true. </do_circulation_diags>
+
+<!--phys_ctl_nl-->
+<dme_energy_adjust> .true. </dme_energy_adjust>
+  
+<!--zmconv_nl-->
+<zmconv_c0_lnd> 0.0200D0 </zmconv_c0_lnd>
+<zmconv_c0_ocn> 0.0200D0 </zmconv_c0_ocn>
+
+<zmconv_ke>     8.0E-6 </zmconv_ke>
+<zmconv_ke_lnd> 8.0E-6 </zmconv_ke_lnd>
+
+
+<!--micro_mg_nl-->
+<micro_mg_dcs hgrid="0.9x1.25">5.5e-4</micro_mg_dcs>
+<micro_mg_dcs hgrid="1.9x2.5" >5.0e-4</micro_mg_dcs>
+
+<!--gw_drag_nl-->
+<tau_0_ubc>  .true.   </tau_0_ubc>
+
+<!--cldfrc_nl-->
+<cldfrc_iceopt hgrid="1.9x2.5"> 4 </cldfrc_iceopt>
+
+<!--cldfrc2m_nl-->
+<cldfrc2m_rhmini hgrid="0.9x1.25">0.90D0</cldfrc2m_rhmini>
+
+<!--Options for megan -->
+<megan_specifier>'isoprene = isoprene','monoterp = myrcene + sabinene + limonene+ carene_3 + ocimene_t_b + pinene_b + pinene_a'</megan_specifier>
+
+<!--set SOA emissions since reading emissions from MEGAN -->
+<isoprene_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_isopr_1850_2000_zero.nc </isoprene_oslo_emis_file>
+<monoterp_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_monoterp_1850_2000_zero.nc </monoterp_oslo_emis_file>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850</sim_year>
+
+<!-- CMIP6 climatological volcanic background forcing -->
+<!--prescribed_strataero_file>' '</prescribed_strataero_file-->
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>CMIP_CAM6_radiation_average_v3_reformatted.nc</prescribed_volcaero_file>
+<prescribed_volcaero_cycle_yr>1850</prescribed_volcaero_cycle_yr>
+<prescribed_volcaero_type>CYCLICAL</prescribed_volcaero_type>
+<rad_climate>'A:Q:H2O','N:O2:O2','N:CO2:CO2','N:ozone:O3','N:N2O:N2O','N:CH4:CH4','N:CFC11:CFC11','N:CFC12:CFC12'</rad_climate>
+
+</namelist_defaults>

--- a/bld/namelist_files/use_cases/ssp126_cam6_noresm_frc2ext.xml
+++ b/bld/namelist_files/use_cases/ssp126_cam6_noresm_frc2ext.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<!-- Solar constant -->
+<solar_irrad_data_file    >   'atm/cam/solar/SolarForcingCMIP6_18491230-22991231_c171031.nc'</solar_irrad_data_file>
+
+<!-- GHG values -->
+<scenario_ghg            >    'CHEM_LBC_FILE'   </scenario_ghg>
+<!-- use waccm LBC file -->  
+<flbc_file>atm/waccm/lb/LBC_2014-2500_CMIP6_SSP126_0p5degLat_GlobAnnAvg_c190301.nc</flbc_file>
+<flbc_type>'SERIAL'</flbc_type>
+<flbc_list>'CO2','CH4','N2O','CFC11eq','CFC12'</flbc_list>
+
+<!-- ozone data -->
+<prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                                    </prescribed_ozone_datapath>
+<prescribed_ozone_file    >   'ozone_strataero_WACCM_L70_zm5day_2015-2100_SSP126_c190221_nc3.nc' </prescribed_ozone_file>
+<prescribed_ozone_name    >   'O3'                                                                         </prescribed_ozone_name>
+<prescribed_ozone_type    >   'CYCLICAL'                                                                     </prescribed_ozone_type>
+<prescribed_ozone_cycle_yr>2100</prescribed_ozone_cycle_yr>
+
+<!-- Prescribed oxidants for aerosol chemistry -->
+<tracer_cnst_datapath     >   'atm/cam/tracer_cnst'                                        </tracer_cnst_datapath>
+<tracer_cnst_file         >   'tracer_cnst_halons_3D_L70_2014-2101_CMIP6-SSP1-2.6_c190307.nc' </tracer_cnst_file>
+<tracer_cnst_specifier    >   'O3','OH','NO3','HO2'                                        </tracer_cnst_specifier>
+<tracer_cnst_type         >   'CYCLICAL'                                      </tracer_cnst_type>
+<tracer_cnst_filelist     >   ''                                                           </tracer_cnst_filelist>
+<tracer_cnst_cycle_yr>2101</tracer_cnst_cycle_yr>
+
+<!-- Surface emissions for MAMOslo -->
+<srf_emis_type> 'CYCLICAL' </srf_emis_type>
+<srf_emis_cycle_yr>2100</srf_emis_cycle_yr>
+<!-- External forcing for MAMOslo -->
+<ext_frc_type>  'CYCLICAL' </ext_frc_type>
+<ext_frc_cycle_yr>2100</ext_frc_cycle_yr>
+<!-- surface emissions -->
+<srf_emis_specifier hgrid="0.9x1.25">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_BC_AX_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_BC_N_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_OM_NI_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_SO2_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_SO4_PR_all_surface_2014-2301_0.9x1.25_version20190808.nc'
+</srf_emis_specifier>
+<srf_emis_specifier hgrid="1.9x2.5">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_BC_AX_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_BC_N_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_OM_NI_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_SO2_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_SO4_PR_all_surface_2014-2301_1.9x2.5_version20190808.nc'
+</srf_emis_specifier>
+
+<!-- 3D emissions -->
+<ext_frc_specifier hgrid="0.9x1.25">
+  'H2O ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_2014-2101_CMIP6-SSP1-2.6_c190307.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_BC_AX_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_BC_N_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_BC_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_OM_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_SO2_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_SO4_PR_all_vertical_2014-2301_0.9x1.25_version20190808.nc'
+</ext_frc_specifier>
+<ext_frc_specifier hgrid="1.9x2.5">
+  'H2O ->  $INPUTDATA_ROOT/noresm-only/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_2100_date2100_CMIP6-SSP1-2.6_c190307.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_BC_AX_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_BC_N_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_BC_NI_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_OM_NI_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_SO2_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_SO4_PR_all_vertical_2014-2301_1.9x2.5_version20190808.nc'
+</ext_frc_specifier>
+
+
+<clubb_gamma_coef hgrid="0.9x1.25">0.286</clubb_gamma_coef>
+<clubb_gamma_coef hgrid="1.9x2.5" >0.264</clubb_gamma_coef>
+
+<!-- dyn_fv-->
+<fv_high_order_top> .false. </fv_high_order_top>
+<fv_am_geom_crrct> .true. </fv_am_geom_crrct>
+<fv_am_correction> .true. </fv_am_correction>
+<fv_am_fixer>      .true. </fv_am_fixer>
+<fv_am_fix_lbl>    .true. </fv_am_fix_lbl>
+<fv_am_diag>       .true. </fv_am_diag>
+
+<!--diagnostics-->
+<do_circulation_diags> .true. </do_circulation_diags>
+
+<!--phys_ctl_nl-->
+<dme_energy_adjust> .true. </dme_energy_adjust>
+  
+<!--zmconv_nl-->
+<zmconv_c0_lnd> 0.0200D0 </zmconv_c0_lnd>
+<zmconv_c0_ocn> 0.0200D0 </zmconv_c0_ocn>
+
+<zmconv_ke>     8.0E-6 </zmconv_ke>
+<zmconv_ke_lnd> 8.0E-6 </zmconv_ke_lnd>
+
+
+<!--micro_mg_nl-->
+<micro_mg_dcs hgrid="0.9x1.25">5.5e-4</micro_mg_dcs>
+<micro_mg_dcs hgrid="1.9x2.5" >5.0e-4</micro_mg_dcs>
+
+<!--gw_drag_nl-->
+<tau_0_ubc>  .true.   </tau_0_ubc>
+
+<!--cldfrc_nl-->
+<cldfrc_iceopt hgrid="1.9x2.5"> 4 </cldfrc_iceopt>
+
+<!--cldfrc2m_nl-->
+<cldfrc2m_rhmini hgrid="0.9x1.25">0.90D0</cldfrc2m_rhmini>
+
+<!--Options for megan -->
+<megan_specifier>'isoprene = isoprene','monoterp = myrcene + sabinene + limonene+ carene_3 + ocimene_t_b + pinene_b + pinene_a'</megan_specifier>
+
+<!--set SOA emissions since reading emissions from MEGAN -->
+<isoprene_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_isopr_1850_2000_zero.nc </isoprene_oslo_emis_file>
+<monoterp_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_monoterp_1850_2000_zero.nc </monoterp_oslo_emis_file>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850</sim_year>
+
+<!-- CMIP6 climatological volcanic background forcing -->
+<!--prescribed_strataero_file>' '</prescribed_strataero_file-->
+<prescribed_volcaero_type>'INTERP_MISSING_MONTHS'</prescribed_volcaero_type>
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>CMIP_CAM6_radiation_v3_reformatted.nc</prescribed_volcaero_file>
+<rad_climate>'A:Q:H2O','N:O2:O2','N:CO2:CO2','N:ozone:O3','N:N2O:N2O','N:CH4:CH4','N:CFC11:CFC11','N:CFC12:CFC12'</rad_climate>
+
+</namelist_defaults>

--- a/bld/namelist_files/use_cases/ssp245_cam6_noresm_aeronly_frc2.xml
+++ b/bld/namelist_files/use_cases/ssp245_cam6_noresm_aeronly_frc2.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<!--micro_do_sb_physics>   .true.   </micro_do_sb_physics-->
+<!--do_tms>                .false.  </do_tms-->
+<!--do_beljaars>           .true.   </do_beljaars-->
+
+<!-- Solar constant -->
+<solar_irrad_data_file     >   'atm/cam/solar/SolarForcingCMIP6piControl_c160921.nc'   </solar_irrad_data_file>
+<solar_data_ymd      >   18500101                                                </solar_data_ymd>
+<solar_data_type     >    FIXED                                                  </solar_data_type>
+
+<!-- 1850 GHG values Taken from Meinshausen et al., 2017 -->
+<co2vmr>   284.32e-6  </co2vmr>
+<ch4vmr>   808.25e-9  </ch4vmr>
+<n2ovmr>   273.02e-9  </n2ovmr>
+<f11vmr>   32.11e-12  </f11vmr>
+<f12vmr>   0.0        </f12vmr>
+
+<!-- 1850 ozone data -->
+<prescribed_ozone_cycle_yr>   1850                                                          </prescribed_ozone_cycle_yr>
+<prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                     </prescribed_ozone_datapath>
+<prescribed_ozone_file    >   'ozone_strataero_cyclical_WACCM6_L70_CMIP6-piControl.001_y21-50avg_zm_5day_c180802.nc'  </prescribed_ozone_file>
+<prescribed_ozone_name    >   'O3'                                                          </prescribed_ozone_name>
+<prescribed_ozone_type    >   'CYCLICAL'                                                    </prescribed_ozone_type>
+
+<!-- Prescribed oxidants for aerosol chemistry -->
+<tracer_cnst_cycle_yr >   1850                                                             </tracer_cnst_cycle_yr>
+<tracer_cnst_datapath >   'atm/cam/tracer_cnst'                                            </tracer_cnst_datapath>
+<tracer_cnst_file     >   'tracer_cnst_WACCM6_halons_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_c180802.nc' </tracer_cnst_file>
+<tracer_cnst_specifier>   'O3','OH','NO3','HO2'                                            </tracer_cnst_specifier>
+<tracer_cnst_type     >   'CYCLICAL'                                                       </tracer_cnst_type>
+<tracer_cnst_filelist >   ''                                                               </tracer_cnst_filelist>
+
+<!-- Surface emissions for MAMOslo -->
+<srf_emis_type> INTERP_MISSING_MONTHS </srf_emis_type>
+
+<!-- External forcing for MAMOslo -->
+<ext_frc_type>  INTERP_MISSING_MONTHS   </ext_frc_type>
+
+<!-- surface emissions -->
+<srf_emis_specifier hgrid="0.9x1.25">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_BC_AX_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_BC_N_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_OM_NI_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_SO2_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_SO4_PR_all_surface_2014-2301_0.9x1.25_version20190808.nc'
+</srf_emis_specifier>
+<srf_emis_specifier hgrid="1.9x2.5">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_BC_AX_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_BC_N_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_OM_NI_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_SO2_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_SO4_PR_all_surface_2014-2301_1.9x2.5_version20190808.nc'
+</srf_emis_specifier>
+
+<!-- 3D emissions -->
+<ext_frc_specifier hgrid="0.9x1.25">
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/perturbations/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_date_0000_5000_c180802.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_BC_AX_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_BC_N_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_BC_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_OM_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_SO2_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_SO4_PR_all_vertical_2014-2301_0.9x1.25_version20190808.nc'
+</ext_frc_specifier>
+<ext_frc_specifier hgrid="1.9x2.5">
+  'H2O    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20180512/perturbations/H2O_emission_CH4_oxidationx2_elev_3DmonthlyL70_1850climoCMIP6piControl001_y21-50avg_date_0000_5000_c180802.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_BC_AX_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_BC_N_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_BC_NI_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_OM_NI_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_SO2_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-MESSAGE-GLOBIOM-ssp245-1-1_SO4_PR_all_vertical_2014-2301_1.9x2.5_version20190808.nc'
+</ext_frc_specifier>
+
+
+<clubb_gamma_coef hgrid="0.9x1.25">0.286</clubb_gamma_coef>
+<clubb_gamma_coef hgrid="1.9x2.5" >0.264</clubb_gamma_coef>
+
+<!-- dyn_fv-->
+<fv_high_order_top> .false. </fv_high_order_top>
+<fv_am_geom_crrct> .true. </fv_am_geom_crrct>
+<fv_am_correction> .true. </fv_am_correction>
+<fv_am_fixer>      .true. </fv_am_fixer>
+<fv_am_fix_lbl>    .true. </fv_am_fix_lbl>
+<fv_am_diag>       .true. </fv_am_diag>
+
+<!--diagnostics-->
+<do_circulation_diags> .true. </do_circulation_diags>
+
+<!--phys_ctl_nl-->
+<dme_energy_adjust> .true. </dme_energy_adjust>
+  
+<!--zmconv_nl-->
+<zmconv_c0_lnd> 0.0200D0 </zmconv_c0_lnd>
+<zmconv_c0_ocn> 0.0200D0 </zmconv_c0_ocn>
+
+<zmconv_ke>     8.0E-6 </zmconv_ke>
+<zmconv_ke_lnd> 8.0E-6 </zmconv_ke_lnd>
+
+
+<!--micro_mg_nl-->
+<micro_mg_dcs hgrid="0.9x1.25">5.5e-4</micro_mg_dcs>
+<micro_mg_dcs hgrid="1.9x2.5" >5.0e-4</micro_mg_dcs>
+
+<!--gw_drag_nl-->
+<tau_0_ubc>  .true.   </tau_0_ubc>
+
+<!--cldfrc_nl-->
+<cldfrc_iceopt hgrid="1.9x2.5"> 4 </cldfrc_iceopt>
+
+<!--cldfrc2m_nl-->
+<cldfrc2m_rhmini hgrid="0.9x1.25">0.90D0</cldfrc2m_rhmini>
+
+<!--Options for megan -->
+<megan_specifier>'isoprene = isoprene','monoterp = myrcene + sabinene + limonene+ carene_3 + ocimene_t_b + pinene_b + pinene_a'</megan_specifier>
+
+<!--set SOA emissions since reading emissions from MEGAN -->
+<isoprene_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_isopr_1850_2000_zero.nc </isoprene_oslo_emis_file>
+<monoterp_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_monoterp_1850_2000_zero.nc </monoterp_oslo_emis_file>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850</sim_year>
+
+<!-- CMIP6 climatological volcanic background forcing -->
+<!--prescribed_strataero_file>' '</prescribed_strataero_file-->
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>CMIP_CAM6_radiation_average_v3_reformatted.nc</prescribed_volcaero_file>
+<prescribed_volcaero_cycle_yr>1850</prescribed_volcaero_cycle_yr>
+<prescribed_volcaero_type>CYCLICAL</prescribed_volcaero_type>
+<rad_climate>'A:Q:H2O','N:O2:O2','N:CO2:CO2','N:ozone:O3','N:N2O:N2O','N:CH4:CH4','N:CFC11:CFC11','N:CFC12:CFC12'</rad_climate>
+
+</namelist_defaults>

--- a/bld/namelist_files/use_cases/ssp370_cam6_noresm_aerlow_frc2.xml
+++ b/bld/namelist_files/use_cases/ssp370_cam6_noresm_aerlow_frc2.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<!-- Solar constant -->
+<solar_irrad_data_file    >   'atm/cam/solar/SolarForcingCMIP6_18491230-22991231_c171031.nc'</solar_irrad_data_file>
+
+<!-- GHG values -->
+<scenario_ghg            >    'CHEM_LBC_FILE'   </scenario_ghg>
+<!-- use waccm LBC file -->  
+<flbc_file>atm/waccm/lb/LBC_2014-2500_CMIP6_SSP370_0p5degLat_GlobAnnAvg_c190301.nc</flbc_file>
+<flbc_type>'SERIAL'</flbc_type>
+<flbc_list>'CO2','CH4','N2O','CFC11eq','CFC12'</flbc_list>
+
+<!-- ozone data -->
+<prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                                    </prescribed_ozone_datapath>
+<prescribed_ozone_file    >   'ozone_strataero_WACCM_L70_zm5day_18500101-21010201_CMIP6histEnsAvg_SSP370_c190403.nc' </prescribed_ozone_file>
+<prescribed_ozone_name    >   'O3'                                                                         </prescribed_ozone_name>
+<prescribed_ozone_type    >   'SERIAL'                                                                     </prescribed_ozone_type>
+
+<!-- Prescribed oxidants for aerosol chemistry -->
+<tracer_cnst_datapath     >   'atm/cam/tracer_cnst'                                        </tracer_cnst_datapath>
+<tracer_cnst_file         >   'tracer_cnst_halons_3D_L70_1849-2101_CMIP6ensAvg_SSP3-7.0_c190403.nc' </tracer_cnst_file>
+<tracer_cnst_specifier    >   'O3','OH','NO3','HO2'                                        </tracer_cnst_specifier>
+<tracer_cnst_type         >   'INTERP_MISSING_MONTHS'                                      </tracer_cnst_type>
+<tracer_cnst_filelist     >   ''                                                           </tracer_cnst_filelist>
+
+<!-- Surface emissions for MAMOslo -->
+<srf_emis_type> INTERP_MISSING_MONTHS </srf_emis_type>
+
+<!-- External forcing for MAMOslo -->
+<ext_frc_type>  INTERP_MISSING_MONTHS </ext_frc_type>
+
+<!-- surface emissions -->
+<srf_emis_specifier hgrid="0.9x1.25">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_AX_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_N_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_OM_NI_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO2_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO4_PR_all_surface_2014-2301_0.9x1.25_version20190808.nc'
+</srf_emis_specifier>
+<srf_emis_specifier hgrid="1.9x2.5">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_AX_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_N_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_OM_NI_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO2_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO4_PR_all_surface_2014-2301_1.9x2.5_version20190808.nc'
+</srf_emis_specifier>
+
+<!-- 3D emissions -->
+<ext_frc_specifier hgrid="0.9x1.25">
+  'H2O ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_1849-2101_CMIP6ensAvg_SSP3-7.0_c190403.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_AX_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_N_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_OM_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO2_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO4_PR_all_vertical_2014-2301_0.9x1.25_version20190808.nc'
+</ext_frc_specifier>
+<ext_frc_specifier hgrid="1.9x2.5">
+  'H2O ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_1849-2101_CMIP6ensAvg_SSP3-7.0_c190403.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_AX_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_N_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_NI_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_OM_NI_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO2_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO4_PR_all_vertical_2014-2301_1.9x2.5_version20190808.nc'
+</ext_frc_specifier>
+
+
+<clubb_gamma_coef hgrid="0.9x1.25">0.286</clubb_gamma_coef>
+<clubb_gamma_coef hgrid="1.9x2.5" >0.264</clubb_gamma_coef>
+
+<!-- dyn_fv-->
+<fv_high_order_top> .false. </fv_high_order_top>
+<fv_am_geom_crrct> .true. </fv_am_geom_crrct>
+<fv_am_correction> .true. </fv_am_correction>
+<fv_am_fixer>      .true. </fv_am_fixer>
+<fv_am_fix_lbl>    .true. </fv_am_fix_lbl>
+<fv_am_diag>       .true. </fv_am_diag>
+
+<!--diagnostics-->
+<do_circulation_diags> .true. </do_circulation_diags>
+
+<!--phys_ctl_nl-->
+<dme_energy_adjust> .true. </dme_energy_adjust>
+  
+<!--zmconv_nl-->
+<zmconv_c0_lnd> 0.0200D0 </zmconv_c0_lnd>
+<zmconv_c0_ocn> 0.0200D0 </zmconv_c0_ocn>
+
+<zmconv_ke>     8.0E-6 </zmconv_ke>
+<zmconv_ke_lnd> 8.0E-6 </zmconv_ke_lnd>
+
+
+<!--micro_mg_nl-->
+<micro_mg_dcs hgrid="0.9x1.25">5.5e-4</micro_mg_dcs>
+<micro_mg_dcs hgrid="1.9x2.5" >5.0e-4</micro_mg_dcs>
+
+<!--gw_drag_nl-->
+<tau_0_ubc>  .true.   </tau_0_ubc>
+
+<!--cldfrc_nl-->
+<cldfrc_iceopt hgrid="1.9x2.5"> 4 </cldfrc_iceopt>
+
+<!--cldfrc2m_nl-->
+<cldfrc2m_rhmini hgrid="0.9x1.25">0.90D0</cldfrc2m_rhmini>
+
+<!--Options for megan -->
+<megan_specifier>'isoprene = isoprene','monoterp = myrcene + sabinene + limonene+ carene_3 + ocimene_t_b + pinene_b + pinene_a'</megan_specifier>
+
+<!--set SOA emissions since reading emissions from MEGAN -->
+<isoprene_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_isopr_1850_2000_zero.nc </isoprene_oslo_emis_file>
+<monoterp_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_monoterp_1850_2000_zero.nc </monoterp_oslo_emis_file>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850</sim_year>
+
+<!-- CMIP6 climatological volcanic background forcing -->
+<!--prescribed_strataero_file>' '</prescribed_strataero_file-->
+<prescribed_volcaero_type>'INTERP_MISSING_MONTHS'</prescribed_volcaero_type>
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>CMIP_CAM6_radiation_v3_reformatted.nc</prescribed_volcaero_file>
+<rad_climate>'A:Q:H2O','N:O2:O2','N:CO2:CO2','N:ozone:O3','N:N2O:N2O','N:CH4:CH4','N:CFC11:CFC11','N:CFC12:CFC12'</rad_climate>
+
+</namelist_defaults>

--- a/bld/namelist_files/use_cases/ssp370lowntcf_cam6_noresm_frc2.xml
+++ b/bld/namelist_files/use_cases/ssp370lowntcf_cam6_noresm_frc2.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<!-- Solar constant -->
+<solar_irrad_data_file    >   'atm/cam/solar/SolarForcingCMIP6_18491230-22991231_c171031.nc'</solar_irrad_data_file>
+
+<!-- GHG values -->
+<scenario_ghg            >    'CHEM_LBC_FILE'   </scenario_ghg>
+<!-- use waccm LBC file -->  
+<flbc_file>noresm-only/atm/cam/lb/cmip6_ghg_version20191114/ghg_cmip6_hist_AerChemMIP_UoM-AIM-ssp370-lowNTCF-1-2-1_2014-2501_annual_0p5degLat_version20191114.nc</flbc_file>
+<flbc_type>'SERIAL'</flbc_type>
+<flbc_list>'CO2','CH4','N2O','CFC11eq','CFC12'</flbc_list>
+
+<!-- ozone data -->
+<prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                                    </prescribed_ozone_datapath>
+<prescribed_ozone_file    >   'ozone_strataero_WACCM_L70_zm5day_18500101-21010201_CMIP6histEnsAvg_SSP370_c190403.nc' </prescribed_ozone_file>
+<prescribed_ozone_name    >   'O3'                                                                         </prescribed_ozone_name>
+<prescribed_ozone_type    >   'SERIAL'                                                                     </prescribed_ozone_type>
+
+<!-- Prescribed oxidants for aerosol chemistry -->
+<tracer_cnst_datapath     >   'atm/cam/tracer_cnst'                                        </tracer_cnst_datapath>
+<tracer_cnst_file         >   'tracer_cnst_halons_3D_L70_1849-2101_CMIP6ensAvg_SSP3-7.0_c190403.nc' </tracer_cnst_file>
+<tracer_cnst_specifier    >   'O3','OH','NO3','HO2'                                        </tracer_cnst_specifier>
+<tracer_cnst_type         >   'INTERP_MISSING_MONTHS'                                      </tracer_cnst_type>
+<tracer_cnst_filelist     >   ''                                                           </tracer_cnst_filelist>
+
+<!-- Surface emissions for MAMOslo -->
+<srf_emis_type> INTERP_MISSING_MONTHS </srf_emis_type>
+
+<!-- External forcing for MAMOslo -->
+<ext_frc_type>  INTERP_MISSING_MONTHS </ext_frc_type>
+
+<!-- surface emissions -->
+<srf_emis_specifier hgrid="0.9x1.25">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_AX_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_N_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_OM_NI_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO2_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO4_PR_all_surface_2014-2301_0.9x1.25_version20190808.nc'
+</srf_emis_specifier>
+<srf_emis_specifier hgrid="1.9x2.5">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_AX_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_N_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_OM_NI_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO2_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO4_PR_all_surface_2014-2301_1.9x2.5_version20190808.nc'
+</srf_emis_specifier>
+
+<!-- 3D emissions -->
+<ext_frc_specifier hgrid="0.9x1.25">
+  'H2O ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_1849-2101_CMIP6ensAvg_SSP3-7.0_c190403.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_AX_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_N_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_OM_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO2_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO4_PR_all_vertical_2014-2301_0.9x1.25_version20190808.nc'
+</ext_frc_specifier>
+<ext_frc_specifier hgrid="1.9x2.5">
+  'H2O ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_1849-2101_CMIP6ensAvg_SSP3-7.0_c190403.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_AX_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_N_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_NI_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_OM_NI_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO2_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO4_PR_all_vertical_2014-2301_1.9x2.5_version20190808.nc'
+</ext_frc_specifier>
+
+
+<clubb_gamma_coef hgrid="0.9x1.25">0.286</clubb_gamma_coef>
+<clubb_gamma_coef hgrid="1.9x2.5" >0.264</clubb_gamma_coef>
+
+<!-- dyn_fv-->
+<fv_high_order_top> .false. </fv_high_order_top>
+<fv_am_geom_crrct> .true. </fv_am_geom_crrct>
+<fv_am_correction> .true. </fv_am_correction>
+<fv_am_fixer>      .true. </fv_am_fixer>
+<fv_am_fix_lbl>    .true. </fv_am_fix_lbl>
+<fv_am_diag>       .true. </fv_am_diag>
+
+<!--diagnostics-->
+<do_circulation_diags> .true. </do_circulation_diags>
+
+<!--phys_ctl_nl-->
+<dme_energy_adjust> .true. </dme_energy_adjust>
+  
+<!--zmconv_nl-->
+<zmconv_c0_lnd> 0.0200D0 </zmconv_c0_lnd>
+<zmconv_c0_ocn> 0.0200D0 </zmconv_c0_ocn>
+
+<zmconv_ke>     8.0E-6 </zmconv_ke>
+<zmconv_ke_lnd> 8.0E-6 </zmconv_ke_lnd>
+
+
+<!--micro_mg_nl-->
+<micro_mg_dcs hgrid="0.9x1.25">5.5e-4</micro_mg_dcs>
+<micro_mg_dcs hgrid="1.9x2.5" >5.0e-4</micro_mg_dcs>
+
+<!--gw_drag_nl-->
+<tau_0_ubc>  .true.   </tau_0_ubc>
+
+<!--cldfrc_nl-->
+<cldfrc_iceopt hgrid="1.9x2.5"> 4 </cldfrc_iceopt>
+
+<!--cldfrc2m_nl-->
+<cldfrc2m_rhmini hgrid="0.9x1.25">0.90D0</cldfrc2m_rhmini>
+
+<!--Options for megan -->
+<megan_specifier>'isoprene = isoprene','monoterp = myrcene + sabinene + limonene+ carene_3 + ocimene_t_b + pinene_b + pinene_a'</megan_specifier>
+
+<!--set SOA emissions since reading emissions from MEGAN -->
+<isoprene_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_isopr_1850_2000_zero.nc </isoprene_oslo_emis_file>
+<monoterp_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_monoterp_1850_2000_zero.nc </monoterp_oslo_emis_file>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850</sim_year>
+
+<!-- CMIP6 climatological volcanic background forcing -->
+<!--prescribed_strataero_file>' '</prescribed_strataero_file-->
+<prescribed_volcaero_type>'INTERP_MISSING_MONTHS'</prescribed_volcaero_type>
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>CMIP_CAM6_radiation_v3_reformatted.nc</prescribed_volcaero_file>
+<rad_climate>'A:Q:H2O','N:O2:O2','N:CO2:CO2','N:ozone:O3','N:N2O:N2O','N:CH4:CH4','N:CFC11:CFC11','N:CFC12:CFC12'</rad_climate>
+
+</namelist_defaults>

--- a/bld/namelist_files/use_cases/ssp370refghglowntcf_cam6_noresm_frc2.xml
+++ b/bld/namelist_files/use_cases/ssp370refghglowntcf_cam6_noresm_frc2.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+
+<!-- Solar constant -->
+<solar_irrad_data_file    >   'atm/cam/solar/SolarForcingCMIP6_18491230-22991231_c171031.nc'</solar_irrad_data_file>
+
+<!-- GHG values -->
+<scenario_ghg            >    'CHEM_LBC_FILE'   </scenario_ghg>
+<!-- use waccm LBC file -->  
+<flbc_file>atm/waccm/lb/LBC_2014-2500_CMIP6_SSP370_0p5degLat_GlobAnnAvg_c190301.nc</flbc_file>
+<flbc_type>'SERIAL'</flbc_type>
+<flbc_list>'CO2','CH4','N2O','CFC11eq','CFC12'</flbc_list>
+
+<!-- ozone data -->
+<prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                                    </prescribed_ozone_datapath>
+<prescribed_ozone_file    >   'ozone_strataero_WACCM_L70_zm5day_18500101-21010201_CMIP6histEnsAvg_SSP370_c190403.nc' </prescribed_ozone_file>
+<prescribed_ozone_name    >   'O3'                                                                         </prescribed_ozone_name>
+<prescribed_ozone_type    >   'SERIAL'                                                                     </prescribed_ozone_type>
+
+<!-- Prescribed oxidants for aerosol chemistry -->
+<tracer_cnst_datapath     >   'atm/cam/tracer_cnst'                                        </tracer_cnst_datapath>
+<tracer_cnst_file         >   'tracer_cnst_halons_3D_L70_1849-2101_CMIP6ensAvg_SSP3-7.0_c190403.nc' </tracer_cnst_file>
+<tracer_cnst_specifier    >   'O3','OH','NO3','HO2'                                        </tracer_cnst_specifier>
+<tracer_cnst_type         >   'INTERP_MISSING_MONTHS'                                      </tracer_cnst_type>
+<tracer_cnst_filelist     >   ''                                                           </tracer_cnst_filelist>
+
+<!-- Surface emissions for MAMOslo -->
+<srf_emis_type> INTERP_MISSING_MONTHS </srf_emis_type>
+
+<!-- External forcing for MAMOslo -->
+<ext_frc_type>  INTERP_MISSING_MONTHS </ext_frc_type>
+
+<!-- surface emissions -->
+<srf_emis_specifier hgrid="0.9x1.25">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_AX_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_N_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_OM_NI_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO2_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO4_PR_all_surface_2014-2301_0.9x1.25_version20190808.nc'
+</srf_emis_specifier>
+<srf_emis_specifier hgrid="1.9x2.5">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_AX_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_N_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_OM_NI_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO2_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO4_PR_all_surface_2014-2301_1.9x2.5_version20190808.nc'
+</srf_emis_specifier>
+
+<!-- 3D emissions -->
+<ext_frc_specifier hgrid="0.9x1.25">
+  'H2O ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_1849-2101_CMIP6ensAvg_SSP3-7.0_c190403.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_AX_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_N_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_OM_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO2_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO4_PR_all_vertical_2014-2301_0.9x1.25_version20190808.nc'
+</ext_frc_specifier>
+<ext_frc_specifier hgrid="1.9x2.5">
+  'H2O ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_1849-2101_CMIP6ensAvg_SSP3-7.0_c190403.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_AX_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_N_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_BC_NI_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_OM_NI_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO2_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_AerChemMIP_IAMC-AIM-ssp370-lowNTCF-1-1_SO4_PR_all_vertical_2014-2301_1.9x2.5_version20190808.nc'
+</ext_frc_specifier>
+
+
+<clubb_gamma_coef hgrid="0.9x1.25">0.286</clubb_gamma_coef>
+<clubb_gamma_coef hgrid="1.9x2.5" >0.264</clubb_gamma_coef>
+
+<!-- dyn_fv-->
+<fv_high_order_top> .false. </fv_high_order_top>
+<fv_am_geom_crrct> .true. </fv_am_geom_crrct>
+<fv_am_correction> .true. </fv_am_correction>
+<fv_am_fixer>      .true. </fv_am_fixer>
+<fv_am_fix_lbl>    .true. </fv_am_fix_lbl>
+<fv_am_diag>       .true. </fv_am_diag>
+
+<!--diagnostics-->
+<do_circulation_diags> .true. </do_circulation_diags>
+
+<!--phys_ctl_nl-->
+<dme_energy_adjust> .true. </dme_energy_adjust>
+  
+<!--zmconv_nl-->
+<zmconv_c0_lnd> 0.0200D0 </zmconv_c0_lnd>
+<zmconv_c0_ocn> 0.0200D0 </zmconv_c0_ocn>
+
+<zmconv_ke>     8.0E-6 </zmconv_ke>
+<zmconv_ke_lnd> 8.0E-6 </zmconv_ke_lnd>
+
+
+<!--micro_mg_nl-->
+<micro_mg_dcs hgrid="0.9x1.25">5.5e-4</micro_mg_dcs>
+<micro_mg_dcs hgrid="1.9x2.5" >5.0e-4</micro_mg_dcs>
+
+<!--gw_drag_nl-->
+<tau_0_ubc>  .true.   </tau_0_ubc>
+
+<!--cldfrc_nl-->
+<cldfrc_iceopt hgrid="1.9x2.5"> 4 </cldfrc_iceopt>
+
+<!--cldfrc2m_nl-->
+<cldfrc2m_rhmini hgrid="0.9x1.25">0.90D0</cldfrc2m_rhmini>
+
+<!--Options for megan -->
+<megan_specifier>'isoprene = isoprene','monoterp = myrcene + sabinene + limonene+ carene_3 + ocimene_t_b + pinene_b + pinene_a'</megan_specifier>
+
+<!--set SOA emissions since reading emissions from MEGAN -->
+<isoprene_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_isopr_1850_2000_zero.nc </isoprene_oslo_emis_file>
+<monoterp_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_monoterp_1850_2000_zero.nc </monoterp_oslo_emis_file>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850</sim_year>
+
+<!-- CMIP6 climatological volcanic background forcing -->
+<!--prescribed_strataero_file>' '</prescribed_strataero_file-->
+<prescribed_volcaero_type>'INTERP_MISSING_MONTHS'</prescribed_volcaero_type>
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>CMIP_CAM6_radiation_v3_reformatted.nc</prescribed_volcaero_file>
+<rad_climate>'A:Q:H2O','N:O2:O2','N:CO2:CO2','N:ozone:O3','N:N2O:N2O','N:CH4:CH4','N:CFC11:CFC11','N:CFC12:CFC12'</rad_climate>
+
+</namelist_defaults>

--- a/bld/namelist_files/use_cases/ssp585_cam6_noresm_frc2ext.xml
+++ b/bld/namelist_files/use_cases/ssp585_cam6_noresm_frc2ext.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0"?>
+
+<namelist_defaults>
+<!-- need to modify for 1 degree atmosphere -->
+<!-- Solar constant -->
+<solar_irrad_data_file    >   'atm/cam/solar/SolarForcingCMIP6_18491230-22991231_c171031.nc'</solar_irrad_data_file>
+
+<!-- GHG values -->
+<scenario_ghg            >    'CHEM_LBC_FILE'   </scenario_ghg>
+<!-- use waccm LBC file -->  
+<flbc_file>atm/waccm/lb/LBC_2014-2500_CMIP6_SSP585_0p5degLat_GlobAnnAvg_c190301.nc</flbc_file>
+<flbc_type>'SERIAL'</flbc_type>
+<flbc_list>'CO2','CH4','N2O','CFC11eq','CFC12'</flbc_list>
+
+<!-- ozone data -->
+<prescribed_ozone_datapath>   'atm/cam/ozone_strataero'                                                    </prescribed_ozone_datapath>
+<prescribed_ozone_file    >   'ozone_strataero_WACCM_L70_zm5day_2015-2100_SSP585_c190529.nc' </prescribed_ozone_file>
+<prescribed_ozone_name    >   'O3'                                                                         </prescribed_ozone_name>
+<prescribed_ozone_type    >   'CYCLICAL'                                                                     </prescribed_ozone_type>
+<prescribed_ozone_cycle_yr>2100</prescribed_ozone_cycle_yr>
+
+<!-- Prescribed oxidants for aerosol chemistry -->
+<tracer_cnst_datapath     >   'atm/cam/tracer_cnst'                                        </tracer_cnst_datapath>
+<tracer_cnst_file         >   'tracer_cnst_halons_3D_L70_2014-2101_CMIP6-SSP5-8.5_c190307.nc' </tracer_cnst_file>
+<tracer_cnst_specifier    >   'O3','OH','NO3','HO2'                                        </tracer_cnst_specifier>
+<tracer_cnst_type         >   'CYCLICAL'                                      </tracer_cnst_type>
+<tracer_cnst_filelist     >   ''                                                           </tracer_cnst_filelist>
+<tracer_cnst_cycle_yr>2101</tracer_cnst_cycle_yr>
+<!-- Surface emissions for MAMOslo -->
+<srf_emis_type> 'CYCLICAL' </srf_emis_type>
+<srf_emis_cycle_yr>2100</srf_emis_cycle_yr>
+<!-- External forcing for MAMOslo -->
+<ext_frc_type> 'CYCLICAL'  </ext_frc_type>
+<ext_frc_cycle_yr>2100</ext_frc_cycle_yr>
+
+<!-- surface emissions -->
+<srf_emis_specifier hgrid="0.9x1.25">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_BC_AX_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_BC_N_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_OM_NI_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_SO2_all_surface_2014-2301_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_SO4_PR_all_surface_2014-2301_0.9x1.25_version20190808.nc'
+</srf_emis_specifier>
+<srf_emis_specifier hgrid="1.9x2.5">
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_BC_AX_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_BC_N_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_OM_NI_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_SO2_all_surface_2014-2301_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_SO4_PR_all_surface_2014-2301_1.9x2.5_version20190808.nc'
+</srf_emis_specifier>
+
+<!-- 3D emissions -->
+<ext_frc_specifier hgrid="0.9x1.25">
+  'H2O ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_2014-2101_CMIP6-SSP5-8.5_c190307.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_BC_AX_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_BC_N_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_BC_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_OM_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_SO2_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_SO4_PR_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
+</ext_frc_specifier>
+<ext_frc_specifier hgrid="1.9x2.5">
+  'H2O ->  $INPUTDATA_ROOT/noresm-only/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_2100_date2100_CMIP6-SSP5-8.5_c190307.nc',
+  'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_BC_AX_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_BC_N_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_BC_NI_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'OM_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_OM_NI_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'SO2    ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_SO2_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+  'SO4_PR ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_SO4_PR_all_vertical_2014-2301_1.9x2.5_version20190808.nc',
+</ext_frc_specifier>
+
+
+<clubb_gamma_coef hgrid="0.9x1.25">0.286</clubb_gamma_coef>
+<clubb_gamma_coef hgrid="1.9x2.5" >0.264</clubb_gamma_coef>
+
+<!-- dyn_fv-->
+<fv_high_order_top> .false. </fv_high_order_top>
+<fv_am_geom_crrct> .true. </fv_am_geom_crrct>
+<fv_am_correction> .true. </fv_am_correction>
+<fv_am_fixer>      .true. </fv_am_fixer>
+<fv_am_fix_lbl>    .true. </fv_am_fix_lbl>
+<fv_am_diag>       .true. </fv_am_diag>
+
+<!--diagnostics-->
+<do_circulation_diags> .true. </do_circulation_diags>
+
+<!--phys_ctl_nl-->
+<dme_energy_adjust> .true. </dme_energy_adjust>
+  
+<!--zmconv_nl-->
+<zmconv_c0_lnd> 0.0200D0 </zmconv_c0_lnd>
+<zmconv_c0_ocn> 0.0200D0 </zmconv_c0_ocn>
+
+<zmconv_ke>     8.0E-6 </zmconv_ke>
+<zmconv_ke_lnd> 8.0E-6 </zmconv_ke_lnd>
+
+
+<!--micro_mg_nl-->
+<micro_mg_dcs hgrid="0.9x1.25">5.5e-4</micro_mg_dcs>
+<micro_mg_dcs hgrid="1.9x2.5" >5.0e-4</micro_mg_dcs>
+
+<!--gw_drag_nl-->
+<tau_0_ubc>  .true.   </tau_0_ubc>
+
+<!--cldfrc_nl-->
+<cldfrc_iceopt hgrid="1.9x2.5"> 4 </cldfrc_iceopt>
+
+<!--cldfrc2m_nl-->
+<cldfrc2m_rhmini hgrid="0.9x1.25">0.90D0</cldfrc2m_rhmini>
+
+<!--Options for megan -->
+<megan_specifier>'isoprene = isoprene','monoterp = myrcene + sabinene + limonene+ carene_3 + ocimene_t_b + pinene_b + pinene_a'</megan_specifier>
+
+<!--set SOA emissions since reading emissions from MEGAN -->
+<isoprene_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_isopr_1850_2000_zero.nc </isoprene_oslo_emis_file>
+<monoterp_oslo_emis_file>noresm-only/atm/cam/chem/trop_mozart_aero/emis/soanucl/bvocgcmFV19_monoterp_1850_2000_zero.nc </monoterp_oslo_emis_file>
+
+<!-- sim_year used for CLM datasets and SSTs forcings -->
+<sim_year>1850</sim_year>
+
+<!-- CMIP6 climatological volcanic background forcing -->
+<!--prescribed_strataero_file>' '</prescribed_strataero_file-->
+<prescribed_volcaero_type>'INTERP_MISSING_MONTHS'</prescribed_volcaero_type>
+<prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
+<prescribed_volcaero_file>CMIP_CAM6_radiation_v3_reformatted.nc</prescribed_volcaero_file>
+<rad_climate>'A:Q:H2O','N:O2:O2','N:CO2:CO2','N:ozone:O3','N:N2O:N2O','N:CH4:CH4','N:CFC11:CFC11','N:CFC12:CFC12'</rad_climate>
+
+</namelist_defaults>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -8,7 +8,7 @@
       CAM
     ===============
    -->
-    <desc atm="CAM60[%1PCT][%4xCO2][%2xCO2][%CCTS][%CFIRE][%CVBSX][%PORT][%RCO2][%SCAM][%SDYN][%WCCM][%WCMD][%WCSC][%WCTS][%NORESM][%FRC2][%GHGONLY][%NATONLY][%AEROXIDONLY][%OZONEONLY][%PINTCF][%PIAER][%PIAEROXID][%NORBC][%GHG2014][%GHGNOH2O2014][%N2O2014][%CH42014][%CH4NOH2O2014][%BC2014][%OC2014][%SO22014][%AER2014][%AEROXID2014][%SO2OXID2014][%NTCF2014][%ANTHRO2014][%GHGOZONELU2014][%OZONE2014][%H2O2014][%OXID2014][%FSST][%NORPDDMSBC][%NORPIBC][%SSP245]">CAM cam6 physics:</desc>
+    <desc atm="CAM60[%1PCT][%4xCO2][%2xCO2][%CCTS][%CFIRE][%CVBSX][%PORT][%RCO2][%SCAM][%SDYN][%WCCM][%WCMD][%WCSC][%WCTS][%NORESM][%FRC2][%GHGONLY][%NATONLY][%AEROXIDONLY][%AERONLY][%OXIDONLY][%OZONEONLY][%LUONLY][%PINTCF][%PIAER][%PIAEROXID][%NORBC][%GHG2014][%GHGNOH2O2014][%CO22014][%N2O2014][%CH42014][%CH4NOH2O2014][%BC2014][%OC2014][%SO22014][%AER2014][%AEROXID2014][%SO2OXID2014][%NTCF2014][%ANTHRO2014][%GHGOZONELU2014][%OZONE2014][%H2O2014][%OXID2014][%FSST][%NORPDDMSBC][%NORPIBC][%SSP245][%AERLOW][%FRC2EXT]">CAM cam6 physics:</desc>
     <desc atm="CAM50[%CCTS][%CLB][%PORT][%RCO2][%SCAM][%SDYN][%WCSC][%WCTS]"              >CAM cam5 physics:</desc>
     <desc atm="CAM40[%PORT][%RCO2][%SCAM][%SDYN][%TMOZ][%WXIE][%WXIED][%WCMD]"                   >CAM cam4 physics:</desc>
     <desc atm="CAM[%ADIAB][%DABIP04][%TJ16][%HS94][%KESSLER][%RCO2][%SPCAMS][%SPCAMCLBS][%SPCAMM][%SPCAMCLBM]">CAM simplified and non-versioned physics :</desc>
@@ -293,7 +293,8 @@
       <value compset="2000_CAM60%PTAERO"  >2000_cam6_oslo</value>
       <value compset="1850_CAM60%PTAERO"  >1850_cam6_oslo</value>
       <value compset="1850_CAM60%NORESM"    >1850_cam6_noresm</value>
-      <value compset="1850_CAM60%NORESM%FRC2"    >1850_cam6_noresm_frc2</value>
+      <value compset="1850_CAM60%NORESM%FRC2"       >1850_cam6_noresm_frc2</value>
+      <value compset="1850_CAM60%NORESM%NORBC%FRC2" >1850_cam6_noresm_frc2</value>
       <!-- DAMIP transient coupled -->
       <value compset="1850_CAM60%NORESM%GHGONLY"     >1850_cam6_noresm_ghgonly</value>
       <value compset="1850_CAM60%NORESM%NATONLY"     >1850_cam6_noresm_natonly</value>
@@ -307,10 +308,13 @@
       <value compset="1850_CAM60%NORESM%NORPIBC%GHGONLY"     >1850_cam6_noresm_ghgonly</value>
       <value compset="1850_CAM60%NORESM%NORPIBC%NATONLY"     >1850_cam6_noresm_natonly</value>
       <value compset="1850_CAM60%NORESM%NORPIBC%AEROXIDONLY" >1850_cam6_noresm_aeroxidonly</value>
+      <value compset="1850_CAM60%NORESM%NORPIBC%AERONLY"     >1850_cam6_noresm_aeronly</value>
+      <value compset="1850_CAM60%NORESM%NORPIBC%OXIDONLY"    >1850_cam6_noresm_oxidonly</value>
       <value compset="1850_CAM60%NORESM%NORPIBC%OZONEONLY"   >1850_cam6_noresm_ozoneonly</value>
       <!-- RFMIP/AerChemMIP constant preindustrial fSST -->
       <value compset="1850_CAM60%NORESM%NORBC%GHG2014" >1850_cam6_noresm_ghg2014</value>
       <value compset="1850_CAM60%NORESM%NORBC%GHGNOH2O2014" >1850_cam6_noresm_ghgnoh2o2014</value>
+      <value compset="1850_CAM60%NORESM%NORBC%CO22014" >1850_cam6_noresm_co22014</value>
       <value compset="1850_CAM60%NORESM%NORBC%N2O2014" >1850_cam6_noresm_n2o2014</value>
       <value compset="1850_CAM60%NORESM%NORBC%CH42014" >1850_cam6_noresm_ch42014</value>
       <value compset="1850_CAM60%NORESM%NORBC%CH4NOH2O2014" >1850_cam6_noresm_ch4noh2o2014</value>
@@ -318,7 +322,9 @@
       <value compset="1850_CAM60%NORESM%NORBC%OC2014"  >1850_cam6_noresm_oc2014</value>
       <value compset="1850_CAM60%NORESM%NORBC%SO22014" >1850_cam6_noresm_so22014</value>
       <value compset="1850_CAM60%NORESM%NORBC%AER2014" >1850_cam6_noresm_aer2014</value>
+      <value compset="1850_CAM60%NORESM%NORBC%AER2014%FRC2" >1850_cam6_noresm_aer2014_frc2</value>
       <value compset="1850_CAM60%NORESM%NORBC%AEROXID2014" >1850_cam6_noresm_aeroxid2014</value>
+      <value compset="1850_CAM60%NORESM%NORBC%AEROXID2014%FRC2" >1850_cam6_noresm_aeroxid2014_frc2</value>
       <value compset="1850_CAM60%NORESM%NORBC%SO2OXID2014" >1850_cam6_noresm_so2oxid2014</value>
       <value compset="1850_CAM60%NORESM%NORBC%NTCF2014" >1850_cam6_noresm_ntcf2014</value>
       <value compset="1850_CAM60%NORESM%NORBC%ANTHRO2014" >1850_cam6_noresm_anthro2014</value>
@@ -326,6 +332,7 @@
       <value compset="1850_CAM60%NORESM%NORBC%OZONE2014" >1850_cam6_noresm_ozone2014</value>
       <value compset="1850_CAM60%NORESM%NORBC%H2O2014" >1850_cam6_noresm_h2o2014</value>
       <value compset="1850_CAM60%NORESM%NORBC%OXID2014" >1850_cam6_noresm_oxid2014</value>
+      <value compset="1850_CAM60%NORESM%NORBC%OXID2014%FRC2" >1850_cam6_noresm_oxid2014_frc2</value>
      
       <value compset="HIST_CAM60%PTAERO"  >hist_cam6_oslo</value>
       <value compset="HIST_CAM60%NORESM"  >hist_cam6_noresm</value>
@@ -343,9 +350,22 @@
       <value compset="HIST_CAM60%NORESM%NORBC%PIAER"   >hist_cam6_noresm_piaer</value>
 
       <value compset="SSP126_CAM60%NORESM%FRC2"  >ssp126_cam6_noresm_frc2</value>
+      <value compset="SSP126_CAM60%NORESM%FRC2EXT"  >ssp126_cam6_noresm_frc2ext</value>
       <value compset="SSP245_CAM60%NORESM%FRC2"  >ssp245_cam6_noresm_frc2</value>
       <value compset="SSP370_CAM60%NORESM%FRC2"  >ssp370_cam6_noresm_frc2</value>
+      <value compset="SSP370LOWNTCF_CAM60%NORESM%FRC2"  >ssp370lowntcf_cam6_noresm_frc2</value>
+      <value compset="SSP370REFGHGLOWNTCF_CAM60%NORESM%FRC2"  >ssp370refghglowntcf_cam6_noresm_frc2</value>
       <value compset="SSP585_CAM60%NORESM%FRC2"  >ssp585_cam6_noresm_frc2</value>
+      <value compset="SSP585_CAM60%NORESM%FRC2EXT"  >ssp585_cam6_noresm_frc2ext</value>
+
+      <value compset="SSP370_CAM60%NORESM%NORBC%FRC2"  >ssp370_cam6_noresm_frc2</value>
+      <value compset="SSP370_CAM60%NORESM%NORBC%AERLOW%FRC2"  >ssp370_cam6_noresm_aerlow_frc2</value>
+
+      <value compset="SSP245_CAM60%NORESM%NORPIBC%FRC2"  >ssp245_cam6_noresm_frc2</value>
+      <value compset="SSP245_CAM60%NORESM%NORPIBC%GHGONLY%FRC2"  >ssp245_cam6_noresm_ghgonly_frc2</value>
+      <value compset="SSP245_CAM60%NORESM%NORPIBC%NATONLY%FRC2"  >ssp245_cam6_noresm_natonly_frc2</value>
+      <value compset="SSP245_CAM60%NORESM%NORPIBC%AERONLY%FRC2"  >ssp245_cam6_noresm_aeronly_frc2</value>
+      <value compset="SSP245_CAM60%NORESM%NORPIBC%AEROXIDONLY%FRC2"  >ssp245_cam6_noresm_aeroxidonly_frc2</value>
 
       <value compset="_CAM50%NUDGEPTAERO" >2000_cam5_oslonudge</value>
       <value compset="_CAM50%NUDGEPTAEROUPD1">cam5_nudge_ptaero_up1</value>
@@ -402,13 +422,15 @@
       <value compset="_CAM60%NORESM%FRC2%1PCT"> flbc_file='$DIN_LOC_ROOT/atm/waccm/lb/LBC_CMIP6_1pctCO2_y1-165_GlobAnnAvg_0p5degLat_c180929.nc'</value>
       <value compset="_CAM60%NORESM%FRC2%1PCT"> flbc_list='CO2','CH4','N2O','CFC11eq','CFC12' </value>
       <!-- fSST NorESM-derived pre-industrial -->
-      <value compset="1850_CAM60%NORESM%NORBC"> ocean_filename='dms-hamocc-dow-taylor_chlor_a-lanaclim_N1850_f19_tn14_20190621_1751-1780_cycle_version20190726.nc' </value>
+      <value compset="1850_CAM60%NORESM%NORBC" grid="a%0.9x1.25"> ocean_filename='dms-hamocc-dow-taylor_chlor_a-lanaclim_N1850frc2_f09_tn14_20191012_1351-1380_cycle_version20200106.nc' </value>
+      <value compset="1850_CAM60%NORESM%NORBC" grid="a%1.9x2.5" > ocean_filename='dms-hamocc-dow-taylor_chlor_a-lanaclim_N1850_f19_tn14_20190621_1751-1780_cycle_version20190726.nc' </value>
       <value compset="1850_CAM60%NORESM%NORBC"> dms_cycle_year=1850 </value>
       <value compset="1850_CAM60%NORESM%NORBC"> opom_cycle_year=1850 </value>
       <value compset="1850_CAM60%NORESM%NORBC"> dms_source_type='CYCLICAL' </value>
       <value compset="1850_CAM60%NORESM%NORBC"> opom_source_type='CYCLICAL' </value>
       <!-- NorESM derived preindustrial -->
-      <value compset="CAM60%NORESM%NORPIBC"> ocean_filename='dms-hamocc-dow-taylor_chlor_a-lanaclim_N1850_f19_tn14_20190621_1751-1780_cycle_version20190726.nc' </value>
+      <value compset="CAM60%NORESM%NORPIBC" grid="a%0.9x1.25"> ocean_filename='dms-hamocc-dow-taylor_chlor_a-lanaclim_N1850frc2_f09_tn14_20191012_1351-1380_cycle_version20200106.nc' </value>
+      <value compset="CAM60%NORESM%NORPIBC" grid="a%1.9x2.5" > ocean_filename='dms-hamocc-dow-taylor_chlor_a-lanaclim_N1850_f19_tn14_20190621_1751-1780_cycle_version20190726.nc' </value>
       <value compset="CAM60%NORESM%NORPIBC"> dms_cycle_year=1850 </value>
       <value compset="CAM60%NORESM%NORPIBC"> opom_cycle_year=1850 </value>
       <value compset="CAM60%NORESM%NORPIBC"> dms_source_type='CYCLICAL' </value>
@@ -418,6 +440,12 @@
       <value compset="HIST_CAM60%NORESM%NORBC"> ocean_filename='dms-hamocc-dow-taylor_chlor_a-lanaclim_NHIST_f19_tn14_20190625_1849-2015_series_version20190726.nc' </value>
       <value compset="HIST_CAM60%NORESM%NORBC"> dms_source_type='INTERP_MISSING_MONTHS' </value>
       <value compset="HIST_CAM60%NORESM%NORBC"> opom_source_type='INTERP_MISSING_MONTHS' </value>
+
+      <!-- NorESM derived evolving -->
+      <value compset="SSP370_CAM60%NORESM%NORBC"> ocean_filename='dms-hamocc-dow-taylor_chlor_a-lanaclim_NSSP370frc2_f19_tn14_20191014_2014-2101_series_version20200109.nc' </value>
+      <value compset="SSP370_CAM60%NORESM%NORBC"> dms_source_type='INTERP_MISSING_MONTHS' </value>
+      <value compset="SSP370_CAM60%NORESM%NORBC"> opom_source_type='INTERP_MISSING_MONTHS' </value>
+
       <!-- fSST AMIP type 1979-2014-->
       <value compset="HIST_CAM60%NORESM%NORPDDMSBC"> ocean_filename='dms-hamocc-dow-taylor_chlor_a-lanaclim_NHIST_f19_tn14_20190625_1985-2014_cycle_version20190726.nc' </value>
       <value compset="HIST_CAM60%NORESM%NORPDDMSBC"> dms_cycle_year=2000 </value>
@@ -426,6 +454,7 @@
       <value compset="HIST_CAM60%NORESM%NORPDDMSBC"> opom_source_type='CYCLICAL' </value>
       <!-- fSST 4xCO2-->
       <value compset="1850_CAM60%NORESM%NORBC%4xCO2"> co2vmr=1138.8e-6 </value>
+      <value compset="1850_CAM60%NORESM%NORBC%FRC2%4xCO2"> co2vmr=1138.8e-6 </value>
       <!-- fSST 2xCO2-->
       <value compset="1850_CAM60%NORESM%NORBC%2xCO2"> co2vmr=568.64e-6  </value>
     </values>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -194,8 +194,68 @@
   </compset>
 
   <compset>
+    <alias>NFHISTnorpibc_aeronly</alias>
+    <lname>1850_CAM60%NORESM%NORPIBC%AERONLY_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NFHISTnorpibc_oxidonly</alias>
+    <lname>1850_CAM60%NORESM%NORPIBC%OXIDONLY_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
     <alias>NFHISTnorpibc_ozoneonly</alias>
     <lname>1850_CAM60%NORESM%NORPIBC%OZONEONLY_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NFHISTnorpibc_luonly</alias>
+    <lname>1850_CAM60%NORESM%NORPIBC%LUONLY_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NFSSP370frc2norbc</alias>
+    <lname>SSP370_CAM60%NORESM%NORBC%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NFSSP370frc2norbc_aerlow</alias>
+    <lname>SSP370_CAM60%NORESM%NORBC%AERLOW%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NFSSP245frc2norpibc</alias>
+    <lname>SSP245_CAM60%NORESM%NORPIBC%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NFSSP245frc2norpibc_ghgonly</alias>
+    <lname>SSP245_CAM60%NORESM%NORPIBC%GHGONLY%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NFSSP245frc2norpibc_natonly</alias>
+    <lname>SSP245_CAM60%NORESM%NORPIBC%NATONLY%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NFSSP245frc2norpibc_aeronly</alias>
+    <lname>SSP245_CAM60%NORESM%NORPIBC%AERONLY%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NFSSP245frc2norpibc_aeroxidonly</alias>
+    <lname>SSP245_CAM60%NORESM%NORPIBC%AEROXIDONLY%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
     <science_support grid="f19_f19"/>
   </compset>
 
@@ -209,15 +269,25 @@
   <compset>
     <alias>NF1850norbc</alias>
     <lname>1850_CAM60%NORESM%NORBC_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09"/>
     <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NF1850frc2norbc</alias>
+    <lname>1850_CAM60%NORESM%NORBC%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f09_f09"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_4xco2</alias>
     <lname>1850_CAM60%NORESM%NORBC%4xCO2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09"/>
     <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NF1850frc2norbc_4xco2</alias>
+    <lname>1850_CAM60%NORESM%NORBC%FRC2%4xCO2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f09_f09"/>
   </compset>
 
   <compset>
@@ -235,6 +305,12 @@
   <compset>
     <alias>NF1850norbc_ghgnoh2o2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%GHGNOH2O2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NF1850norbc_co22014</alias>
+    <lname>1850_CAM60%NORESM%NORBC%CO22014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
     <science_support grid="f19_f19"/>
   </compset>
 
@@ -277,15 +353,25 @@
   <compset>
     <alias>NF1850norbc_aer2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%AER2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09"/>
     <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NF1850frc2norbc_aer2014</alias>
+    <lname>1850_CAM60%NORESM%NORBC%AER2014%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f09_f09"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_aeroxid2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%AEROXID2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09"/>
     <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NF1850frc2norbc_aeroxid2014</alias>
+    <lname>1850_CAM60%NORESM%NORBC%AEROXID2014%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f09_f09"/>
   </compset>
 
   <compset>
@@ -327,8 +413,13 @@
   <compset>
     <alias>NF1850norbc_oxid2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%OXID2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09"/>
     <science_support grid="f19_f19"/>
+  </compset>
+
+  <compset>
+    <alias>NF1850frc2norbc_oxid2014</alias>
+    <lname>1850_CAM60%NORESM%NORBC%OXID2014%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <science_support grid="f09_f09"/>
   </compset>
 
   <!-- CAM simpler model compsets -->
@@ -690,36 +781,46 @@
 
     <entry id="ATM_DOMAIN_FILE">
       <values match="last">
-        <value  compset="%NORESM%NORBC" grid="1.9x2.5">domain.lnd.fv1.9x2.5_tnx1v4.170609.nc</value>
-        <value  compset="%NORESM%NORPIBC" grid="1.9x2.5">domain.lnd.fv1.9x2.5_tnx1v4.170609.nc</value>
+        <value  compset="%NORESM%NORBC" grid="0.9x1.25">domain.lnd.fv0.9x1.25_tnx1v4.170609.nc</value>
+        <value  compset="%NORESM%NORBC" grid="1.9x2.5" >domain.lnd.fv1.9x2.5_tnx1v4.170609.nc</value>
+        <value  compset="%NORESM%NORPIBC" grid="0.9x1.25">domain.lnd.fv0.9x1.25_tnx1v4.170609.nc</value>
+        <value  compset="%NORESM%NORPIBC" grid="1.9x2.5" >domain.lnd.fv1.9x2.5_tnx1v4.170609.nc</value>
       </values>
     </entry>    
 
     <entry id="LND_DOMAIN_FILE">
       <values match="last">
-        <value  compset="%NORESM%NORBC" grid="1.9x2.5">domain.lnd.fv1.9x2.5_tnx1v4.170609.nc</value>
-        <value  compset="%NORESM%NORPIBC" grid="1.9x2.5">domain.lnd.fv1.9x2.5_tnx1v4.170609.nc</value>
+        <value  compset="%NORESM%NORBC" grid="0.9x1.25">domain.lnd.fv0.9x1.25_tnx1v4.170609.nc</value>
+        <value  compset="%NORESM%NORBC" grid="1.9x2.5" >domain.lnd.fv1.9x2.5_tnx1v4.170609.nc</value>
+        <value  compset="%NORESM%NORPIBC" grid="0.9x1.25">domain.lnd.fv0.9x1.25_tnx1v4.170609.nc</value>
+        <value  compset="%NORESM%NORPIBC" grid="1.9x2.5" >domain.lnd.fv1.9x2.5_tnx1v4.170609.nc</value>
       </values>
     </entry>    
 
     <entry id="ICE_DOMAIN_FILE">
       <values match="last">
-        <value  compset="%NORESM%NORBC" grid="1.9x2.5">domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</value>
-        <value  compset="%NORESM%NORPIBC" grid="1.9x2.5">domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</value>
+        <value  compset="%NORESM%NORBC" grid="0.9x1.25">domain.ocn.fv0.9x1.25_tnx1v4.170609_djlo.nc</value>
+        <value  compset="%NORESM%NORBC" grid="1.9x2.5" >domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</value>
+        <value  compset="%NORESM%NORPIBC" grid="0.9x1.25">domain.ocn.fv0.9x1.25_tnx1v4.170609_djlo.nc</value>
+        <value  compset="%NORESM%NORPIBC" grid="1.9x2.5" >domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</value>
       </values>
     </entry>    
 
     <entry id="OCN_DOMAIN_FILE">
       <values match="last">
-        <value  compset="%NORESM%NORBC" grid="1.9x2.5">domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</value>
-        <value  compset="%NORESM%NORPIBC" grid="1.9x2.5">domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</value>
+        <value  compset="%NORESM%NORBC" grid="0.9x1.25">domain.ocn.fv0.9x1.25_tnx1v4.170609_djlo.nc</value>
+        <value  compset="%NORESM%NORBC" grid="1.9x2.5" >domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</value>
+        <value  compset="%NORESM%NORPIBC" grid="0.9x1.25">domain.ocn.fv0.9x1.25_tnx1v4.170609_djlo.nc</value>
+        <value  compset="%NORESM%NORPIBC" grid="1.9x2.5" >domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</value>
       </values>
     </entry>    
 
     <entry id="SSTICE_GRID_FILENAME">
       <values match="last">
-        <value  compset="%NORESM%NORBC" grid="1.9x2.5">$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</value>
-        <value  compset="%NORESM%NORPIBC" grid="1.9x2.5">$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</value>
+        <value  compset="%NORESM%NORBC" grid="0.9x1.25">$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.ocn.fv0.9x1.25_tnx1v4.170609_djlo.nc</value>
+        <value  compset="%NORESM%NORBC" grid="1.9x2.5" >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</value>
+        <value  compset="%NORESM%NORPIBC" grid="0.9x1.25">$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.ocn.fv0.9x1.25_tnx1v4.170609_djlo.nc</value>
+        <value  compset="%NORESM%NORPIBC" grid="1.9x2.5" >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</value>
       </values>
     </entry>    
 
@@ -787,6 +888,7 @@
 
        <!-- fSST : evolving NorESM derived -->
        <value compset="HIST_CAM60%NORESM%NORBC"     grid=".+"                >$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_NHIST_f19_tn14_20190625_1849-2015_series_version20190726_ts.nc</value>
+       <value compset="SSP370_CAM60%NORESM%NORBC"   grid=".+"                >$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_NSSP370frc2_f19_tn14_20191014_2014-2101_series_version20200109_ts.nc</value>
 
         <value compset="1850_" grid=".+"                                     >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_pi_c101029.nc</value>
         <value compset="1850_"         grid="a%T31.*_oi%T31"                 >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_clim_pi_c101028.nc</value>
@@ -796,8 +898,10 @@
         <value compset="1850_"         grid="a%0.23x0.31.*_oi%0.23x0.31"     >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_pi_c101028.nc</value>
        
         <!-- fSST : constant preindustrial NorESM derived -->
-        <value compset="1850_CAM60%NORESM%NORBC"   grid=".+"                 >$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_N1850_f19_tn14_20190621_1751-1780_series_version20190726_clim.nc</value>
-        <value compset="CAM60%NORESM%NORPIBC"      grid=".+"                 >$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_N1850_f19_tn14_20190621_1751-1780_series_version20190726_clim.nc</value>
+        <value compset="1850_CAM60%NORESM%NORBC"   grid="a%0.9x1.25"         >$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_N1850frc2_f09_tn14_20191012_1351-1380_series_version20200106_clim.nc</value>
+        <value compset="1850_CAM60%NORESM%NORBC"   grid="a%1.9x2.5"          >$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_N1850_f19_tn14_20190621_1751-1780_series_version20190726_clim.nc</value>
+        <value compset="CAM60%NORESM%NORPIBC"      grid="a%0.9x1.25"         >$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_N1850frc2_f09_tn14_20191012_1351-1380_series_version20200106_clim.nc</value>
+        <value compset="CAM60%NORESM%NORPIBC"      grid="a%1.9x2.5"          >$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_N1850_f19_tn14_20190621_1751-1780_series_version20190726_clim.nc</value>
 
         <value compset="2000"          grid=".+"                             >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_2000climo_c180511.nc</value>
         <value compset="2000"          grid="a%T31.*_oi%T31"                 >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_2000climo_c180511.nc</value>

--- a/src/NorESM/fv/metdata.F90
+++ b/src/NorESM/fv/metdata.F90
@@ -872,6 +872,9 @@ contains
       enddo
     else
     
+!ak+
+     if (.not. met_nudge_only_uvps) then
+!ak-
       if (.not.has_ts) then
          if (masterproc) then
             write(iulog,*) 'get_ocn_ice_frcs: TS is not in the met dataset and cannot set ocnfrc and icefrc'
@@ -879,6 +882,10 @@ contains
             call endrun('get_ocn_ice_frcs: TS is not in the met dataset')
          endif
       endif
+!ak+
+     endif
+!ak-
+
 
       do i = 1,ncol
 


### PR DESCRIPTION
Some compsets used for CMIP6 existing in the old git-repository (branch featureCESM2.1.0-OsloDevelopment branch) have been imported in the new repository structure.