### PR TITLE
Added correction of size function in dry deposition

### DIFF
--- a/src/chemistry/oslo_aero/oslo_aerosols_intr.F90
+++ b/src/chemistry/oslo_aero/oslo_aerosols_intr.F90
@@ -371,7 +371,6 @@ contains
     !The following logic is based on that process-mode tracers 
     !always follow AFTER the actual tracers!!
 
-      dens_aer(:,:) = 0._r8
    do m = 0, nmodes   ! main loop over aerosol modes
 
        do lphase = 1, 2   ! loop over interstitial / cloud-borne forms
@@ -386,7 +385,7 @@ contains
                rad_aer(1:ncol,:top_lev-1) = 0._r8
              end if
              rad_aer(1:ncol,top_lev:) = 0.5_r8*dgncur_awet(1:ncol,top_lev:,m)   &
-                                 *exp(1.5_r8*(logSigma))
+                                 *exp(1.5_r8*(logSigma**2))
 
              ! dens_aer(1:ncol,:) = wet density (kg/m3)
              if(top_lev.gt.1)then
@@ -427,7 +426,7 @@ contains
                   rad_aer(1:ncol, top_lev-1) = 0.0_r8
                 end if
                 rad_aer(1:ncol,top_lev:) = 0.5_r8*dgncur_awet_processmode(1:ncol,top_lev:,processModeMap(mm))   &
-                                 *exp(1.5_r8*(logSigma))
+                                 *exp(1.5_r8*(logSigma**2))
                 call modal_aero_depvel_part( ncol, state%t(:,:), state%pmid(:,:), ram1, fv,  & 
                            vlc_dry(:,:,jvlc), vlc_trb(:,jvlc), vlc_grv(:,:,jvlc),  &
                            rad_aer(:,:), dens_aer(:,:), sg_aer(:,:), 3, lchnk)


### PR DESCRIPTION
Given that cam-Nor-dev is now open for changes in the answer I am now sending the dry deposition correction that Jean Iaquinta found some time ago. As part of the testing I checked that cam-Nor-dev reproduces CMIP6 so this will be the first answer changing results. Comparisons can be found at: 
http://ns2345k.web.sigma2.no/diagnostics/noresm/oyvinds/N1850_f19_tn14_vdcorr_220112/ 
for general output and
http://ns2345k.web.sigma2.no/aerosol_diagnostics/NF1850norbc_aer2014_f19_f19_20210530_vd-NF1850norbc_aer2014_f19_f19_20210530/ModIvsModII.htm
for aerosols. The net imbalance on the top of the atmosphere does not change but there is cancellation between lower cloud forcing and less net incoming solar radiation.