### PR TITLE
Fixed test related to freezing of rain to produce ice if mean rain size is smaller than Dcs

### DIFF
--- a/src/NorESM/micro_mg2_0.F90
+++ b/src/NorESM/micro_mg2_0.F90
@@ -1733,11 +1733,13 @@ subroutine micro_mg_tend ( &
         if (do_cldice) then
 
            ! freezing of rain to produce ice if mean rain size is smaller than Dcs
-           if (lamr(i,k) > qsmall .and. 1._r8/lamr(i,k) < Dcs) then
-              mnuccri(i,k)=mnuccr(i,k)
-              nnuccri(i,k)=nnuccr(i,k)
-              mnuccr(i,k)=0._r8
-              nnuccr(i,k)=0._r8
+           if (lamr(i,k) > qsmall) then
+              if (1._r8/lamr(i,k) < Dcs) then
+                 mnuccri(i,k)=mnuccr(i,k)
+                 nnuccri(i,k)=nnuccr(i,k)
+                 mnuccr(i,k)=0._r8
+                 nnuccr(i,k)=0._r8
+              end if
            end if
         end if
 


### PR DESCRIPTION
The Fortran standard does not specify the sequence in which compound logical expressions are evaluated in an if instruction. 

When two conditions are combined and tested using .AND. as in:

           if (lamr(i,k) > qsmall .AND. 1._r8/lamr(i,k) < Dcs) then
              mnuccri(i,k)=mnuccr(i,k)
              nnuccri(i,k)=nnuccr(i,k)
              mnuccr(i,k)=0._r8
              nnuccr(i,k)=0._r8
           end if​

(from https://github.com/NorESMhub/CAM/blob/cam_cesm2_1_rel_05-Nor_v1.0.2/src/NorESM/micro_mg2_0.F90 at line 1736)

it is wrong to assume that the compiler has to treat them from left to right and stop the evaluation if the first condition becomes true: the second condition might be evaluated first which produces an erroneous arithmetic operation (floating-point exception) when lamr(i,k)=0:

The workaround is to use two consecutive if instructions:

           if (lamr(i,k) > qsmall) then 
                   if (1._r8/lamr(i,k) < Dcs) then
                           mnuccri(i,k)=mnuccr(i,k)
                           nnuccri(i,k)=nnuccr(i,k)
                           mnuccr(i,k)=0._r8
                           nnuccr(i,k)=0._r8
                   end if
           end if​​
