### PR TITLE
Add CAM-Nor tag descriptions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,28 @@
 **[ REMOVE ALL TEXT IN SQUARE BRACKETS (INCLUDING THIS SENTENCE) BEFORE HITTING 'Create pull request'. ]**
 
-_[ Edit the title to be of the form: `<proposed_tag_name>: Very short description` ]_
+[ Edit the title to be of the form: `<proposed_tag_name>: Very short description` ]
 
-Contributors: _[ Your name and/or GitHub ID along with those from everyone who contributed to this PR. ]_
+Summary: [ One-line summary of changes introduced in this PR and/or reason for the PR ]
 
-Reviewers: _[ Put in proposed reviewers names / GitHub IDs ]_
+Contributors: [ Your name and/or GitHub ID along with those from everyone who contributed to this PR. ]
 
-Summary: _[ One-line summary of changes introduced in this PR and/or reason for the PR ]_
+Reviewers: [ Put in proposed reviewers names / GitHub IDs ]
 
-Github PR URL: _[ add this once PR is open but erase this text first ]_
+Purpose of changes: [ Include the issue number and title text for each relevant GitHub issue ]
 
-Purpose of changes: _[ Include the issue number and title text for each relevant GitHub issue ]_
+Github PR URL: [ add this once PR is open but erase this text first ]
 
-Changes made to build system: _[ describe or write 'None' ]_
+Changes made to build system: [ describe or write 'None' ]
 
-Changes made to the namelist: _[ describe or write 'None' ]_
+Changes made to the namelist: [ describe or write 'None' ]
 
-Changes to the defaults for the boundary datasets: _[ describe or write 'None' ]_
+Changes to the defaults for the boundary datasets: [ describe or write 'None' ]
 
-Substantial timing or memory changes: _[ describe or write 'None' ]_
+Substantial timing or memory changes: [ describe or write 'None' ]
 
-_[ Detailed description of changes ]_
+[ Detailed description of changes ]
 
-_[ List each test suite run. For each suite, include machine, compiler, and any test failures.
-  For each failure, include the contents of TestStatus or the output from cs.status.testid for that test ]_
+[ List each test suite run. For each suite, include machine, compiler, and any test failures.
+  For each failure, include the contents of TestStatus or the output from cs.status.testid for that test ]
 
-Issues addressed by this PR: _[ For each issue include a [GitHub issue entry](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue), one per line. ]_
+Issues addressed by this PR: [ For each issue include a [GitHub issue entry](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue), one per line. ]

