### PR TITLE
added pes settings for atm-only simulation on betzy machine

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1437,6 +1437,43 @@
       </pes>
     </mach>
   </grid>
+  <grid name="any">
+    <mach name="betzy">
+      <pes pesize="any" compset="any">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-4</ntasks_atm> 
+	  <ntasks_lnd>-4</ntasks_lnd>           
+	  <ntasks_rof>-4</ntasks_rof> 
+	  <ntasks_ice>-4</ntasks_ice> 
+	  <ntasks_ocn>-4</ntasks_ocn> 
+	  <ntasks_glc>-4</ntasks_glc> 
+	  <ntasks_wav>-4</ntasks_wav> 
+	  <ntasks_cpl>-4</ntasks_cpl> 
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm> 
+	  <nthrds_lnd>1</nthrds_lnd> 
+	  <nthrds_rof>1</nthrds_rof> 
+	  <nthrds_ice>1</nthrds_ice> 
+	  <nthrds_ocn>1</nthrds_ocn> 
+	  <nthrds_glc>1</nthrds_glc> 
+	  <nthrds_wav>1</nthrds_wav> 
+	  <nthrds_cpl>1</nthrds_cpl> 
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm> 
+	  <rootpe_lnd>0</rootpe_lnd> 
+	  <rootpe_rof>0</rootpe_rof> 
+	  <rootpe_ice>0</rootpe_ice>    
+	  <rootpe_ocn>0</rootpe_ocn>   
+	  <rootpe_glc>0</rootpe_glc> 
+	  <rootpe_wav>0</rootpe_wav> 
+	  <rootpe_cpl>0</rootpe_cpl>                         
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
   <grid name="a%0.9x1.25">
     <mach name="any">
       <pes pesize="any" compset="any">


### PR DESCRIPTION
in cime_config/config_pes.xml : added settings for Betzy machine 
4 nodes for atmosphere-only simulations (standard was 2 nodes before)