### PR TITLE
Adding issue and pull-request templates for CAM

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug Report
+description: File a CAM-Nor bug report (remember to search existing issues and the GitHub discussions first)
+title: "Put brief (<65 char) bug title here!"
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also - what did you expect to happen?
+      placeholder: Write a description here.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: What are the steps to reproduce the bug?
+      description: How can we see this issue?
+      placeholder: ex. Run the case in /cluster/work/users/...
+    validations:
+      required: true
+  - type: input
+    id: cam-tag
+    attributes:
+      label: What CAM-Nor tag were you using?
+      description: Type "git describe" to see the tag
+      placeholder: ex. noresm_v4_cam6_3_112
+    validations:
+      required: true
+  - type: dropdown
+    id: machine
+    attributes:
+      label: What machine were you running CAM (or NorESM) on?
+      multiple: true
+      options:
+        - Betzy
+        - Docker container
+        - Personal Computer
+        - Other (please explain below)
+    validations:
+      required: true
+  - type: dropdown
+    id: compiler
+    attributes:
+      label: What compiler were you using?
+      multiple: true
+      options:
+        - Intel
+        - GNU
+        - Other (please specify below)
+    validations:
+      required: true
+  - type: input
+    id: case-directory
+    attributes:
+      label: Path to a case directory, if applicable
+      description: The full path to a case in which the error occurred
+      placeholder: ex. /cluster/projects/nn0000k/...
+    validations:
+      required: false
+  - type: dropdown
+    id: implemenation
+    attributes:
+      label: Will you be addressing this bug yourself?
+      description: If Yes, please also assign this issue to yourself (if possible)
+      multiple: false
+      options:
+        - "Yes"
+        - "Yes, but I will need some help"
+        - "No"
+    validations:
+      required: true
+  - type: textarea
+    id: extra-info
+    attributes:
+      label: Extra info
+      description: Please provide any additional information here that you think might be relevant
+      placeholder: Write a description here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: NorESM documentation
+    url: https://noresm-docs.readthedocs.io/en/noresm2
+    about: The NorESM documentation is the best place to start
+  - name: CAM GitHub Discussions forum
+    url: https://github.com/NorESMhub/CAM/discussions
+    about: GitHub discussion topics related to CAM-Nor

--- a/.github/ISSUE_TEMPLATE/enhancement_request.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.yml
@@ -1,0 +1,44 @@
+name: Enhancement Request
+description: Request an enhancement
+title: "Put brief (<65 char) title here!"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: enhancement-description
+    attributes:
+      label: What is the feature/what would you like to discuss?
+      placeholder: ex. Implement changes from Discussion item #12345
+    validations:
+      required: true
+  - type: textarea
+    id: user-reference
+    attributes:
+      label: Is there anyone in particular you want to be part of this conversation?
+      description: Add the user(s) with @<username>
+      placeholder: ex. @altmuligmann
+    validations:
+      required: false
+  - type: dropdown
+    id: answer-changing
+    attributes:
+      label: Will this change (regression test) answers?
+      description: If yes, please describe level (e.g., roundoff, climate changing)
+      multiple: false
+      options:
+        - "Yes"
+        - "No"
+        - "I Don't Know"
+    validations:
+      required: true
+  - type: dropdown
+    id: implemenation
+    attributes:
+      label: Will you be implementing this enhancement yourself?
+      description: If Yes, please also assign this issue to yourself
+      multiple: false
+      options:
+        - "Yes"
+        - "Yes, but I will need some help"
+        - "No"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,49 @@
+name: Other
+description: ex. code clean-up, infrastructure updates
+title: "Put brief (<65 char) title here!"
+body:
+  - type: dropdown
+    id: other-type
+    attributes:
+      label: Issue Type
+      description: If applicable, please add relevant label(s)
+      multiple: true
+      options:
+        - Code Clean-up
+        - Infrastructure Update
+        - Externals Update
+        - Documentation Update
+        - Other (please describe below)
+    validations:
+      required: true
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Issue Description
+      description: Describe what will change
+    validations:
+      required: true
+  - type: dropdown
+    id: answer-changing
+    attributes:
+      label: Will this change answers?
+      description: If yes, please please describe level (e.g., roundoff, climate changing)
+      multiple: false
+      options:
+        - "Yes"
+        - "No"
+        - "I Don't Know"
+    validations:
+      required: true
+  - type: dropdown
+    id: implemenation
+    attributes:
+      label: Will you be implementing this yourself?
+      description: If Yes, please also assign this issue to yourself (if possible)
+      multiple: false
+      options:
+        - "Yes"
+        - "Yes, but I will need some help"
+        - "No"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+**[ REMOVE ALL TEXT IN SQUARE BRACKETS (INCLUDING THIS SENTENCE) BEFORE HITTING 'Create pull request'. ]**
+
+_[ Edit the title to be of the form: `<proposed_tag_name>: Very short description` ]_
+
+Contributors: _[ Your name and/or GitHub ID along with those from everyone who contributed to this PR. ]_
+
+Reviewers: _[ Put in proposed reviewers names / GitHub IDs ]_
+
+Summary: _[ One-line summary of changes introduced in this PR and/or reason for the PR ]_
+
+Github PR URL: _[ add this once PR is open but erase this text first ]_
+
+Purpose of changes: _[ Include the issue number and title text for each relevant GitHub issue ]_
+
+Changes made to build system: _[ describe or write 'None' ]_
+
+Changes made to the namelist: _[ describe or write 'None' ]_
+
+Changes to the defaults for the boundary datasets: _[ describe or write 'None' ]_
+
+Substantial timing or memory changes: _[ describe or write 'None' ]_
+
+_[ Detailed description of changes ]_
+
+_[ List each test suite run. For each suite, include machine, compiler, and any test failures.
+  For each failure, include the contents of TestStatus or the output from cs.status.testid for that test ]_
+
+Issues addressed by this PR: _[ For each issue include a [GitHub issue entry](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue), one per line. ]_


### PR DESCRIPTION
Contributors: Steve Goldhaber

Reviewers: Dirk Olivie, Mariana Vertenstein

Summary: Add templates for new issues and for pull requests to prompt for necessary information

Github PR URL:  https://github.com/NorESMhub/CAM/pull/85

Purpose of Changes: #84; Add templates

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

There is a single pull request template but when opening a new issue, the user will be prompted to enter a bug report, enhancement request, or other type of issue.

No tests to run but reviewed appearance of files.

Issues addressed by this PR: 
closes #84 