--- a/README.md
+++ b/README.md
@@ -8,28 +8,30 @@ This repository has the following CAM-Nor branches:
 
 * **cam_cesm2_1_rel_05-Nor** - contains the CAM6-Nor code, based on CESM2.1 CAM code. Contains aerotab and further changes as described by [Seland et al. 2020](https://gmd.copernicus.org/articles/13/6165/2020/), with tags
 
-  - cam_cesm2_1_rel_05-Nor_v1.0.0 -- CAM6-Nor version (NorESM tag [release-noresm2.0.1](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-1)), initial preliminary release of CMIP6 version, 18 March 2020
+    - cam_cesm2_1_rel_05-Nor_v1.0.0 -- CAM6-Nor version (NorESM tag [release-noresm2.0.1](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-1)), 18 March 2020
+        - initial preliminary release of CMIP6 version
+    - cam_cesm2_1_rel_05-Nor_v1.0.1 -- CAM6-Nor version, not used in a NorESM tag, 11 May 2020
+    - cam_cesm2_1_rel_05-Nor_v1.0.2 -- CAM6-Nor version (NorESM tag [release-noresm2.0.2](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-2)), 17 July 2020
+        - CMIP6 bit-identical version (if used on fram, and as MM)
+    - cam_cesm2_1_rel_05-Nor_v1.0.3 -- CAM6-Nor version (NorESM tag [release-noresm2.0.3](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-3)), 1 April 2021
+        - automatic download of AeroTab files for PTAERO compsets
+    - cam_cesm2_1_rel_05-Nor_v1.0.4 -- CAM6-Nor version (NorESM tag [release-noresm2.0.4](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-4)), 8 May 2021
+        - allow configuration of coupled N2000_CAM6%NORESM compsets
+        - fix Fortran logic error in MG microphysics that could sometimes cause the model to crash
+    - cam_cesm2_1_rel_05-Nor_v1.0.5 -- CAM6-Nor version (NorESM tags [release-noresm2.0.5](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-5) and [release-noresm2.0.6](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-6)), 9 December 2022
+        - add SSP5-3.4 and emission driven SSP compsets
+        - technical (non answer-changing) modifications in CAM-Nor : correction in CCN (ndrop.F90) and COSP (cosp_optics.F90) diagnostics
+        - correction in H2O emission file link for f09 for the extended (year 2100-2300) SSP1-2.6 and SSP5-8.5 compsets
 
-  - cam_cesm2_1_rel_05-Nor_v1.0.1 -- CAM6-Nor version, not used in a NorESM tag, 11 May 2020
-
-  - cam_cesm2_1_rel_05-Nor_v1.0.2 -- CAM6-Nor version (NorESM tag [release-noresm2.0.2](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-2)), CMIP6 bit-identical version (if used on fram, and as MM), 17 July 2020
-
-  - cam_cesm2_1_rel_05-Nor_v1.0.3 -- CAM6-Nor version (NorESM tag [release-noresm2.0.3](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-3)), automatic download of AeroTab files for PTAERO compsets, 1 April 2021
-
-  - cam_cesm2_1_rel_05-Nor_v1.0.4 -- CAM6-Nor version (NorESM tag [release-noresm2.0.4](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-4)), allow configuration of coupled N2000_CAM6%NORESM compsets, 8 May 2021
-
-  - cam_cesm2_1_rel_05-Nor_v1.0.5 -- CAM6-Nor version (NorESM tags [release-noresm2.0.5](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-5) and [release-noresm2.0.6](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-6)), add SSP5-3.4 and emission driven SSP compsets, 9 December 2022
-
-* **cam_cesm2_1_rel_05-Nor-SpAer** - based on cam_cesm2_1_rel_05-Nor, about to contain simple plume aerosol model code
-
-* **cam_cesm2_1_rel_05-Nor_v1.0.2_keyClim-withoutanthraer** - based on cam_cesm2_1_rel_05-Nor (branched off at tag cam_cesm2_1_rel_05-Nor_v1.0.2) : related to version used in project KeyClim for simulation without anthropogenic aerosol (only natural aerosol)
-
-* **cam-Nor-dev** - based on cam_cesm2_1_rel_05-Nor (branched off at tag cam_cesm2_1_rel_05-Nor_v1.0.2) : post-CMIP6 development version of CAM6-Nor (including bugfixes, new developments, answer-changes modifications, ...)
-
-* **feature-hamocc-vsls** - based on cam_cesm2_1_rel_05-Nor (branched off at tag cam_cesm2_1_rel_05-Nor_v1.0.2) : related to version developed in project KeyClim for simulation of Very Short Lived Spiecies (VSLS) in ocean and atmosphere.
-
+* **cam_cesm2_1_rel_05-Nor-SpAer** - based on cam_cesm2_1_rel_05-Nor
+    - about to contain simple plume aerosol model code
+* **cam_cesm2_1_rel_05-Nor_v1.0.2_keyClim-withoutanthraer** - based on cam_cesm2_1_rel_05-Nor (branched off at tag cam_cesm2_1_rel_05-Nor_v1.0.2)
+    - related to version used in project KeyClim for simulation without anthropogenic aerosol (only natural aerosol)
+* **cam-Nor-dev** - based on cam_cesm2_1_rel_05-Nor (branched off at tag cam_cesm2_1_rel_05-Nor_v1.0.2)
+    - post-CMIP6 development version of CAM6-Nor (including bugfixes, new developments, answer-changes modifications, ...)
+* **feature-hamocc-vsls** - based on cam_cesm2_1_rel_05-Nor (branched off at tag cam_cesm2_1_rel_05-Nor_v1.0.2)
+    - related to version developed in project KeyClim for simulation of Very Short Lived Spiecies (VSLS) in ocean and atmosphere.
 * **noresm_develop** - main development branch for future release versions of NorESM
-
 * **main** - contains this README, basic guidelines, and some special GitHub scripts.
 
 ### CAM-Nor and NorESM documentation https://noresm-docs.readthedocs.io/en/noresm2/

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This repository has the following CAM-Nor branches:
 
   - cam_cesm2_1_rel_05-Nor_v1.0.2 -- CAM6-Nor version (NorESM tag [release-noresm2.0.2](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-2)), CMIP6 bit-identical version (if used on fram, and as MM), 17 July 2020
 
-  - cam_cesm2_1_rel_05-Nor_v1.0.3 -- CAM6-Nor version (NorESM tag [release-noresm2.0.3](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-3)), ??, 1 April 2021
+  - cam_cesm2_1_rel_05-Nor_v1.0.3 -- CAM6-Nor version (NorESM tag [release-noresm2.0.3](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-3)), automatic download of AeroTab files for PTAERO compsets, 1 April 2021
 
-  - cam_cesm2_1_rel_05-Nor_v1.0.4 -- CAM6-Nor version (NorESM tag [release-noresm2.0.4](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-4)), ??, 8 May 2021
+  - cam_cesm2_1_rel_05-Nor_v1.0.4 -- CAM6-Nor version (NorESM tag [release-noresm2.0.4](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-4)), allow configuration of coupled N2000_CAM6%NORESM compsets, 8 May 2021
 
-  - cam_cesm2_1_rel_05-Nor_v1.0.5 -- CAM6-Nor version (NorESM tags [release-noresm2.0.5](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-5) and [release-noresm2.0.6](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-6)), ??, 9 December 2022
+  - cam_cesm2_1_rel_05-Nor_v1.0.5 -- CAM6-Nor version (NorESM tags [release-noresm2.0.5](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-5) and [release-noresm2.0.6](https://noresm-docs.readthedocs.io/en/noresm2/access/releases_noresm20.html#noresm2-0-6)), add SSP5-3.4 and emission driven SSP compsets, 9 December 2022
 
 * **cam_cesm2_1_rel_05-Nor-SpAer** - based on cam_cesm2_1_rel_05-Nor, about to contain simple plume aerosol model code
 


### PR DESCRIPTION
Summary: Add descriptions for cam_cesm2_1_rel_05-Nor_v1.0.3, cam_cesm2_1_rel_05-Nor_v1.0.4, and cam_cesm2_1_rel_05-Nor_v1.0.5.

Contributors: gold2718, DirkOlivie

Reviewers: DirkOlivie

Github PR URL: https://github.com/NorESMhub/CAM/pull/87

Purpose of changes:  Missing information in README #86

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

No tests run but new text reviewed.

Issues addressed by this PR: 
Closes #86 