### PR TITLE
H2O link for f09 in ssp126_cam6_noresm_frc2ext.xml and ssp585_cam6_noresm_frc2ext.xml

### DIFF
--- a/bld/namelist_files/use_cases/ssp126_cam6_noresm_frc2ext.xml
+++ b/bld/namelist_files/use_cases/ssp126_cam6_noresm_frc2ext.xml
@@ -51,7 +51,7 @@
 
 <!-- 3D emissions -->
 <ext_frc_specifier hgrid="0.9x1.25">
-  'H2O ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_2014-2101_CMIP6-SSP1-2.6_c190307.nc',
+  'H2O ->  $INPUTDATA_ROOT/noresm-only/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_2100_date2100_CMIP6-SSP1-2.6_c190307.nc',
   'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_BC_AX_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
   'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_BC_N_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
   'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-IMAGE-ssp126-1-1_BC_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',

--- a/bld/namelist_files/use_cases/ssp585_cam6_noresm_frc2ext.xml
+++ b/bld/namelist_files/use_cases/ssp585_cam6_noresm_frc2ext.xml
@@ -51,7 +51,7 @@
 
 <!-- 3D emissions -->
 <ext_frc_specifier hgrid="0.9x1.25">
-  'H2O ->  $INPUTDATA_ROOT/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_2014-2101_CMIP6-SSP5-8.5_c190307.nc',
+  'H2O ->  $INPUTDATA_ROOT/noresm-only/atm/cam/chem/emis/elev/H2OemissionCH4oxidationx2_3D_L70_2100_date2100_CMIP6-SSP5-8.5_c190307.nc',
   'BC_AX  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_BC_AX_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
   'BC_N   ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_BC_N_all_vertical_2014-2301_0.9x1.25_version20190808.nc',
   'BC_NI  ->  $INPUTDATA_ROOT/atm/cam/chem/emis/cmip6_emissions_version20190808/emissions_cmip6_noresm2_ScenarioMIP_IAMC-REMIND-MAGPIE-ssp585-1-1_BC_NI_all_vertical_2014-2301_0.9x1.25_version20190808.nc',

--- a/src/chemistry/oslo_aero/ndrop.F90
+++ b/src/chemistry/oslo_aero/ndrop.F90
@@ -2969,55 +2969,47 @@ subroutine ccncalc_oslo(state &
    do m=1,nmodes
       do k=top_lev,pver
 
-         do i=1,ncol
-
-!+tht
-          if (hasAerosol(i,k,m)) then
-!-tht
+          do i=1,ncol
+            if (hasAerosol(i,k,m)) then
             !Curvature-parameter "A" in ARGI (eqn 5)
-            a = surften_coef/tair(i,k)
+               a = surften_coef/tair(i,k)
 
             !standard factor for transforming size distr
             !volume ==> number (google psd.pdf by zender)
-            exp45logsig_var = & 
-               exp(4.5_r8*lnsigma(i,k,m)*lnsigma(i,k,m))
+               exp45logsig_var = & 
+                  exp(4.5_r8*lnsigma(i,k,m)*lnsigma(i,k,m))
 
             !Numbe rmedian radius (power of three)
             !By definition of lognormal distribution
-            amcube =(3._r8*volumeConcentration(i,k,m) & 
-               /(4._r8*pi*exp45logsig_var*numberConcentration(i,k,m)))  ! only if variable size dist
+               amcube =(3._r8*volumeConcentration(i,k,m) & 
+                  /(4._r8*pi*exp45logsig_var*numberConcentration(i,k,m)))  ! only if variable size dist
 
 
             !This is part of eqn 9 in ARGII 
             !where A smcoefcoef is 2/3^(3/2) 
-            smcoef = smcoefcoef * a * sqrt(a)
+               smcoef = smcoefcoef * a * sqrt(a)
 
             !This is finally solving eqn 9 
             !(solve for critical supersat of mode)
-            sm=smcoef   &
+               sm=smcoef   &
                / sqrt(hygroscopicity(i,k,m)*amcube) ! critical supersaturation
 
             !Solve eqn 13 in ARGII
-            do lsat = 1,psat
+               do lsat = 1,psat
    
                !eqn 15 in ARGII
-               argfactor=twothird/(sq2*lnSigma(i,k,m))
+                  argfactor=twothird/(sq2*lnSigma(i,k,m))
 
                !eqn 15 in ARGII
-               arg=argfactor*log(sm/super(lsat))
+                  arg=argfactor*log(sm/super(lsat))
 
                !eqn 13 i ARGII
-               ccn(i,k,lsat)=ccn(i,k,lsat) &
-                  +numberConcentration(i,k,m)&
-                  *0.5_r8*(1._r8-erf(arg))
-            end do
-!+tht
-          else
-            do lsat = 1, psat
-               ccn(i,k,lsat)=0._r8
-            enddo
-          endif
-!-tht
+                  ccn(i,k,lsat)=ccn(i,k,lsat) &
+                     +numberConcentration(i,k,m)&
+                     *0.5_r8*(1._r8-erf(arg))
+
+               end do
+            end if
          end do
       end do
    end do

--- a/src/physics/cosp2/optics/cosp_optics.F90
+++ b/src/physics/cosp2/optics/cosp_optics.F90
@@ -34,7 +34,7 @@ module cosp_optics
   USE COSP_KINDS, ONLY: wp,dp
   USE COSP_MATH_CONSTANTS,  ONLY: pi
   USE COSP_PHYS_CONSTANTS,  ONLY: rholiq,km,rd,grav
-  USE MOD_MODIS_SIM,        ONLY: phaseIsLiquid,phaseIsIce,get_g_nir=>get_g_nir_old,get_ssa_nir=>get_ssa_nir_old
+  USE MOD_MODIS_SIM,        ONLY: phaseIsLiquid,phaseIsIce,get_g_nir,get_ssa_nir
   implicit none
   
   real(wp),parameter ::        & !


### PR DESCRIPTION
corrected H2O emission file link for f09 for the extended (year 2100-2300) SSP1-2.6 and SSP5-8.5 compsets.  The updated files are ssp126_cam6_noresm_frc2ext.xml and ssp585_cam6_noresm_frc2ext.xml.  Without this correction the model would stop running as it would not find the correct years in the file.  There was no problem for the f19 setup - there the link was to the correct file.