### PR TITLE
cam_noresm2_1_v1.0.0: Address remaining NorESM2.1 issues

### DIFF
--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -100,7 +100,7 @@ def buildcpp(case):
     if "-cosp" in config_opts:
         config_opts += ["-cosp_libdir", os.path.join(exeroot, "atm", "obj", "cosp")]
 
-    print "cam_aerocom is ",cam_aerocom
+    print(f"cam_aerocom is {cam_aerocom}")
     if cam_aerocom:
         config_opts += [" -aerocom"]
 

--- a/cime_config/testdefs/testmods_dirs/cam/aerocom/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/aerocom/user_nl_cam
@@ -2,3 +2,4 @@ mfilt=1,1,1,1,1,1
 ndens=1,1,1,1,1,1
 nhtfrq=9,9,9,9,9,9
 inithist='ENDOFRUN'
+fincl2='ATMEINT:I','qv_pre_PBL:I','ql_pre_PBL:I','qi_pre_PBL:I','uten_PBL:I','vten_PBL:I','qvten_PBL:I','qlten_PBL','qiten_PBL','BC_AcondTend:I','BC_NcondTend:I','BC_AIcondTend:I','BC_AXcondTend:I','BC_NIcondTend:I','OM_AIcondTend:I','OM_NIcondTend:I','SO4_A1condTend:I','SOA_A1condTend:I','SO4_NAcondTend:I','SOA_NAcondTend:I','FSUS_DRF:I'

--- a/cime_config/usermods_dirs/cmip6_noresm/SourceMods/src.cam/preprocessorDefinitions.h
+++ b/cime_config/usermods_dirs/cmip6_noresm/SourceMods/src.cam/preprocessorDefinitions.h
@@ -1,2 +1,0 @@
-#define AEROCOM
-#define AEROFFL

--- a/cime_config/usermods_dirs/cmip6_noresm_fsst_hifreq_xaer/SourceMods/src.cam/preprocessorDefinitions.h
+++ b/cime_config/usermods_dirs/cmip6_noresm_fsst_hifreq_xaer/SourceMods/src.cam/preprocessorDefinitions.h
@@ -1,2 +1,0 @@
-#define AEROCOM
-#define AEROFFL

--- a/cime_config/usermods_dirs/cmip6_noresm_fsst_xaer/SourceMods/src.cam/preprocessorDefinitions.h
+++ b/cime_config/usermods_dirs/cmip6_noresm_fsst_xaer/SourceMods/src.cam/preprocessorDefinitions.h
@@ -1,2 +1,0 @@
-#define AEROCOM
-#define AEROFFL

--- a/src/NorESM/cam_diagnostics.F90
+++ b/src/NorESM/cam_diagnostics.F90
@@ -1363,7 +1363,7 @@ contains
 
     do m = 1, pcnst
       if (cnst_cam_outfld(m)) then
-        call outfld(cnst_name(m), state%q(1,1,m), pcols, lchnk)
+        call outfld(cnst_name(m), state%q(:,:,m), pcols, lchnk)
       end if
     end do
 
@@ -1556,9 +1556,9 @@ contains
     !
     ! Output U, V, T, P and Z at bottom level
     !
-    call outfld ('UBOT    ', state%u(1,pver)  ,  pcols, lchnk)
-    call outfld ('VBOT    ', state%v(1,pver)  ,  pcols, lchnk)
-    call outfld ('ZBOT    ', state%zm(1,pver) , pcols, lchnk)
+    call outfld ('UBOT    ', state%u(:,pver)  ,  pcols, lchnk)
+    call outfld ('VBOT    ', state%v(:,pver)  ,  pcols, lchnk)
+    call outfld ('ZBOT    ', state%zm(:,pver) , pcols, lchnk)
 
     !! Boundary layer atmospheric stability, temperature, water vapor diagnostics
 
@@ -1694,13 +1694,13 @@ contains
     ncol  = state%ncol
     do m=1,pcnst
       if ( cnst_cam_outfld(m) ) then
-        call outfld(cnst_name(m),state%q(1,1,m),pcols ,lchnk )
+        call outfld(cnst_name(m),state%q(:,:,m),pcols ,lchnk )
       end if
     end do
 
     if (co2_transport()) then
       do m = 1,4
-        call outfld(trim(cnst_name(c_i(m)))//'_BOT', state%q(1,pver,c_i(m)), pcols, lchnk)
+        call outfld(trim(cnst_name(c_i(m)))//'_BOT', state%q(:,pver,c_i(m)), pcols, lchnk)
       end do
     end if
 
@@ -1806,7 +1806,7 @@ contains
     !
     ! Output Q at bottom level
     !
-    call outfld ('QBOT    ', state%q(1,pver,1),  pcols, lchnk)
+    call outfld ('QBOT    ', state%q(:,pver,1),  pcols, lchnk)
 
     ! Total energy of the atmospheric column for atmospheric heat storage calculations
 
@@ -1823,7 +1823,7 @@ contains
     do k=2,pver
       ftem(:ncol,1) = ftem(:ncol,1) + ftem(:ncol,k)
     end do
-    call outfld ('ATMEINT   ',ftem(:ncol,1)  ,pcols   ,lchnk     )
+    call outfld ('ATMEINT   ',ftem(:ncol,1)  ,ncol   ,lchnk     )
 
     !! Boundary layer atmospheric stability, temperature, water vapor diagnostics
 
@@ -2148,7 +2148,7 @@ contains
     if (moist_physics) then
       call outfld('SHFLX',    cam_in%shf,       pcols, lchnk)
       call outfld('LHFLX',    cam_in%lhf,       pcols, lchnk)
-      call outfld('QFLX',     cam_in%cflx(1,1), pcols, lchnk)
+      call outfld('QFLX',     cam_in%cflx(:,:), pcols, lchnk)
 
       call outfld('TAUX',     cam_in%wsx,       pcols, lchnk)
       call outfld('TAUY',     cam_in%wsy,       pcols, lchnk)
@@ -2523,16 +2523,16 @@ contains
 !AL
 
     if ( cnst_cam_outfld(       1) ) then
-      call outfld (apcnst(       1), state%q(1,1,       1), pcols, lchnk)
+      call outfld (apcnst(       1), state%q(:,:,       1), pcols, lchnk)
     end if
     if (ixcldliq > 0) then
       if (cnst_cam_outfld(ixcldliq)) then
-        call outfld (apcnst(ixcldliq), state%q(1,1,ixcldliq), pcols, lchnk)
+        call outfld (apcnst(ixcldliq), state%q(:,:,ixcldliq), pcols, lchnk)
       end if
     end if
     if (ixcldice > 0) then
       if ( cnst_cam_outfld(ixcldice) ) then
-        call outfld (apcnst(ixcldice), state%q(1,1,ixcldice), pcols, lchnk)
+        call outfld (apcnst(ixcldice), state%q(:,:,ixcldice), pcols, lchnk)
       end if
     end if
 
@@ -2704,16 +2704,16 @@ contains
     call cnst_get_ind('CLDICE', ixcldice, abort=.false.)
 
     if ( cnst_cam_outfld(       1) ) then
-      call outfld (bpcnst(       1), state%q(1,1,       1), pcols, lchnk)
+      call outfld (bpcnst(       1), state%q(:,:,       1), pcols, lchnk)
     end if
     if (ixcldliq > 0) then
       if (cnst_cam_outfld(ixcldliq)) then
-        call outfld (bpcnst(ixcldliq), state%q(1,1,ixcldliq), pcols, lchnk)
+        call outfld (bpcnst(ixcldliq), state%q(:,:,ixcldliq), pcols, lchnk)
       end if
     end if
     if (ixcldice > 0) then
       if (cnst_cam_outfld(ixcldice)) then
-        call outfld (bpcnst(ixcldice), state%q(1,1,ixcldice), pcols, lchnk)
+        call outfld (bpcnst(ixcldice), state%q(:,:,ixcldice), pcols, lchnk)
       end if
     end if
 

--- a/src/NorESM/micro_mg2_0.F90
+++ b/src/NorESM/micro_mg2_0.F90
@@ -2082,12 +2082,19 @@ subroutine micro_mg_tend ( &
         ! make sure that ni at advanced time step does not exceed
         ! maximum (existing N + source terms*dt), which is possible if mtime < deltat
         ! note that currently mtime = deltat
-        !================================================================
 
-        if (do_cldice .and. nitend(i,k).gt.0._r8.and.ni(i,k)+nitend(i,k)*deltat.gt.nimax(i,k)) then
-          nitncons(i,k) = nitncons(i,k) + nitend(i,k)-max(0._r8,(nimax(i,k)-ni(i,k))/deltat) !AL
+        !================================================================
+        !shofer---
+        if (nnucct(i,k)+nnuccc(i,k)+nnudep(i,k).gt.0._r8) then
+           nimax(i,k) = nimax(i,k)+(nnucct(i,k)+nnuccc(i,k)+nnudep(i,k))*lcldm(i,k)*deltat
+        end if
+
+        if (do_cldice .and. (nitend(i,k) > 0._r8) .and.                    &
+            (ni(i,k) + (nitend(i,k)*deltat) < nimax(i,k))) then
+           nitncons(i,k) = nitncons(i,k) + nitend(i,k) - max(0._r8,(nimax(i,k)-ni(i,k))/deltat)
            nitend(i,k)=max(0._r8,(nimax(i,k)-ni(i,k))/deltat)
         end if
+        !shofer---
 
      end do
 

--- a/src/NorESM/zm_conv_intr.F90
+++ b/src/NorESM/zm_conv_intr.F90
@@ -8,7 +8,7 @@ module zm_conv_intr
 ! January 2010 modified by J. Kay to add COSP simulator fields to physics buffer
 !---------------------------------------------------------------------------------
    use shr_kind_mod, only: r8=>shr_kind_r8
-   use physconst,    only: cpair                              
+   use physconst,    only: cpair
    use ppgrid,       only: pver, pcols, pverp, begchunk, endchunk
    use zm_conv,      only: zm_conv_evap, zm_convr, convtran, momtran
    use zm_microphysics,  only: zm_aero_t, zm_conv_t
@@ -21,7 +21,7 @@ module zm_conv_intr
    use perf_mod
    use cam_logfile,  only: iulog
    use constituents, only: cnst_add
-   
+
    implicit none
    private
    save
@@ -67,19 +67,19 @@ module zm_conv_intr
    real(r8) :: zmconv_ke_lnd = unset_r8
    real(r8) :: zmconv_momcu  = unset_r8
    real(r8) :: zmconv_momcd  = unset_r8
-   integer  :: zmconv_num_cin            ! Number of negative buoyancy regions that are allowed 
+   integer  :: zmconv_num_cin            ! Number of negative buoyancy regions that are allowed
                                          ! before the convection top and CAPE calculations are completed.
-   logical  :: zmconv_org                ! Parameterization for sub-grid scale convective organization for the ZM deep 
+   logical  :: zmconv_org                ! Parameterization for sub-grid scale convective organization for the ZM deep
                                          ! convective scheme based on Mapes and Neale (2011)
    logical  :: zmconv_microp = .false.             ! switch for microphysics
 
 
 !  indices for fields in the physics buffer
-   integer  ::    cld_idx          = 0    
-   integer  ::    icwmrdp_idx      = 0     
-   integer  ::    rprddp_idx       = 0    
-   integer  ::    fracis_idx       = 0   
-   integer  ::    nevapr_dpcu_idx  = 0    
+   integer  ::    cld_idx          = 0
+   integer  ::    icwmrdp_idx      = 0
+   integer  ::    rprddp_idx       = 0
+   integer  ::    fracis_idx       = 0
+   integer  ::    nevapr_dpcu_idx  = 0
    integer  ::    dgnum_idx        = 0
 
    integer :: nmodes
@@ -103,38 +103,38 @@ subroutine zm_conv_register
 
   integer idx
 
-   call pbuf_add_field('ZM_MU', 'physpkg', dtype_r8, (/pcols,pver/), zm_mu_idx) 
-   call pbuf_add_field('ZM_EU', 'physpkg', dtype_r8, (/pcols,pver/), zm_eu_idx) 
-   call pbuf_add_field('ZM_DU', 'physpkg', dtype_r8, (/pcols,pver/), zm_du_idx) 
-   call pbuf_add_field('ZM_MD', 'physpkg', dtype_r8, (/pcols,pver/), zm_md_idx) 
-   call pbuf_add_field('ZM_ED', 'physpkg', dtype_r8, (/pcols,pver/), zm_ed_idx) 
+   call pbuf_add_field('ZM_MU', 'physpkg', dtype_r8, (/pcols,pver/), zm_mu_idx)
+   call pbuf_add_field('ZM_EU', 'physpkg', dtype_r8, (/pcols,pver/), zm_eu_idx)
+   call pbuf_add_field('ZM_DU', 'physpkg', dtype_r8, (/pcols,pver/), zm_du_idx)
+   call pbuf_add_field('ZM_MD', 'physpkg', dtype_r8, (/pcols,pver/), zm_md_idx)
+   call pbuf_add_field('ZM_ED', 'physpkg', dtype_r8, (/pcols,pver/), zm_ed_idx)
 
    ! wg layer thickness in mbs (between upper/lower interface).
-   call pbuf_add_field('ZM_DP', 'physpkg', dtype_r8, (/pcols,pver/), zm_dp_idx) 
+   call pbuf_add_field('ZM_DP', 'physpkg', dtype_r8, (/pcols,pver/), zm_dp_idx)
 
    ! wg layer thickness in mbs between lcl and maxi.
-   call pbuf_add_field('ZM_DSUBCLD', 'physpkg', dtype_r8, (/pcols/), zm_dsubcld_idx) 
+   call pbuf_add_field('ZM_DSUBCLD', 'physpkg', dtype_r8, (/pcols/), zm_dsubcld_idx)
 
    ! wg top level index of deep cumulus convection.
-   call pbuf_add_field('ZM_JT', 'physpkg', dtype_i4, (/pcols/), zm_jt_idx) 
+   call pbuf_add_field('ZM_JT', 'physpkg', dtype_i4, (/pcols/), zm_jt_idx)
 
    ! wg gathered values of maxi.
-   call pbuf_add_field('ZM_MAXG', 'physpkg', dtype_i4, (/pcols/), zm_maxg_idx) 
+   call pbuf_add_field('ZM_MAXG', 'physpkg', dtype_i4, (/pcols/), zm_maxg_idx)
 
    ! map gathered points to chunk index
-   call pbuf_add_field('ZM_IDEEP', 'physpkg', dtype_i4, (/pcols/), zm_ideep_idx) 
+   call pbuf_add_field('ZM_IDEEP', 'physpkg', dtype_i4, (/pcols/), zm_ideep_idx)
 
 ! Flux of precipitation from deep convection (kg/m2/s)
-   call pbuf_add_field('DP_FLXPRC','global',dtype_r8,(/pcols,pverp/),dp_flxprc_idx) 
+   call pbuf_add_field('DP_FLXPRC','global',dtype_r8,(/pcols,pverp/),dp_flxprc_idx)
 
-! Flux of snow from deep convection (kg/m2/s) 
-   call pbuf_add_field('DP_FLXSNW','global',dtype_r8,(/pcols,pverp/),dp_flxsnw_idx) 
+! Flux of snow from deep convection (kg/m2/s)
+   call pbuf_add_field('DP_FLXSNW','global',dtype_r8,(/pcols,pverp/),dp_flxsnw_idx)
 
 ! deep gbm cloud liquid water (kg/kg)
-   call pbuf_add_field('DP_CLDLIQ','global',dtype_r8,(/pcols,pver/), dp_cldliq_idx)  
+   call pbuf_add_field('DP_CLDLIQ','global',dtype_r8,(/pcols,pver/), dp_cldliq_idx)
 
-! deep gbm cloud liquid water (kg/kg)    
-   call pbuf_add_field('DP_CLDICE','global',dtype_r8,(/pcols,pver/), dp_cldice_idx)  
+! deep gbm cloud liquid water (kg/kg)
+   call pbuf_add_field('DP_CLDICE','global',dtype_r8,(/pcols,pver/), dp_cldice_idx)
 
    call pbuf_add_field('ICWMRDP',    'physpkg',dtype_r8,(/pcols,pver/),icwmrdp_idx)
    call pbuf_add_field('RPRDDP',     'physpkg',dtype_r8,(/pcols,pver/),rprddp_idx)
@@ -253,7 +253,7 @@ subroutine zm_conv_init(pref_edge)
 
   allocate(aero(begchunk:endchunk))
 
-! 
+!
 ! Register fields with the output buffer
 !
 
@@ -270,13 +270,13 @@ subroutine zm_conv_init(pref_edge)
     call addfld ('FZSNTZM',  (/ 'lev' /),  'A', 'K/s','T tendency - Rain to snow conversion from Zhang convection')
     call addfld ('EVSNTZM',  (/ 'lev' /),  'A', 'K/s','T tendency - Snow to rain prod from Zhang convection')
     call addfld ('EVAPQZM',  (/ 'lev' /),  'A', 'kg/kg/s','Q tendency - Evaporation from Zhang-McFarlane moist convection')
-    
+
     call addfld ('ZMFLXPRC', (/ 'ilev' /), 'A', 'kg/m2/s','Flux of precipitation from ZM convection'       )
     call addfld ('ZMFLXSNW', (/ 'ilev' /), 'A', 'kg/m2/s','Flux of snow from ZM convection'                )
     call addfld ('ZMNTPRPD', (/ 'lev' /) , 'A', 'kg/kg/s','Net precipitation production from ZM convection')
     call addfld ('ZMNTSNPD', (/ 'lev' /) , 'A', 'kg/kg/s','Net snow production from ZM convection'         )
     call addfld ('ZMEIHEAT', (/ 'lev' /) , 'A', 'W/kg'   ,'Heating by ice and evaporation in ZM convection')
-    
+
     call addfld ('CMFMCDZM', (/ 'ilev' /), 'A', 'kg/m2/s','Convection mass flux from ZM deep ')
     call addfld ('PRECCDZM', horiz_only,   'A', 'm/s','Convective precipitation rate from ZM deep')
 
@@ -284,7 +284,7 @@ subroutine zm_conv_init(pref_edge)
     call addfld ('PCONVT',   horiz_only ,  'A', 'Pa'    ,'convection top  pressure')
 
     call addfld ('CAPE',     horiz_only,   'A', 'J/kg', 'Convectively available potential energy')
-    call addfld ('FREQZM',   horiz_only  , 'A', 'fraction', 'Fractional occurance of ZM convection') 
+    call addfld ('FREQZM',   horiz_only  , 'A', 'fraction', 'Fractional occurance of ZM convection')
 
     call addfld ('ZMMTT',    (/ 'lev' /),  'A', 'K/s', 'T tendency - ZM convective momentum transport')
     call addfld ('ZMMTU',    (/ 'lev' /),  'A', 'm/s2', 'U tendency - ZM convective momentum transport')
@@ -348,12 +348,12 @@ subroutine zm_conv_init(pref_edge)
        end do
        if ( limcnv == 0 ) limcnv = plevp
     end if
-    
+
     if (masterproc) then
        write(iulog,*)'ZM_CONV_INIT: Deep convection will be capped at intfc ',limcnv, &
             ' which is ',pref_edge(limcnv),' pascals'
     end if
-        
+
     no_deep_pbl = phys_deepconv_pbl()
     call zm_convi(limcnv,zmconv_c0_lnd, zmconv_c0_ocn, zmconv_ke, zmconv_ke_lnd, &
                   zmconv_momcu, zmconv_momcd, zmconv_num_cin, zmconv_org, &
@@ -373,7 +373,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
      rliq    ,rice    ,ztodt    , &
      jctop   ,jcbot , &
      state   ,ptend_all   ,landfrac,  pbuf)
-  
+
 
    use cam_history,   only: outfld
    use physics_types, only: physics_state, physics_ptend
@@ -398,7 +398,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    real(r8), intent(in) :: ztodt                       ! 2 delta t (model time increment)
    real(r8), intent(in) :: pblh(pcols)                 ! Planetary boundary layer height
    real(r8), intent(in) :: tpert(pcols)                ! Thermal temperature excess
-   real(r8), intent(in) :: landfrac(pcols)             ! RBN - Landfrac 
+   real(r8), intent(in) :: landfrac(pcols)             ! RBN - Landfrac
 
    real(r8), intent(out) :: mcon(pcols,pverp)  ! Convective mass flux--m sub c
    real(r8), intent(out) :: pflx(pcols,pverp)  ! scattered precip flux at each level
@@ -435,7 +435,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
 
    ! physics buffer fields
    real(r8), pointer, dimension(:)   :: prec         ! total precipitation
-   real(r8), pointer, dimension(:)   :: snow         ! snow from ZM convection 
+   real(r8), pointer, dimension(:)   :: snow         ! snow from ZM convection
    real(r8), pointer, dimension(:,:) :: cld
    real(r8), pointer, dimension(:,:) :: ql           ! wg grid slice of cloud liquid water.
    real(r8), pointer, dimension(:,:) :: rprd         ! rain production rate
@@ -452,16 +452,16 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    real(r8), pointer :: lambdadpcu(:,:) ! slope of cloud liquid size distr
    real(r8), pointer :: mudpcu(:,:)     ! width parameter of droplet size distr
 
-   real(r8), pointer :: mu(:,:)    ! (pcols,pver) 
-   real(r8), pointer :: eu(:,:)    ! (pcols,pver) 
-   real(r8), pointer :: du(:,:)    ! (pcols,pver) 
-   real(r8), pointer :: md(:,:)    ! (pcols,pver) 
-   real(r8), pointer :: ed(:,:)    ! (pcols,pver) 
-   real(r8), pointer :: dp(:,:)    ! (pcols,pver) 
-   real(r8), pointer :: dsubcld(:) ! (pcols) 
-   integer,  pointer :: jt(:)      ! (pcols) 
-   integer,  pointer :: maxg(:)    ! (pcols) 
-   integer,  pointer :: ideep(:)   ! (pcols) 
+   real(r8), pointer :: mu(:,:)    ! (pcols,pver)
+   real(r8), pointer :: eu(:,:)    ! (pcols,pver)
+   real(r8), pointer :: du(:,:)    ! (pcols,pver)
+   real(r8), pointer :: md(:,:)    ! (pcols,pver)
+   real(r8), pointer :: ed(:,:)    ! (pcols,pver)
+   real(r8), pointer :: dp(:,:)    ! (pcols,pver)
+   real(r8), pointer :: dsubcld(:) ! (pcols)
+   integer,  pointer :: jt(:)      ! (pcols)
+   integer,  pointer :: maxg(:)    ! (pcols)
+   integer,  pointer :: ideep(:)   ! (pcols)
    integer           :: lengath
 
    real(r8) :: jctop(pcols)  ! o row of top-of-deep-convection indices passed out.
@@ -490,7 +490,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    logical  :: l_windt(2)
    real(r8) :: tfinal1, tfinal2
    integer  :: ii
-   
+
    real(r8),pointer :: zm_org2d(:,:)
    real(r8),pointer :: orgt(:,:), org(:,:)
 
@@ -554,7 +554,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
        conv%dcape(pcols) )
    end if
 
-   ftem = 0._r8   
+   ftem = 0._r8
    mu_out(:,:) = 0._r8
    md_out(:,:) = 0._r8
    wind_tends(:ncol,:pver,:) = 0.0_r8
@@ -637,7 +637,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
 
    if (zmconv_org) then
       allocate(zm_org2d(pcols,pver))
-      org => state%q(:,:,ixorg) 
+      org => state%q(:,:,ixorg)
       orgt => ptend_loc%q(:,:,ixorg)
    endif
 
@@ -645,8 +645,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
                     state%t       ,state%q(:,:,1),      prec    ,jctop   ,jcbot   , &
                     pblh    ,state%zm      ,state%phis    ,state%zi      ,ptend_loc%q(:,:,1)    , &
                     ptend_loc%s    , state%pmid     ,state%pint    ,state%pdel     , &
-!                   .5_r8*ztodt    ,mcon    ,cme     , cape,      &
-                    .5_r8*ztodt    ,mcon    ,cme     , cape, eurt,& !+tht eurt
+                    .5_r8*ztodt    ,mcon    ,cme     , cape, eurt,&
                     tpert   ,dlf     ,pflx    ,zdu     ,rprd    , &
                     mu,      md,      du,      eu,      ed,       &
 !                   dp,      dsubcld, jt,      maxg,    ideep,    &
@@ -656,12 +655,9 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
                     dif, dnlf, dnif,  conv, &
                     aero(lchnk), rice)
 
-!  lengath = count(ideep > 0)
-
    call outfld('CAPE', cape, pcols, lchnk)        ! RBN - CAPE output
 
-  !call outfld('EURT', eurt, pcols, lchnk)        !+tht: entr.rate 2D
-   call outfld('EURT', eurt(1,1), pcols, lchnk)   !+tht: entr.rate 3D 
+   call outfld('EURT', eurt, pcols, lchnk)   !+tht: entr.rate 3D
 
 !
 ! Output fractional occurance of ZM convection
@@ -693,7 +689,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
 
    ftem(:ncol,:pver) = ptend_loc%s(:ncol,:pver)/cpair
    call outfld('ZMDT    ',ftem           ,pcols   ,lchnk   )
-   call outfld('ZMDQ    ',ptend_loc%q(1,1,1) ,pcols   ,lchnk   )
+   call outfld('ZMDQ    ',ptend_loc%q(:,:,1) ,pcols   ,lchnk   )
    call t_stopf ('zm_convr')
 
    call outfld('DIFZM'   ,dif            ,pcols, lchnk)
@@ -718,7 +714,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
   ! add tendency from this process to tendencies from other processes
   call physics_ptend_sum(ptend_loc,ptend_all, ncol)
 
-  ! update physics state type state1 with ptend_loc 
+  ! update physics state type state1 with ptend_loc
   call physics_update(state1, ptend_loc, ztodt)
 
   ! initialize ptend for next process
@@ -752,13 +748,13 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
          prec, snow, ntprprd, ntsnprd , flxprec, flxsnow, conv%sprd)
 
     evapcdp(:ncol,:pver) = ptend_loc%q(:ncol,:pver,1)
-    
+
      if (zmconv_org) then
          ptend_loc%q(:ncol,:pver,ixorg) = min(1._r8,max(0._r8,(50._r8*1000._r8*1000._r8*abs(evapcdp(:ncol,:pver))) &
                                           -(state%q(:ncol,:pver,ixorg)/10800._r8)))
-         ptend_loc%q(:ncol,:pver,ixorg) = (ptend_loc%q(:ncol,:pver,ixorg) - state%q(:ncol,:pver,ixorg))/ztodt 
-     endif    
-    
+         ptend_loc%q(:ncol,:pver,ixorg) = (ptend_loc%q(:ncol,:pver,ixorg) - state%q(:ncol,:pver,ixorg))/ztodt
+     endif
+
 !
 ! Write out variables from zm_conv_evap
 !
@@ -768,7 +764,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
    call outfld('FZSNTZM ',ftem           ,pcols   ,lchnk   )
    ftem(:ncol,:pver) = tend_s_snwevmlt(:ncol,:pver)/cpair
    call outfld('EVSNTZM ',ftem           ,pcols   ,lchnk   )
-   call outfld('EVAPQZM ',ptend_loc%q(1,1,1) ,pcols   ,lchnk   )
+   call outfld('EVAPQZM ',ptend_loc%q(:,:,1) ,pcols   ,lchnk   )
    call outfld('ZMFLXPRC', flxprec, pcols, lchnk)
    call outfld('ZMFLXSNW', flxsnow, pcols, lchnk)
    call outfld('ZMNTPRPD', ntprprd, pcols, lchnk)
@@ -785,7 +781,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
   ! add tendency from this process to tend from other processes here
   call physics_ptend_sum(ptend_loc,ptend_all, ncol)
 
-  ! update physics state type state1 with ptend_loc 
+  ! update physics state type state1 with ptend_loc
   call physics_update(state1, ptend_loc, ztodt)
 
 
@@ -797,7 +793,7 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
 
      winds(:ncol,:pver,1) = state1%u(:ncol,:pver)
      winds(:ncol,:pver,2) = state1%v(:ncol,:pver)
-   
+
      l_windt(1) = .true.
      l_windt(2) = .true.
 
@@ -806,16 +802,16 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
                    l_windt,winds, 2,  mu, md,   &
                    du, eu, ed, dp, dsubcld,  &
                    jt, maxg, ideep, 1, lengath,  &
-                   nstep,  wind_tends, pguall, pgdall, icwu, icwd, ztodt, seten )  
+                   nstep,  wind_tends, pguall, pgdall, icwu, icwd, ztodt, seten )
      call t_stopf ('momtran')
 
      ptend_loc%u(:ncol,:pver) = wind_tends(:ncol,:pver,1)
      ptend_loc%v(:ncol,:pver) = wind_tends(:ncol,:pver,2)
-     ptend_loc%s(:ncol,:pver) = seten(:ncol,:pver)  
+     ptend_loc%s(:ncol,:pver) = seten(:ncol,:pver)
 
      call physics_ptend_sum(ptend_loc,ptend_all, ncol)
 
-     ! update physics state type state1 with ptend_loc 
+     ! update physics state type state1 with ptend_loc
      call physics_update(state1, ptend_loc, ztodt)
 
      ftem(:ncol,:pver) = seten(:ncol,:pver)/cpair
@@ -824,20 +820,20 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
         call outfld('ZM_ORG2D', zm_org2d, pcols, lchnk)
      endif
      call outfld('ZMMTT', ftem             , pcols, lchnk)
-     call outfld('ZMMTU', wind_tends(1,1,1), pcols, lchnk)
-     call outfld('ZMMTV', wind_tends(1,1,2), pcols, lchnk)
-   
+     call outfld('ZMMTU', wind_tends(:,:,1), pcols, lchnk)
+     call outfld('ZMMTV', wind_tends(:,:,2), pcols, lchnk)
+
      ! Output apparent force from  pressure gradient
-     call outfld('ZMUPGU', pguall(1,1,1), pcols, lchnk)
-     call outfld('ZMUPGD', pgdall(1,1,1), pcols, lchnk)
-     call outfld('ZMVPGU', pguall(1,1,2), pcols, lchnk)
-     call outfld('ZMVPGD', pgdall(1,1,2), pcols, lchnk)
+     call outfld('ZMUPGU', pguall(:,:,1), pcols, lchnk)
+     call outfld('ZMUPGD', pgdall(:,:,1), pcols, lchnk)
+     call outfld('ZMVPGU', pguall(:,:,2), pcols, lchnk)
+     call outfld('ZMVPGD', pgdall(:,:,2), pcols, lchnk)
 
      ! Output in-cloud winds
-     call outfld('ZMICUU', icwu(1,1,1), pcols, lchnk)
-     call outfld('ZMICUD', icwd(1,1,1), pcols, lchnk)
-     call outfld('ZMICVU', icwu(1,1,2), pcols, lchnk)
-     call outfld('ZMICVD', icwd(1,1,2), pcols, lchnk)
+     call outfld('ZMICUU', icwu(:,:,1), pcols, lchnk)
+     call outfld('ZMICUD', icwd(:,:,1), pcols, lchnk)
+     call outfld('ZMICVU', icwu(:,:,2), pcols, lchnk)
+     call outfld('ZMICVD', icwd(:,:,2), pcols, lchnk)
 
    end if
 
@@ -862,8 +858,8 @@ subroutine zm_conv_tend(pblh    ,mcon    ,cme     , &
                   nstep,   fracis,  ptend_loc%q, fake_dpdry, ztodt)
    call t_stopf ('convtran1')
 
-   call outfld('ZMDICE ',ptend_loc%q(1,1,ixcldice) ,pcols   ,lchnk   )
-   call outfld('ZMDLIQ ',ptend_loc%q(1,1,ixcldliq) ,pcols   ,lchnk   )
+   call outfld('ZMDICE ',ptend_loc%q(:,:,ixcldice) ,pcols   ,lchnk   )
+   call outfld('ZMDLIQ ',ptend_loc%q(:,:,ixcldliq) ,pcols   ,lchnk   )
 
    ! add tendency from this process to tend from other processes here
    call physics_ptend_sum(ptend_loc,ptend_all, ncol)
@@ -941,11 +937,11 @@ subroutine zm_conv_tend_2( state,  ptend,  ztodt, pbuf)
    use time_manager,  only: get_nstep
    use physics_buffer, only: pbuf_get_index, pbuf_get_field, physics_buffer_desc
    use constituents,   only: pcnst, cnst_is_convtran2
- 
+
 ! Arguments
    type(physics_state), intent(in )   :: state          ! Physics state variables
    type(physics_ptend), intent(out)   :: ptend          ! indivdual parameterization tendencies
-   
+
    type(physics_buffer_desc), pointer :: pbuf(:)
 
    real(r8), intent(in) :: ztodt                          ! 2 delta t (model time increment)
@@ -957,18 +953,18 @@ subroutine zm_conv_tend_2( state,  ptend,  ztodt, pbuf)
 
    real(r8), dimension(pcols,pver) :: dpdry
 
-   ! physics buffer fields 
+   ! physics buffer fields
    real(r8), pointer :: fracis(:,:,:)  ! fraction of transported species that are insoluble
-   real(r8), pointer :: mu(:,:)    ! (pcols,pver) 
-   real(r8), pointer :: eu(:,:)    ! (pcols,pver) 
-   real(r8), pointer :: du(:,:)    ! (pcols,pver) 
-   real(r8), pointer :: md(:,:)    ! (pcols,pver) 
-   real(r8), pointer :: ed(:,:)    ! (pcols,pver) 
-   real(r8), pointer :: dp(:,:)    ! (pcols,pver) 
-   real(r8), pointer :: dsubcld(:) ! (pcols) 
-   integer,  pointer :: jt(:)      ! (pcols) 
-   integer,  pointer :: maxg(:)    ! (pcols) 
-   integer,  pointer :: ideep(:)   ! (pcols) 
+   real(r8), pointer :: mu(:,:)    ! (pcols,pver)
+   real(r8), pointer :: eu(:,:)    ! (pcols,pver)
+   real(r8), pointer :: du(:,:)    ! (pcols,pver)
+   real(r8), pointer :: md(:,:)    ! (pcols,pver)
+   real(r8), pointer :: ed(:,:)    ! (pcols,pver)
+   real(r8), pointer :: dp(:,:)    ! (pcols,pver)
+   real(r8), pointer :: dsubcld(:) ! (pcols)
+   integer,  pointer :: jt(:)      ! (pcols)
+   integer,  pointer :: maxg(:)    ! (pcols)
+   integer,  pointer :: ideep(:)   ! (pcols)
    !-----------------------------------------------------------------------------------
 
 
@@ -1025,7 +1021,7 @@ subroutine zm_conv_micro_init()
 
   integer :: i
 
-  ! 
+  !
   ! Register fields with the output buffer
   !
     call addfld ('ICIMRDP', (/ 'lev' /), 'A','kg/kg',  'Deep Convection in-cloud ice mixing ratio ')

--- a/src/chemistry/oslo_aero/condtend.F90
+++ b/src/chemistry/oslo_aero/condtend.F90
@@ -40,26 +40,26 @@ contains
    subroutine registerCondensation()
 
       implicit none
-   
+
 
       integer                        :: iDonor
       integer                        :: l_donor
       integer                        :: tracerIndex
       integer                        :: mode_index_donor
 
-      !These are the lifecycle-species which receive mass when  
+      !These are the lifecycle-species which receive mass when
       !the externally mixed modes receive condensate,
-      !e.g. the receiver of l_so4_n mass is the tracer l_so4_na 
+      !e.g. the receiver of l_so4_n mass is the tracer l_so4_na
       lifeCycleReceiver(:) = -99
       lifeCycleReceiver(chemistryIndex(l_bc_n))   = chemistryIndex(l_bc_a)    !create bc int mix from bc in mode 12
-      lifeCycleReceiver(chemistryIndex(l_bc_ni))  = chemistryIndex(l_bc_ai)   !create bc int mix from bc in mode 14 
+      lifeCycleReceiver(chemistryIndex(l_bc_ni))  = chemistryIndex(l_bc_ai)   !create bc int mix from bc in mode 14
       lifeCycleReceiver(chemistryIndex(l_om_ni))  = chemistryIndex(l_om_ai)
       !!create om int mix from om in mode 14
       lifeCycleReceiver(chemistryIndex(l_bc_ax))  = chemistryIndex(l_bc_ai)
-      !!create bc int mix from bc in mode 0. Note Mass is conserved but not number 
+      !!create bc int mix from bc in mode 0. Note Mass is conserved but not number
 
       !Sticking coeffcients for H2SO4 condensation
-      !See table 1 in Kirkevag et al (2013) 
+      !See table 1 in Kirkevag et al (2013)
       !http://www.geosci-model-dev.net/6/207/2013/gmd-6-207-2013.html
       !Note: In NorESM1, sticking coefficients of the externally mixed modes were
       !used for the internally mixed modes in modallapp. In condtend the internally
@@ -82,15 +82,15 @@ contains
 
    subroutine initializeCondensation()
 
-      !condensation coefficients: 
+      !condensation coefficients:
       !Theory: Poling et al, "The properties of gases and liquids"
       !5th edition, eqn 11-4-4
 
-      use cam_history,     only: addfld, add_default, fieldname_len, horiz_only 
+      use cam_history,     only: addfld, add_default, fieldname_len, horiz_only
       implicit none
 
       real(r8), parameter :: aunit = 1.6606e-27_r8  ![kg] Atomic mass unit
-      real(r8), parameter :: boltz = 1.3806e-23_r8   ![J/K/molec] 
+      real(r8), parameter :: boltz = 1.3806e-23_r8   ![J/K/molec]
       real(r8), parameter :: t0 = 273.15_r8         ![K] standard temperature
       real(r8), parameter :: p0 = 101325.0_r8       ! [Pa] Standard pressure
       real(r8), parameter :: radair = 1.73e-10_r8   ![m] Typical air molecule collision radius
@@ -112,7 +112,7 @@ contains
       integer                        :: mode_index_donor  !index for mode
       integer                        :: iMode             !Counter for mode
       integer                        :: tracerIndex       !counter for chem. spec
-     
+
       logical                        :: history_aerosol
       logical                        :: isAlreadyOnList(gas_pcnst)
       integer                        :: cond_vap_idx
@@ -132,51 +132,51 @@ contains
 
       do cond_vap_idx = 1, N_COND_VAP
 
-         rho = rhopart(physicsIndex(cond_vap_map(cond_vap_idx))) !pick up densities from aerosoldef 
+         rho = rhopart(physicsIndex(cond_vap_map(cond_vap_idx))) !pick up densities from aerosoldef
 
          molecularWeight=adv_mass(cond_vap_map(cond_vap_idx))    !pick up molecular weights from mozart
 
          !https://en.wikipedia.org/wiki/Thermal_velocity
-         th(cond_vap_idx) = sqrt(8.0_r8*boltz*t0/(pi*molecularweight*aunit))   ! thermal velocity for H2SO4 in air (m/s) 
+         th(cond_vap_idx) = sqrt(8.0_r8*boltz*t0/(pi*molecularweight*aunit))   ! thermal velocity for H2SO4 in air (m/s)
 
          !Radius of molecul (straight forward assuming spherical)
-         radmol=(3.0_r8*molecularWeight*aunit/(4.0_r8*pi*rho))**aThird    ! molecule radius 
+         radmol=(3.0_r8*molecularWeight*aunit/(4.0_r8*pi*rho))**aThird    ! molecule radius
 
          Mdual=2.0_r8/(1.0_r8/Mair+1.0_r8/molecularWeight) !factor of [1/m_1 + 1_m2]
 
-         !calculating microphysical parameters from equations in Ch. 8 of Seinfeld & Pandis (1998): 
-         mfv(cond_vap_idx)=1.0_r8/(pi*sqrt(1.0_r8+MolecularWeight/Mair)*(radair+radmol)**2*p0/(boltz*t0)) ! mean free path for molec in air (m)  
-         
+         !calculating microphysical parameters from equations in Ch. 8 of Seinfeld & Pandis (1998):
+         mfv(cond_vap_idx)=1.0_r8/(pi*sqrt(1.0_r8+MolecularWeight/Mair)*(radair+radmol)**2*p0/(boltz*t0)) ! mean free path for molec in air (m)
+
          !Solve eqn 11-4.4 in Poling et al
          !(A bit hard to follow units here, but result in the book is in cm2/s)..
          !so scale by "cm2Tom2" to get m2/sec
          diff(cond_vap_idx) = cm2Tom2   &
             *0.00143_r8*t0**1.75_r8     &
-          /((p0/1.0e5_r8)*sqrt(Mdual)   &    
-          *(((Vad(cond_vap_idx))**aThird+(Vadair)**aThird)**2))  
+          /((p0/1.0e5_r8)*sqrt(Mdual)   &
+          *(((Vad(cond_vap_idx))**aThird+(Vadair)**aThird)**2))
 
          !Values used in noresm1:
          !real(r8), parameter :: diff = 9.5e-6    !m2/s  diffusion coefficient (H2SO4)
          !real(r8), parameter :: th   = 243.0_r8  !m/s   thermal velocity (H2SO4)
          !real(r8), parameter :: mfv  = 1.65e-8   !m     mean free path (H2SO4)
 
-         !Check values obtained here (H2SO4 / SOA) 
+         !Check values obtained here (H2SO4 / SOA)
          !write(*,*) 'mfv =   ', mfv(cond_vap_idx)     !2.800830854409093E-008 / 1.633546464678737E-008
          !write(*,*) ' diff = ', diff(cond_vap_idx)    !->  9.360361706957621E-006 / !->  4.185923463242946E-006
          !write(*,*) ' th = ', th                      !->  242.818542922924 / 185.421069430852
       end do
 
       do cond_vap_idx = 1, N_COND_VAP
-         do imode = 0, nmodes         !all modes receive condensation 
+         do imode = 0, nmodes         !all modes receive condensation
             do nsiz = 1, nBinsTab     !aerotab sizes
-            !Correct for non-continuum effects, formula is from 
-            !Chuang and Penner, Tellus, 1995, sticking coeffient from 
+            !Correct for non-continuum effects, formula is from
+            !Chuang and Penner, Tellus, 1995, sticking coeffient from
             !Vignati et al, JGR, 2004
             !fxm: make "diff ==> diff (cond_vap_idx)
-            DiffusionCoefficient(nsiz,imode,cond_vap_idx) = diff(cond_vap_idx)  &    !original diffusion coefficient 
-               /(                                    &       
+            DiffusionCoefficient(nsiz,imode,cond_vap_idx) = diff(cond_vap_idx)  &    !original diffusion coefficient
+               /(                                    &
                   rBinMidPoint(nsiz)/(rBinMidPoint(nsiz)+mfv(cond_vap_idx))  &  !non-continuum correction factor
-                  +4.0_r8*diff(cond_vap_idx)/(stickingCoefficient(imode,cond_vap_idx)*th(cond_vap_idx)*rBinMidPoint(nsiz)) & 
+                  +4.0_r8*diff(cond_vap_idx)/(stickingCoefficient(imode,cond_vap_idx)*th(cond_vap_idx)*rBinMidPoint(nsiz)) &
                  )
             enddo
          end do !receiver modes
@@ -220,7 +220,7 @@ contains
             end if
          end if
       end do
-      !Need to add so4_a1, soa_na, so4_na, soa_a1 also (which are not parts of the donor-receiver stuff) 
+      !Need to add so4_a1, soa_na, so4_na, soa_a1 also (which are not parts of the donor-receiver stuff)
       fieldname_receiver = trim(solsym(chemistryIndex(l_so4_a1)))//"condTend"
       call addfld( fieldname_receiver, horiz_only, 'A', unit, "condensation tendency")
       if(history_aerosol)then
@@ -249,13 +249,13 @@ contains
 
 
    subroutine condtend_sub(lchnk,  q, cond_vap_gasprod, temperature, &
-               pmid, pdel, dt, ncol, pblh,zm,qh20) 
+               pmid, pdel, dt, ncol, pblh,zm,qh20)
 
-! Calculate the sulphate nucleation rate, and condensation rate of 
-! aerosols used for parameterising the transfer of externally mixed 
+! Calculate the sulphate nucleation rate, and condensation rate of
+! aerosols used for parameterising the transfer of externally mixed
 ! aitken mode particles into an internal mixture.
-! Note the parameterisation for conversion of externally mixed particles 
-! used the h2so4 lifetime onto the particles, and not a given 
+! Note the parameterisation for conversion of externally mixed particles
+! used the h2so4 lifetime onto the particles, and not a given
 ! increase in particle radius. Will be improved in future versions of the model
 ! Added input for h2so4 and soa nucleation: soa_lv_gasprod, soa_sv_gasprod, pblh,zm,qh20 (cka)
 
@@ -263,7 +263,7 @@ contains
 !nuctst3+   use koagsub,         only: normalizedCoagulationSink,receiverMode,numberOfCoagulationReceivers ! h2so4 and soa nucleation(cka)
 !   use koagsub,         only: normCoagSinkMode1,normalizedCoagulationSink,receiverMode,numberOfCoagulationReceivers ! h2so4 and soa nucleation(cka)
 !nuctst3-
-!ak+ 
+!ak+
     use koagsub,         only: normalizedCoagulationSink,receiverMode,numberOfCoagulationReceivers, &
                                numberOfAddCoagReceivers,addReceiverMode,normCoagSinkAdd
 !ak-
@@ -305,36 +305,36 @@ contains
 
    real(r8) :: intermediateConcentration(pcols,pver,N_COND_VAP)
    real(r8) :: rhoAir(pcols,pver)                           ![kg/m3] density of air
-! Volume of added  material from condensate;  surface area of core particle; 
-   real(r8) :: volume_shell, area_core,vol_monolayer 
-   real (r8) :: frac_transfer                   ! Fraction of hydrophobic material converted to an internally mixed mode 
+! Volume of added  material from condensate;  surface area of core particle;
+   real(r8) :: volume_shell, area_core,vol_monolayer
+   real (r8) :: frac_transfer                   ! Fraction of hydrophobic material converted to an internally mixed mode
    logical  :: history_aerosol
    character(128)                 :: long_name                              ![-] needed for diagnostics
 
-!cka:+   
+!cka:+
    ! needed for h2so4 and soa nucleation treatment
    integer  :: modeIndexReceiverCoag             !Index of modes receiving coagulate
    integer  :: iCoagReceiver                     !counter for species receiving coagulate
-   real(r8) :: coagulationSink(pcols,pver)       ![1/s] coaglation loss for SO4_n and soa_n   
+   real(r8) :: coagulationSink(pcols,pver)       ![1/s] coaglation loss for SO4_n and soa_n
 !nuctst3+
 !   real(r8) :: normCSmode1(pcols,pver)           !normalized coagulation from self coagulation (simplified)
 !nuctst3-
-   real(r8), parameter :: lvocfrac=0.5           !Fraction of organic oxidation products with low enough 
+   real(r8), parameter :: lvocfrac=0.5           !Fraction of organic oxidation products with low enough
                                                   !volatility to enter nucleation mode particles (1-24 nm)
    real(r8) :: soa_lv_forNucleation(pcols,pver)  ![kg/kg] soa gas available for nucleation
-   real(r8) :: gasLost(pcols,pver,N_COND_VAP)          ![kg/kg] budget terms on H2SO4 (gas) 
+   real(r8) :: gasLost(pcols,pver,N_COND_VAP)          ![kg/kg] budget terms on H2SO4 (gas)
    real(r8) :: fracNucl(pcols,pver,N_COND_VAP)               ! [frc] fraction of gas nucleated
-   real(r8) :: firstOrderLossRateNucl(pcols,pver,N_COND_VAP) ![1/s] first order loss rate due to nucleation 
-   real(r8) :: nuclso4(pcols,pver)               ![kg/kg/s] Nucleated so4 mass tendency from RM's parameterization 
-   real(r8) :: nuclsoa(pcols,pver)               ![kg/kg/s] Nucleated soa mass tendency from RM's parameterization 
+   real(r8) :: firstOrderLossRateNucl(pcols,pver,N_COND_VAP) ![1/s] first order loss rate due to nucleation
+   real(r8) :: nuclso4(pcols,pver)               ![kg/kg/s] Nucleated so4 mass tendency from RM's parameterization
+   real(r8) :: nuclsoa(pcols,pver)               ![kg/kg/s] Nucleated soa mass tendency from RM's parameterization
    integer  :: cond_vap_idx
-   
+
     !Initialize h2so4 and soa nucl variables
-    coagulationSink(:,:)=0.0_r8             
+    coagulationSink(:,:)=0.0_r8
     condensationSinkFraction(:,:,:,:) = 0.0_r8  !Sink to the coming "receiver" of any vapour
     numberConcentrationExtMix(:,:,:) = 0.0_r8
 !ak+
-!    normCSmode1(:,:)=0.0_r8 
+!    normCSmode1(:,:)=0.0_r8
 !ak-
 
     do k=1,pver
@@ -363,7 +363,7 @@ contains
                !Add up the number concentration of the receiving mode [#/m3]
                numberConcentration(mode_index_receiver) = numberConcentration(mode_index_receiver) &  !previous value
                                              + q(i,k,l_receiver)                   &  !kg/kg
-                                             / rhopart(physicsIndex(l_receiver))   &  !m3/kg ==> m3_{aer}/kg_{air} 
+                                             / rhopart(physicsIndex(l_receiver))   &  !m3/kg ==> m3_{aer}/kg_{air}
                                              * volumeToNumber(mode_index_receiver) &  !#/m3 ==> #/kg_{air}
                                              * rhoAir(i,k)                                 !kg/m3 ==> #/m3_{air}
             end do !Lifecycle "core" species in this mode
@@ -374,7 +374,7 @@ contains
          do cond_vap_idx=1,N_COND_VAP
             do mode_index_receiver = 0, nmodes
 
-               !This is the loss rate a gas molecule will see due to aerosol surface area 
+               !This is the loss rate a gas molecule will see due to aerosol surface area
                condensationSink(mode_index_receiver,cond_vap_idx)   = normalizedCondensationSink(mode_index_receiver,cond_vap_idx)  & ![m3/#/s]
                                                    * numberConcentration(mode_index_receiver)             ![#/m3]
                                                    !==> [1/s]
@@ -390,10 +390,10 @@ contains
 
 
             !Solve the intermediate (end of timestep) concentration using
-            !euler backward solution C_{old} + P *dt - L*C_{new}*dt = C_{new} ==> 
+            !euler backward solution C_{old} + P *dt - L*C_{new}*dt = C_{new} ==>
             !Cnew -Cold = prod - loss ==>
             intermediateConcentration(i,k,cond_vap_idx) = &
-                                 ( q(i,k,cond_vap_map(cond_vap_idx)) + cond_vap_gasprod(i,k,cond_vap_idx)*dt ) & 
+                                 ( q(i,k,cond_vap_map(cond_vap_idx)) + cond_vap_gasprod(i,k,cond_vap_idx)*dt ) &
                                  / (1.0_r8 + sumCondensationSink(i,k,cond_vap_idx)*dt)
          end do
 
@@ -401,12 +401,12 @@ contains
          !(Needed below to find volume shell)
          do cond_vap_idx=1,N_COND_VAP
 
-            do iDonor = 1,numberOfExternallyMixedModes 
+            do iDonor = 1,numberOfExternallyMixedModes
             !Find the mode in question
-            mode_index_donor    = externallyMixedMode(iDonor) 
+            mode_index_donor    = externallyMixedMode(iDonor)
 
                !Remember fraction of cond sink for this mode
-               condensationSinkFraction(i,k,iDonor,cond_vap_idx) = & 
+               condensationSinkFraction(i,k,iDonor,cond_vap_idx) = &
                   condensationSink(mode_index_donor,cond_vap_idx)    &
                    / sumCondensationSink(i,k,cond_vap_idx)
 
@@ -429,8 +429,8 @@ contains
 
             coagulationSink(i,k) =   &                                                ![1/s]
                coagulationSink(i,k) + &                                               ![1/] previous value
-               normalizedCoagulationSink(modeIndexReceiverCoag,MODE_IDX_SO4SOA_AIT) & ![m3/#/s] 
-                              * numberConcentration(modeIndexReceiverCoag)            !numberConcentration (#/m3) 
+               normalizedCoagulationSink(modeIndexReceiverCoag,MODE_IDX_SO4SOA_AIT) & ![m3/#/s]
+                              * numberConcentration(modeIndexReceiverCoag)            !numberConcentration (#/m3)
          end do    !coagulation sink
 
 !nuctst3+
@@ -441,15 +441,15 @@ contains
 !nuctst3-
 !ak+
          !Sum coagulation sink for nucleated so4 and soa particles over all additional
-         !receivers od coagulate (not directly affecting the life-cycle). 
+         !receivers od coagulate (not directly affecting the life-cycle).
          do iCoagReceiver = 1, numberOfAddCoagReceivers
 
             modeIndexReceiverCoag = addReceiverMode(iCoagReceiver)
 
             coagulationSink(i,k) =   &                                                ![1/s]
                coagulationSink(i,k) + &                                               ![1/] previous value
-               normCoagSinkAdd(iCoagReceiver) & ![m3/#/s] 
-                              * numberConcentration(modeIndexReceiverCoag)            !numberConcentration (#/m3) 
+               normCoagSinkAdd(iCoagReceiver) & ![m3/#/s]
+                              * numberConcentration(modeIndexReceiverCoag)            !numberConcentration (#/m3)
          end do    !coagulation sink
 !ak-
 
@@ -477,7 +477,7 @@ contains
             !Solve implicitly (again)
             !C_new - C_old =  PROD_{gas} - CS*C_new*dt - LR_{nucl}*C_new =>
             intermediateConcentration(i,k,cond_vap_idx) = &
-                           ( q(i,k,cond_vap_map(cond_vap_idx)) + cond_vap_gasprod(i,k,cond_vap_idx)*dt ) & 
+                           ( q(i,k,cond_vap_map(cond_vap_idx)) + cond_vap_gasprod(i,k,cond_vap_idx)*dt ) &
                            / (1.0_r8 + sumCondensationSink(i,k,cond_vap_idx)*dt + firstOrderLossRateNucl(i,k,cond_vap_idx)*dt)
 
             !fraction nucleated
@@ -489,35 +489,35 @@ contains
                                  - intermediateConcentration(i,k,cond_vap_idx)    !cnew
 
          end do !cond_vap_idx
-         
+
          !Add nuceated mass to so4_na mode
          q(i,k,chemistryIndex(l_so4_na)) =  q(i,k,chemistryIndex(l_so4_na))       &
                      + gasLost(i,k,COND_VAP_H2SO4)*fracNucl(i,k,COND_VAP_H2SO4)
 
          !H2SO4 condensate
-         q(i,k,chemistryIndex(l_so4_a1)) = q(i,k,chemistryIndex(l_so4_a1))         & 
-                        + gasLost(i,k,COND_VAP_H2SO4)*(1.0_r8-fracNucl(i,k,COND_VAP_H2SO4))   
+         q(i,k,chemistryIndex(l_so4_a1)) = q(i,k,chemistryIndex(l_so4_a1))         &
+                        + gasLost(i,k,COND_VAP_H2SO4)*(1.0_r8-fracNucl(i,k,COND_VAP_H2SO4))
 
          !Add nucleated mass to soa_na mode
          q(i,k,chemistryIndex(l_soa_na)) =  q(i,k,chemistryIndex(l_soa_na))       &
                      + gasLost(i,k,COND_VAP_ORG_LV)*fracNucl(i,k,COND_VAP_ORG_LV)
 
          !Organic condensate (from both soa_lv and soa_sv) goes to the soaCondensateReceiver tracer (cka)
-         q(i,k,chemistryIndex(l_soa_a1)) = q(i,k,chemistryIndex(l_soa_a1))         & 
-                        + gasLost(i,k,COND_VAP_ORG_SV)                             &           ! "semi volatile" can not nucleate 
+         q(i,k,chemistryIndex(l_soa_a1)) = q(i,k,chemistryIndex(l_soa_a1))         &
+                        + gasLost(i,k,COND_VAP_ORG_SV)                             &           ! "semi volatile" can not nucleate
                         + gasLost(i,k,COND_VAP_ORG_LV)*(1.0_r8-fracNucl(i,k,COND_VAP_ORG_LV))  ! part of low volatile which does not nucleate
-  
+
          !condenseable vapours
          q(i,k,chemistryIndex(l_h2so4))  = intermediateConcentration(i,k,COND_VAP_H2SO4)
          q(i,k,chemistryIndex(l_soa_lv)) = intermediateConcentration(i,k,COND_VAP_ORG_LV)
          q(i,k,chemistryIndex(l_soa_sv)) = intermediateConcentration(i,k,COND_VAP_ORG_SV)
 
 
-         !Condensation transfers mass from externally mixed to internally mixed modes 
-         do iDonor = 1,numberOfExternallyMixedModes 
+         !Condensation transfers mass from externally mixed to internally mixed modes
+         do iDonor = 1,numberOfExternallyMixedModes
 
             !Find the mode in question
-            mode_index_donor    = externallyMixedMode(iDonor) 
+            mode_index_donor    = externallyMixedMode(iDonor)
 
             if(getNumberOfTracersInMode(mode_index_donor) .eq. 0)then
                cycle
@@ -525,17 +525,17 @@ contains
 
             volume_shell = 0.0_r8
             do cond_vap_idx = 1, N_COND_VAP
-               
-               !Add up volume shell for this 
+
+               !Add up volume shell for this
                !condenseable vapour
-               volume_shell = volume_shell                                               & 
+               volume_shell = volume_shell                                               &
                      + condensationSinkFraction(i,k,iDonor,cond_vap_idx)                 & ![frc]
                      * gasLost(i,k,cond_vap_idx)*(1.0_r8-fracNucl(i,k,cond_vap_idx))     & ![kg/kg]
                      * invRhoPart(physicsIndex(cond_vap_map(cond_vap_idx)))              & !*[m3/kg] ==> [m3/kg_{air}
                      * rhoAir(i,k)                                                         !*[kg/m3] ==> m3/m3
-        
+
             end do
-                           
+
             area_core=numberConcentrationExtMix(i,k,iDonor)*numberToSurface(mode_index_donor)   !#/m3 * m2/# ==> m2/m3
             vol_monolayer=area_core*dr_so4_monolayers_age
 
@@ -550,34 +550,34 @@ contains
 
                !Indexes here are in "chemistry space"
                l_donor    = getTracerIndex(mode_index_donor, tracerIndex,.true.)
-               l_receiver = lifeCycleReceiver(l_donor) 
+               l_receiver = lifeCycleReceiver(l_donor)
 
                if( l_receiver .le. 0)then
                   stop !something wrong
                endif
 
-               !Transfer from donor to receiver takes into account 
+               !Transfer from donor to receiver takes into account
                !fraction transferred
                totalLoss(i,k,l_donor) = frac_transfer*q(i,k,l_donor)
                q(i,k,l_donor) = q(i,k,l_donor) - totalLoss(i,k,l_donor)
                q(i,k,l_receiver) = q(i,k,l_receiver) + totalLoss(i,k,l_donor)
             end do !tracers in mode
          end do    !loop over receivers
-      end do !physical index k 
+      end do !physical index k
    end do    !physical index i
 
    !Output for diagnostics
    call phys_getopts(history_aerosol_out = history_aerosol)
- 
+
    if(history_aerosol)then
       coltend(:ncol,:) = 0.0_r8
-      do i=1,gas_pcnst 
+      do i=1,gas_pcnst
          !Check if species contributes to condensation
          if(lifeCycleReceiver(i) .gt. 0)then
            !Loss from the donor specie
            tracer_coltend(:ncol) = sum(totalLoss(:ncol, :,i)*pdel(:ncol,:),2)/gravit/dt
            coltend(:ncol,i) = coltend(:ncol,i) - tracer_coltend(:ncol) !negative (loss for donor)
-           coltend(:ncol,lifeCycleReceiver(i)) = coltend(:ncol,lifeCycleReceiver(i)) + tracer_coltend(:ncol) 
+           coltend(:ncol,lifeCycleReceiver(i)) = coltend(:ncol,lifeCycleReceiver(i)) + tracer_coltend(:ncol)
          endif
       end do
 
@@ -595,7 +595,7 @@ contains
                                                 *(1.0_r8 - fracNucl(:ncol,:,COND_VAP_H2SO4))*pdel(:ncol,:) , 2 &
                                                 )/gravit/dt
 
-      !Take into account soa_lv (gas) nucleated in budget 
+      !Take into account soa_lv (gas) nucleated in budget
       coltend(:ncol,chemistryIndex(l_soa_na)) = coltend(:ncol,chemistryIndex(l_soa_na)) + &
                                              sum(                                         &
                                                 gasLost(:ncol,:,COND_VAP_ORG_LV)              &
@@ -608,27 +608,27 @@ contains
                                                 gasLost(:ncol,:,COND_VAP_ORG_LV)           &
                                                 *(1.0_r8 - fracNucl(:ncol,:,COND_VAP_ORG_LV))*pdel(:ncol,:) , 2 &
                                                 )/gravit/dt                        &
-                                                +                                  & 
+                                                +                                  &
                                              sum(                                         &
                                                 gasLost(:ncol,:,COND_VAP_ORG_SV)*pdel(:ncol,:) , 2 &
-                                                )/gravit/dt                        
-                                                
+                                                )/gravit/dt
+
       do i=1,gas_pcnst
          if(lifeCycleReceiver(i) .gt. 0 )then
             long_name= trim(solsym(i))//"condTend"
-            call outfld(long_name, coltend(:ncol,i), pcols, lchnk)
+            call outfld(long_name, coltend(:,i), pcols, lchnk)
             long_name= trim(solsym(lifeCycleReceiver(i)))//"condTend"
-            call outfld(long_name, coltend(:ncol,lifeCycleReceiver(i)),pcols,lchnk)
+            call outfld(long_name, coltend(:,lifeCycleReceiver(i)),pcols,lchnk)
          end if
       end do
       long_name=trim(solsym(chemistryIndex(l_so4_a1)))//"condTend"
-      call outfld(long_name, coltend(:ncol,chemistryIndex(l_so4_a1)),pcols,lchnk)
+      call outfld(long_name, coltend(:,chemistryIndex(l_so4_a1)),pcols,lchnk)
       long_name=trim(solsym(chemistryIndex(l_soa_a1)))//"condTend"
-      call outfld(long_name, coltend(:ncol,chemistryIndex(l_soa_a1)),pcols,lchnk)
+      call outfld(long_name, coltend(:,chemistryIndex(l_soa_a1)),pcols,lchnk)
       long_name=trim(solsym(chemistryIndex(l_so4_na)))//"condTend"
-      call outfld(long_name, coltend(:ncol,chemistryIndex(l_so4_na)),pcols,lchnk)
+      call outfld(long_name, coltend(:,chemistryIndex(l_so4_na)),pcols,lchnk)
       long_name=trim(solsym(chemistryIndex(l_soa_na)))//"condTend"
-      call outfld(long_name, coltend(:ncol,chemistryIndex(l_soa_na)),pcols,lchnk)
+      call outfld(long_name, coltend(:,chemistryIndex(l_soa_na)),pcols,lchnk)
 
    endif
 

--- a/src/chemistry/oslo_aero/ndrop.F90
+++ b/src/chemistry/oslo_aero/ndrop.F90
@@ -2024,7 +2024,7 @@ subroutine dropmixnuc( &
 #endif
    if(history_aerosol) then
    do l = 1, psat
-      call outfld(ccn_name(l), ccn(1,1,l), pcols, lchnk)
+      call outfld(ccn_name(l), ccn(:,:,l), pcols, lchnk)
    enddo
    end if
 #ifndef OSLO_AERO

--- a/src/chemistry/oslo_aero/oslo_aerosols_intr.F90
+++ b/src/chemistry/oslo_aero/oslo_aerosols_intr.F90
@@ -386,7 +386,7 @@ contains
                rad_aer(1:ncol,:top_lev-1) = 0._r8
              end if
              rad_aer(1:ncol,top_lev:) = 0.5_r8*dgncur_awet(1:ncol,top_lev:,m)   &
-                                 *exp(1.5_r8*(logSigma))
+                                 *exp(1.5_r8*(logSigma**2))
 
              ! dens_aer(1:ncol,:) = wet density (kg/m3)
              if(top_lev.gt.1)then
@@ -427,7 +427,7 @@ contains
                   rad_aer(1:ncol, top_lev-1) = 0.0_r8
                 end if
                 rad_aer(1:ncol,top_lev:) = 0.5_r8*dgncur_awet_processmode(1:ncol,top_lev:,processModeMap(mm))   &
-                                 *exp(1.5_r8*(logSigma))
+                                 *exp(1.5_r8*(logSigma**2))
                 call modal_aero_depvel_part( ncol, state%t(:,:), state%pmid(:,:), ram1, fv,  & 
                            vlc_dry(:,:,jvlc), vlc_trb(:,jvlc), vlc_grv(:,:,jvlc),  &
                            rad_aer(:,:), dens_aer(:,:), sg_aer(:,:), 3, lchnk)

--- a/src/physics/cam/cam_diagnostics.F90
+++ b/src/physics/cam/cam_diagnostics.F90
@@ -965,7 +965,7 @@ contains
 
     do m = 1, pcnst
       if (cnst_cam_outfld(m)) then
-        call outfld(cnst_name(m), state%q(1,1,m), pcols, lchnk)
+        call outfld(cnst_name(m), state%q(:,:,m), pcols, lchnk)
       end if
     end do
 
@@ -1145,9 +1145,9 @@ contains
     !
     ! Output U, V, T, P and Z at bottom level
     !
-    call outfld ('UBOT    ', state%u(1,pver)  ,  pcols, lchnk)
-    call outfld ('VBOT    ', state%v(1,pver)  ,  pcols, lchnk)
-    call outfld ('ZBOT    ', state%zm(1,pver) , pcols, lchnk)
+    call outfld ('UBOT    ', state%u(:,pver)  ,  pcols, lchnk)
+    call outfld ('VBOT    ', state%v(:,pver)  ,  pcols, lchnk)
+    call outfld ('ZBOT    ', state%zm(:,pver) , pcols, lchnk)
 
     !! Boundary layer atmospheric stability, temperature, water vapor diagnostics
 
@@ -1284,7 +1284,7 @@ contains
 
     if (co2_transport()) then
       do m = 1,4
-        call outfld(trim(cnst_name(c_i(m)))//'_BOT', state%q(1,pver,c_i(m)), pcols, lchnk)
+        call outfld(trim(cnst_name(c_i(m)))//'_BOT', state%q(:,pver,c_i(m)), pcols, lchnk)
       end do
     end if
 
@@ -1379,7 +1379,7 @@ contains
     !
     ! Output Q at bottom level
     !
-    call outfld ('QBOT    ', state%q(1,pver,1),  pcols, lchnk)
+    call outfld ('QBOT    ', state%q(:,pver,1),  pcols, lchnk)
 
     ! Total energy of the atmospheric column for atmospheric heat storage calculations
 
@@ -1396,7 +1396,7 @@ contains
     do k=2,pver
       ftem(:ncol,1) = ftem(:ncol,1) + ftem(:ncol,k)
     end do
-    call outfld ('ATMEINT   ',ftem(:ncol,1)  ,pcols   ,lchnk     )
+    call outfld ('ATMEINT   ',ftem(:,1)  ,pcols   ,lchnk     )
 
     !! Boundary layer atmospheric stability, temperature, water vapor diagnostics
 
@@ -1419,11 +1419,11 @@ contains
          hist_fld_active('THE9251000') .or. &
          hist_fld_active('THE8501000') .or. &
          hist_fld_active('THE7001000')) then
-      call vertinterp(ncol, pcols, pver, state%pmid, 100000._r8, state%q(1,1,1), p_surf_q1)
+      call vertinterp(ncol, pcols, pver, state%pmid, 100000._r8, state%q(:,:,1), p_surf_q1)
     end if
 
     if (hist_fld_active('THE9251000')) then
-      call vertinterp(ncol, pcols, pver, state%pmid, 92500._r8, state%q(1,1,1), p_surf_q2)
+      call vertinterp(ncol, pcols, pver, state%pmid, 92500._r8, state%q(:,:,1), p_surf_q2)
     end if
 
 !!! at 1000 mb and 925 mb
@@ -1450,7 +1450,7 @@ contains
 
 !!! at 1000 mb and 850 mb
     if (hist_fld_active('THE8501000')) then
-      call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, state%q(1,1,1), p_surf_q2)
+      call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, state%q(:,:,1), p_surf_q2)
       p_surf = ((p_surf_t(:, surf_085000)*(1000.0_r8/850.0_r8)**cappa) *              &
                 exp((2500000.0_r8*p_surf_q2)/(1004.0_r8*p_surf_t(:, surf_085000)))) - &
                 (p_surf_t(:,surf_100000)*(1.0_r8)**cappa)*exp((2500000.0_r8*p_surf_q1)/(1004.0_r8*p_surf_t(:,surf_100000)))
@@ -1465,7 +1465,7 @@ contains
 
 !!! at 1000 mb and 700 mb
     if (hist_fld_active('THE7001000')) then
-      call vertinterp(ncol, pcols, pver, state%pmid, 70000._r8, state%q(1,1,1), p_surf_q2)
+      call vertinterp(ncol, pcols, pver, state%pmid, 70000._r8, state%q(:,:,1), p_surf_q2)
       p_surf = ((p_surf_t(:, surf_070000)*(1000.0_r8/700.0_r8)**cappa) *              &
                 exp((2500000.0_r8*p_surf_q2)/(1004.0_r8*p_surf_t(:, surf_070000)))) - &
                 (p_surf_t(:,surf_100000)*(1.0_r8)**cappa)*exp((2500000.0_r8*p_surf_q1)/(1004.0_r8*p_surf_t(:,surf_100000)))
@@ -1721,7 +1721,7 @@ contains
     if (moist_physics) then
       call outfld('SHFLX',    cam_in%shf,       pcols, lchnk)
       call outfld('LHFLX',    cam_in%lhf,       pcols, lchnk)
-      call outfld('QFLX',     cam_in%cflx(1,1), pcols, lchnk)
+      call outfld('QFLX',     cam_in%cflx(:,:), pcols, lchnk)
 
       call outfld('TAUX',     cam_in%wsx,       pcols, lchnk)
       call outfld('TAUY',     cam_in%wsy,       pcols, lchnk)
@@ -2089,16 +2089,16 @@ contains
     call cnst_get_ind('CLDICE', ixcldice, abort=.false.)
 
     if ( cnst_cam_outfld(       1) ) then
-      call outfld (apcnst(       1), state%q(1,1,       1), pcols, lchnk)
+      call outfld (apcnst(       1), state%q(:,:,       1), pcols, lchnk)
     end if
     if (ixcldliq > 0) then
       if (cnst_cam_outfld(ixcldliq)) then
-        call outfld (apcnst(ixcldliq), state%q(1,1,ixcldliq), pcols, lchnk)
+        call outfld (apcnst(ixcldliq), state%q(:,:,ixcldliq), pcols, lchnk)
       end if
     end if
     if (ixcldice > 0) then
       if ( cnst_cam_outfld(ixcldice) ) then
-        call outfld (apcnst(ixcldice), state%q(1,1,ixcldice), pcols, lchnk)
+        call outfld (apcnst(ixcldice), state%q(:,:,ixcldice), pcols, lchnk)
       end if
     end if
 
@@ -2242,16 +2242,16 @@ contains
     call cnst_get_ind('CLDICE', ixcldice, abort=.false.)
 
     if ( cnst_cam_outfld(       1) ) then
-      call outfld (bpcnst(       1), state%q(1,1,       1), pcols, lchnk)
+      call outfld (bpcnst(       1), state%q(:,:,       1), pcols, lchnk)
     end if
     if (ixcldliq > 0) then
       if (cnst_cam_outfld(ixcldliq)) then
-        call outfld (bpcnst(ixcldliq), state%q(1,1,ixcldliq), pcols, lchnk)
+        call outfld (bpcnst(ixcldliq), state%q(:,:,ixcldliq), pcols, lchnk)
       end if
     end if
     if (ixcldice > 0) then
       if (cnst_cam_outfld(ixcldice)) then
-        call outfld (bpcnst(ixcldice), state%q(1,1,ixcldice), pcols, lchnk)
+        call outfld (bpcnst(ixcldice), state%q(:,:,ixcldice), pcols, lchnk)
       end if
     end if
 

--- a/src/physics/cam/convect_shallow.F90
+++ b/src/physics/cam/convect_shallow.F90
@@ -19,19 +19,19 @@
    use phys_control,      only : phys_getopts
 
    implicit none
-   private                 
+   private
    save
 
    public :: &
              convect_shallow_register,       & ! Register fields in physics buffer
              convect_shallow_init,           & ! Initialize shallow module
              convect_shallow_tend,           & ! Return tendencies
-             convect_shallow_use_shfrc	       ! 
+             convect_shallow_use_shfrc	       !
 
    ! The following namelist variable controls which shallow convection package is used.
    !        'Hack'   = Hack shallow convection (default)
    !        'UW'     = UW shallow convection by Sungsu Park and Christopher S. Bretherton
-   !        'UNICON' = General Convection Model by Sungsu Park  
+   !        'UNICON' = General Convection Model by Sungsu Park
    !        'off'    = No shallow convection
 
    character(len=16) :: shallow_scheme      ! Default set in phys_control.F90, use namelist to change
@@ -40,16 +40,16 @@
    logical           :: history_budget      ! Output tendencies and state variables for CAM4 T, qv, ql, qi
    integer           :: history_budget_histfile_num ! output history file number for budget fields
 
-   ! Physics buffer indices 
-   integer    ::     icwmrsh_idx    = 0  
-   integer    ::      rprdsh_idx    = 0 
-   integer    ::     rprdtot_idx    = 0 
-   integer    ::      cldtop_idx    = 0 
-   integer    ::      cldbot_idx    = 0 
-   integer    ::        cush_idx    = 0 
+   ! Physics buffer indices
+   integer    ::     icwmrsh_idx    = 0
+   integer    ::      rprdsh_idx    = 0
+   integer    ::     rprdtot_idx    = 0
+   integer    ::      cldtop_idx    = 0
+   integer    ::      cldbot_idx    = 0
+   integer    ::        cush_idx    = 0
    integer    :: nevapr_shcu_idx    = 0
-   integer    ::       shfrc_idx    = 0 
-   integer    ::         cld_idx    = 0 
+   integer    ::       shfrc_idx    = 0
+   integer    ::         cld_idx    = 0
    integer    ::      concld_idx    = 0
    integer    ::      rprddp_idx    = 0
    integer    ::         tke_idx    = 0
@@ -84,9 +84,9 @@
   use physics_buffer, only : pbuf_add_field, dtype_r8, dyn_time_lvls
   use phys_control, only: use_gw_convect_sh
   use unicon_cam,     only: unicon_cam_register
-  
+
   call phys_getopts( shallow_scheme_out = shallow_scheme, microp_scheme_out = microp_scheme)
-                     
+
   ! SPCAM registers its own fields
   if (shallow_scheme == 'SPCAM') return
 
@@ -95,7 +95,7 @@
   call pbuf_add_field('RPRDTOT',    'physpkg' ,dtype_r8,(/pcols,pver/),       rprdtot_idx )
   call pbuf_add_field('CLDTOP',     'physpkg' ,dtype_r8,(/pcols,1/),          cldtop_idx )
   call pbuf_add_field('CLDBOT',     'physpkg' ,dtype_r8,(/pcols,1/),          cldbot_idx )
-  call pbuf_add_field('cush',       'global'  ,dtype_r8,(/pcols,dyn_time_lvls/), cush_idx ) 	
+  call pbuf_add_field('cush',       'global'  ,dtype_r8,(/pcols,dyn_time_lvls/), cush_idx )
   call pbuf_add_field('NEVAPR_SHCU','physpkg' ,dtype_r8,(/pcols,pver/),       nevapr_shcu_idx )
   call pbuf_add_field('PREC_SH',    'physpkg' ,dtype_r8,(/pcols/),            prec_sh_idx )
   call pbuf_add_field('SNOW_SH',    'physpkg' ,dtype_r8,(/pcols/),            snow_sh_idx )
@@ -110,16 +110,16 @@
   endif
 
 ! shallow interface gbm flux_convective_cloud_rain+snow (kg/m2/s)
-  call pbuf_add_field('SH_FLXPRC','physpkg',dtype_r8,(/pcols,pverp/),sh_flxprc_idx)  
+  call pbuf_add_field('SH_FLXPRC','physpkg',dtype_r8,(/pcols,pverp/),sh_flxprc_idx)
 
 ! shallow interface gbm flux_convective_cloud_snow (kg/m2/s)
-  call pbuf_add_field('SH_FLXSNW','physpkg',dtype_r8,(/pcols,pverp/),sh_flxsnw_idx)  
+  call pbuf_add_field('SH_FLXSNW','physpkg',dtype_r8,(/pcols,pverp/),sh_flxsnw_idx)
 
 ! shallow gbm cloud liquid water (kg/kg)
-  call pbuf_add_field('SH_CLDLIQ','physpkg',dtype_r8,(/pcols,pver/),sh_cldliq_idx)  
+  call pbuf_add_field('SH_CLDLIQ','physpkg',dtype_r8,(/pcols,pver/),sh_cldliq_idx)
 
 ! shallow gbm cloud ice water (kg/kg)
-  call pbuf_add_field('SH_CLDICE','physpkg',dtype_r8,(/pcols,pver/),sh_cldice_idx)  
+  call pbuf_add_field('SH_CLDICE','physpkg',dtype_r8,(/pcols,pver/),sh_cldice_idx)
 
   ! If gravity waves from shallow convection are on, output this field.
   if (use_gw_convect_sh) then
@@ -154,7 +154,7 @@
   use spmd_utils,        only : masterproc
   use cam_abortutils,    only : endrun
   use phys_control,      only : cam_physpkg_is
-  
+
   use physics_buffer,    only : pbuf_get_index, physics_buffer_desc, pbuf_set_field
 
   real(r8),                  intent(in) :: pref_edge(plevp)  ! Reference pressures at interfaces
@@ -163,7 +163,7 @@
   integer limcnv                                   ! Top interface level limit for convection
   integer k
   character(len=16)          :: eddy_scheme
-    
+
   ! SPCAM does its own convection
   if (shallow_scheme == 'SPCAM') return
 
@@ -222,7 +222,7 @@
   call addfld( 'PCLDBOT',    horiz_only,   'A', '1',        'Pressure of cloud base'                                    )
 
   call addfld( 'FREQSH',     horiz_only,   'A', 'fraction', 'Fractional occurance of shallow convection'                )
-                                                                                                                    
+
   call addfld( 'HKFLXPRC',   (/ 'ilev' /), 'A', 'kg/m2/s',  'Flux of precipitation from HK convection'                  )
   call addfld( 'HKFLXSNW',   (/ 'ilev' /), 'A', 'kg/m2/s',  'Flux of snow from HK convection'                           )
   call addfld( 'HKNTPRPD',   (/ 'lev' /),  'A', 'kg/kg/s',  'Net precipitation production from HK convection'           )
@@ -287,7 +287,7 @@
      if( masterproc ) then
          write(iulog,*) 'MFINTI: Convection will be capped at intfc ', limcnv, ' which is ', pref_edge(limcnv), ' pascals'
      end if
-     
+
      call mfinti( rair, cpair, gravit, latvap, rhoh2o, limcnv) ! Get args from inti.F90
 
   case('UW') ! Park and Bretherton shallow convection scheme
@@ -347,7 +347,7 @@
   !=============================================================================== !
 
   subroutine convect_shallow_tend( ztodt  , cmfmc   , &
-                                   qc     , qc2     , rliq     , rliq2    , & 
+                                   qc     , qc2     , rliq     , rliq2    , &
                                    state  , ptend_all, pbuf, cam_in)
 
    use physics_buffer,  only : physics_buffer_desc, pbuf_get_field, pbuf_set_field, pbuf_old_tim_idx
@@ -358,7 +358,7 @@
    use physics_types,   only : physics_ptend_dealloc
    use physics_types,   only : physics_ptend_sum
    use camsrfexch,      only : cam_in_t
-   
+
    use constituents,    only : pcnst, cnst_get_ind, cnst_get_type_byind
    use hk_conv,         only : cmfmca
    use uwshcu,          only : compute_uwshcu_inv
@@ -382,7 +382,7 @@
    real(r8),            intent(out)   :: rliq2(pcols)                    ! Vertically-integrated reserved cloud condensate [ m/s ]
    real(r8),            intent(out)   :: qc2(pcols,pver)                 ! Same as qc but only from shallow convection scheme
 
-   
+
 
    real(r8),            intent(inout) :: cmfmc(pcols,pverp)    ! Moist deep + shallow convection cloud mass flux [ kg/s/m2 ]
    real(r8),            intent(inout) :: qc(pcols,pver)        ! dq/dt due to export of cloud water into environment by shallow
@@ -393,7 +393,7 @@
 
 
    ! --------------- !
-   ! Local Variables ! 
+   ! Local Variables !
    ! --------------- !
    integer  :: i, k, m
    integer  :: n, x
@@ -433,7 +433,7 @@
    real(r8) :: pcnb(pcols)                                               ! Bottom pressure level of shallow + deep convective activity
    real(r8) :: cmfsl(pcols,pverp )                                       ! Convective flux of liquid water static energy
    real(r8) :: cmflq(pcols,pverp )                                       ! Convective flux of total water in energy unit
-   
+
    real(r8) :: ftem_preCu(pcols,pver)                                    ! Saturation vapor pressure after shallow Cu convection
    real(r8) :: tem2(pcols,pver)                                          ! Saturation specific humidity and RH
    real(r8) :: t_preCu(pcols,pver)                                       ! Temperature after shallow Cu convection
@@ -443,7 +443,7 @@
    real(r8) :: icwmr_UW(pcols,pver)                                      ! In-cloud Cumulus LWC     [ kg/m2 ]
    real(r8) :: icimr_UW(pcols,pver)                                      ! In-cloud Cumulus IWC     [ kg/m2 ]
    real(r8) :: ptend_tracer(pcols,pver,pcnst)                            ! Tendencies of tracers
-   real(r8) :: sum1, sum2, sum3, pdelx 
+   real(r8) :: sum1, sum2, sum3, pdelx
    real(r8) :: landfracdum(pcols)
 
    real(r8), dimension(pcols,pver) :: sl, qt, slv
@@ -477,14 +477,14 @@
    type(unicon_out_t) :: unicon_out
 
    ! ----------------------- !
-   ! Main Computation Begins ! 
+   ! Main Computation Begins !
    ! ----------------------- !
 
    zero  = 0._r8
    nstep = get_nstep()
    lchnk = state%lchnk
    ncol  = state%ncol
-  
+
    call physics_state_copy( state, state1 )          ! Copy state to local state1.
 
    ! Associate pointers with physics buffer fields
@@ -554,7 +554,7 @@
       snow        = 0._r8
 
    case('Hack') ! Hack scheme
-                                   
+
       lq(:) = .TRUE.
       call physics_ptend_init( ptend_loc, state%psetcols, 'cmfmca', ls=.true., lq=lq  ) ! Initialize local ptend type
 
@@ -566,7 +566,7 @@
                    state%rpdel  ,  state%zm     ,  tpert      ,  qpert       ,  state%phis  ,   &
                    pblh         ,  state%t      ,  state%q    ,  ptend_loc%s ,  ptend_loc%q ,   &
                    cmfmc2       ,  rprdsh       ,  cmfsl      ,  cmflq       ,  precc       ,   &
-                   qc2          ,  cnt2         ,  cnb2       ,  icwmr       ,  rliq2       ,   & 
+                   qc2          ,  cnt2         ,  cnb2       ,  icwmr       ,  rliq2       ,   &
                    state%pmiddry,  state%pdeldry,  state%rpdeldry )
 
    case('UW')   ! UW shallow convection scheme
@@ -577,7 +577,7 @@
 
       ! Initialize local ptend type
       lq(:) = .TRUE.
-      call physics_ptend_init( ptend_loc, state%psetcols, 'UWSHCU', ls=.true., lu=.true., lv=.true., lq=lq  ) 
+      call physics_ptend_init( ptend_loc, state%psetcols, 'UWSHCU', ls=.true., lu=.true., lv=.true., lq=lq  )
 
       call pbuf_get_field(pbuf, cush_idx, cush  ,(/1,itim_old/),  (/pcols,1/))
       call pbuf_get_field(pbuf, tke_idx,  tke)
@@ -588,7 +588,7 @@
       call pbuf_get_field(pbuf, sh_e_ed_ratio_idx, sh_e_ed_ratio)
 
       call compute_uwshcu_inv( pcols     , pver    , ncol           , pcnst         , ztodt         ,                   &
-                               state%pint, state%zi, state%pmid     , state%zm      , state%pdel    ,                   & 
+                               state%pint, state%zi, state%pmid     , state%zm      , state%pdel    ,                   &
                                state%u   , state%v , state%q(:,:,1) , state%q(:,:,ixcldliq), state%q(:,:,ixcldice),     &
                                state%t   , state%s , state%q(:,:,:) ,                                                   &
                                tke       , cld     , concld         , pblh          , cush          ,                   &
@@ -607,14 +607,14 @@
       ! In addition, define 'icwmr' which includes both liquid and ice.       !
       ! --------------------------------------------------------------------- !
 
-      icwmr(:ncol,:)  = iccmr_UW(:ncol,:) 
+      icwmr(:ncol,:)  = iccmr_UW(:ncol,:)
       rprdsh(:ncol,:) = rprdsh(:ncol,:) + cmfdqs(:ncol,:)
       do m = 4, pcnst
          ptend_loc%q(:ncol,:pver,m) = ptend_tracer(:ncol,:pver,m)
       enddo
 
       ! Conservation check
-      
+
       !  do i = 1, ncol
       !  do m = 1, pcnst
       !     sum1 = 0._r8
@@ -627,8 +627,8 @@
       !          pdelx = state%pdeldry(i,k)
       !       endif
       !       sum1 = sum1 + state%q(i,k,m)*pdelx
-      !       sum2 = sum2 +(state%q(i,k,m)+ptend_loc%q(i,k,m)*ztodt)*pdelx  
-      !       sum3 = sum3 + ptend_loc%q(i,k,m)*pdelx 
+      !       sum2 = sum2 +(state%q(i,k,m)+ptend_loc%q(i,k,m)*ztodt)*pdelx
+      !       sum3 = sum3 + ptend_loc%q(i,k,m)*pdelx
       !  enddo
       !  if( m .gt. 3 .and. abs(sum1) .gt. 1.e-13_r8 .and. abs(sum2-sum1)/sum1 .gt. 1.e-12_r8 ) then
       !! if( m .gt. 3 .and. abs(sum3) .gt. 1.e-13_r8 ) then
@@ -672,7 +672,7 @@
 
    end select
 
-   ! --------------------------------------------------------!     
+   ! --------------------------------------------------------!
    ! Calculate fractional occurance of shallow convection    !
    ! --------------------------------------------------------!
 
@@ -697,7 +697,7 @@
 
    ! -------------------------------------------------------------- !
    ! 'cnt2' & 'cnb2' are from shallow, 'cnt' & 'cnb' are from deep  !
-   ! 'cnt2' & 'cnb2' are the interface indices of cloud top & base: ! 
+   ! 'cnt2' & 'cnb2' are the interface indices of cloud top & base: !
    !        cnt2 = float(kpen)                                      !
    !        cnb2 = float(krel - 1)                                  !
    ! Note that indices decreases with height.                       !
@@ -707,28 +707,28 @@
       if( cnt2(i) < cnt(i)) cnt(i) = cnt2(i)
       if( cnb2(i) > cnb(i)) cnb(i) = cnb2(i)
       pcnt(i) = state%pmid(i,int(cnt(i)))
-      pcnb(i) = state%pmid(i,int(cnb(i)))     
+      pcnb(i) = state%pmid(i,int(cnb(i)))
    end do
-   
+
    ! ----------------------------------------------- !
    ! This quantity was previously known as CMFDQR.   !
    ! Now CMFDQR is the shallow rain production only. !
    ! ----------------------------------------------- !
 
-   
+
    call pbuf_set_field(pbuf, rprdtot_idx, rprdsh(:ncol,:pver) + rprddp(:ncol,:pver), start=(/1,1/), kount=(/ncol,pver/))
- 
-   ! ----------------------------------------------------------------------- ! 
+
+   ! ----------------------------------------------------------------------- !
    ! Add shallow reserved cloud condensate to deep reserved cloud condensate !
    !     qc [ kg/kg/s] , rliq [ m/s ]                                        !
    ! ----------------------------------------------------------------------- !
 
    qc(:ncol,:pver) = qc(:ncol,:pver) + qc2(:ncol,:pver)
-   rliq(:ncol)     = rliq(:ncol) + rliq2(:ncol)    
+   rliq(:ncol)     = rliq(:ncol) + rliq2(:ncol)
 
    ! ---------------------------------------------------------------------------- !
    ! Output new partition of cloud condensate variables, as well as precipitation !
-   ! ---------------------------------------------------------------------------- ! 
+   ! ---------------------------------------------------------------------------- !
 
    if( microp_scheme == 'MG' ) then
        call cnst_get_ind( 'NUMLIQ', ixnumliq )
@@ -740,9 +740,9 @@
    call outfld( 'ICWMRSH ', icwmr                    , pcols   , lchnk )
 
    call outfld( 'CMFDT  ', ftem                      , pcols   , lchnk )
-   call outfld( 'CMFDQ  ', ptend_loc%q(1,1,1)        , pcols   , lchnk )
-   call outfld( 'CMFDICE', ptend_loc%q(1,1,ixcldice) , pcols   , lchnk )
-   call outfld( 'CMFDLIQ', ptend_loc%q(1,1,ixcldliq) , pcols   , lchnk )
+   call outfld( 'CMFDQ  ', ptend_loc%q(:,:,1)        , pcols   , lchnk )
+   call outfld( 'CMFDICE', ptend_loc%q(:,:,ixcldice) , pcols   , lchnk )
+   call outfld( 'CMFDLIQ', ptend_loc%q(:,:,ixcldliq) , pcols   , lchnk )
    call outfld( 'CMFMC'  , cmfmc                     , pcols   , lchnk )
    call outfld( 'QC'     , qc2                       , pcols   , lchnk )
    call outfld( 'CMFDQR' , rprdsh                    , pcols   , lchnk )
@@ -752,12 +752,12 @@
    call outfld( 'CLDTOP' , cnt                       , pcols   , lchnk )
    call outfld( 'CLDBOT' , cnb                       , pcols   , lchnk )
    call outfld( 'PCLDTOP', pcnt                      , pcols   , lchnk )
-   call outfld( 'PCLDBOT', pcnb                      , pcols   , lchnk )  
+   call outfld( 'PCLDBOT', pcnb                      , pcols   , lchnk )
    call outfld( 'FREQSH' , freqsh                    , pcols   , lchnk )
 
    if( shallow_scheme .eq. 'UW' ) then
       call outfld( 'CBMF'   , cbmf                      , pcols   , lchnk )
-      call outfld( 'UWFLXPRC', flxprec                  , pcols   , lchnk )  
+      call outfld( 'UWFLXPRC', flxprec                  , pcols   , lchnk )
       call outfld( 'UWFLXSNW' , flxsnow                 , pcols   , lchnk )
    endif
 
@@ -794,8 +794,8 @@
    call outfld( 't_pre_Cu       ', state1%t               , pcols, lchnk )
    call outfld( 'rh_pre_Cu      ', ftem_preCu             , pcols, lchnk )
 
-   ! ----------------------------------------------- ! 
-   ! Update physics state type state1 with ptend_loc ! 
+   ! ----------------------------------------------- !
+   ! Update physics state type state1 with ptend_loc !
    ! ----------------------------------------------- !
 
    call physics_update( state1, ptend_loc, ztodt )
@@ -825,8 +825,8 @@
    call outfld( 't_aft_Cu       ', state1%t               , pcols, lchnk )
    call outfld( 'rh_aft_Cu      ', ftem                   , pcols, lchnk )
 
-   tten(:ncol,:)  = ( state1%t(:ncol,:pver) - t_preCu(:ncol,:) ) / ztodt 
-   rhten(:ncol,:) = ( ftem(:ncol,:) - ftem_preCu(:ncol,:) ) / ztodt 
+   tten(:ncol,:)  = ( state1%t(:ncol,:pver) - t_preCu(:ncol,:) ) / ztodt
+   rhten(:ncol,:) = ( ftem(:ncol,:) - ftem_preCu(:ncol,:) ) / ztodt
 
    call outfld( 'tten_Cu        ', tten                           , pcols, lchnk )
    call outfld( 'rhten_Cu       ', rhten                          , pcols, lchnk )
@@ -867,7 +867,7 @@
     call zm_conv_evap( state1%ncol, state1%lchnk,                                    &
                        state1%t, state1%pmid, state1%pdel, state1%q(:pcols,:pver,1), &
 		       landfracdum, &
-                       ptend_loc%s, tend_s_snwprd, tend_s_snwevmlt,                  & 
+                       ptend_loc%s, tend_s_snwprd, tend_s_snwevmlt,                  &
                        ptend_loc%q(:pcols,:pver,1),                                  &
                        rprdsh, cld, ztodt,                                           &
                        precc, snow, ntprprd, ntsnprd , flxprec, flxsnow )
@@ -884,7 +884,7 @@
    call outfld( 'FZSNTCM '       , ftem                           , pcols, lchnk )
    ftem(:ncol,:pver) = tend_s_snwevmlt(:ncol,:pver) / cpair
    call outfld( 'EVSNTCM '       , ftem                           , pcols, lchnk )
-   call outfld( 'EVAPQCM '       , ptend_loc%q(1,1,1)             , pcols, lchnk )
+   call outfld( 'EVAPQCM '       , ptend_loc%q(:,:,1)             , pcols, lchnk )
    call outfld( 'PRECSH  '       , precc                          , pcols, lchnk )
    call outfld( 'HKFLXPRC'       , flxprec                        , pcols, lchnk )
    call outfld( 'HKFLXSNW'       , flxsnow                        , pcols, lchnk )
@@ -892,7 +892,7 @@
    call outfld( 'HKNTSNPD'       , ntsnprd                        , pcols, lchnk )
    call outfld( 'HKEIHEAT'       , ptend_loc%s                    , pcols, lchnk )
 
-   ! ---------------------------------------------------------------- !      
+   ! ---------------------------------------------------------------- !
    ! Add tendency from this process to tend from other processes here !
    ! ---------------------------------------------------------------- !
 

--- a/src/physics/cam/ndrop.F90
+++ b/src/physics/cam/ndrop.F90
@@ -160,7 +160,7 @@ subroutine ndrop_init
       voltonumbhi_amode(m) = 1._r8 / ( (pi/6._r8)*                          &
                              (dgnumhi_amode(m)**3._r8)*exp(4.5_r8*alogsig(m)**2._r8) )
    end do
-      
+
    ! Init the table for local indexing of mam number conc and mmr.
    ! This table uses species index 0 for the number conc.
 
@@ -243,7 +243,7 @@ subroutine ndrop_init
 
 
          end if
-            
+
       end do
    end do
 
@@ -261,7 +261,7 @@ subroutine ndrop_init
    call addfld('NDROPSNK', (/ 'lev' /), 'A', '#/kg/s', 'Droplet number loss by microphysics')
    call addfld('NDROPCOL', horiz_only,  'A', '#/m2', 'Column droplet number')
 
-   ! set the add_default fields  
+   ! set the add_default fields
    if (history_amwg) then
       call add_default('CCN3', 1, ' ')
    endif
@@ -411,7 +411,7 @@ subroutine dropmixnuc( &
    real(r8), allocatable :: fluxn(:)           ! number  activation fraction flux (cm/s)
    real(r8), allocatable :: fluxm(:)           ! mass    activation fraction flux (cm/s)
    real(r8)              :: flux_fullact(pver) ! 100%    activation fraction flux (cm/s)
-   !     note:  activation fraction fluxes are defined as 
+   !     note:  activation fraction fluxes are defined as
    !     fluxn = [flux of activated aero. number into cloud (#/cm2/s)]
    !           / [aero. number conc. in updraft, just below cloudbase (#/cm3)]
 
@@ -485,7 +485,7 @@ subroutine dropmixnuc( &
       fluxn(ntot_amode),              &
       fluxm(ntot_amode)               )
 
-   ! Init pointers to mode number and specie mass mixing ratios in 
+   ! Init pointers to mode number and specie mass mixing ratios in
    ! intersitial and cloud borne phases.
    do m = 1, ntot_amode
       mm = mam_idx(m, 0)
@@ -498,7 +498,7 @@ subroutine dropmixnuc( &
       end do
    end do
 
-   called_from_spcam = (present(from_spcam)) 
+   called_from_spcam = (present(from_spcam))
 
    if (called_from_spcam) then
       rgas  => state%q
@@ -597,9 +597,9 @@ subroutine dropmixnuc( &
 
       ! droplet nucleation/aerosol activation
 
-      ! tau_cld_regenerate = time scale for regeneration of cloudy air 
+      ! tau_cld_regenerate = time scale for regeneration of cloudy air
       !    by (horizontal) exchange with clear air
-      tau_cld_regenerate = 3600.0_r8 * 3.0_r8 
+      tau_cld_regenerate = 3600.0_r8 * 3.0_r8
 
       if (called_from_spcam) then
       ! when this is called  in the MMF part, no cloud regeneration and decay.
@@ -652,7 +652,7 @@ subroutine dropmixnuc( &
          !    alternate formulation
          !    cldn_tmp = cldn(i,k) * max( 0.0_r8, (1.0_r8-dtmicro/tau_cld_regenerate) )
 
-         ! fraction is also provided. 
+         ! fraction is also provided.
          if (cldn_tmp < cldo_tmp) then
             !  droplet loss in decaying cloud
             !++ sungsup
@@ -679,7 +679,7 @@ subroutine dropmixnuc( &
 
          ! growing liquid cloud ......................................................
          !    treat the increase of cloud fraction from when cldn(i,k) > cldo(i,k)
-         !    and also regenerate part of the cloud 
+         !    and also regenerate part of the cloud
          cldo_tmp = cldn_tmp
          cldn_tmp = lcldn(i,k)
 
@@ -780,7 +780,7 @@ subroutine dropmixnuc( &
                phase   = 1   ! interstitial
 
                do m = 1, ntot_amode
-                  ! rce-comment - use kp1 here as old-cloud activation involves 
+                  ! rce-comment - use kp1 here as old-cloud activation involves
                   !   aerosol from layer below
                   call loadaer( &
                      state, pbuf, i, i, kp1,  &
@@ -819,14 +819,14 @@ subroutine dropmixnuc( &
                ! rce-comment 2
                !    code for k=pver was changed to use the following conceptual model
                !    in k=pver, there can be no cloud-base activation unless one considers
-               !       a scenario such as the layer being partially cloudy, 
+               !       a scenario such as the layer being partially cloudy,
                !       with clear air at bottom and cloudy air at top
-               !    assume this scenario, and that the clear/cloudy portions mix with 
+               !    assume this scenario, and that the clear/cloudy portions mix with
                !       a timescale taumix_internal = dz(i,pver)/wtke_cen(i,pver)
-               !    in the absence of other sources/sinks, qact (the activated particle 
+               !    in the absence of other sources/sinks, qact (the activated particle
                !       mixratio) attains a steady state value given by
                !          qact_ss = fcloud*fact*qtot
-               !       where fcloud is cloud fraction, fact is activation fraction, 
+               !       where fcloud is cloud fraction, fact is activation fraction,
                !       qtot=qact+qint, qint is interstitial particle mixratio
                !    the activation rate (from mixing within the layer) can now be
                !       written as
@@ -836,8 +836,8 @@ subroutine dropmixnuc( &
                !    also, d(qact)/dt can be negative.  in the code below
                !       it is forced to be >= 0
                !
-               ! steve -- 
-               !    you will likely want to change this.  i did not really understand 
+               ! steve --
+               !    you will likely want to change this.  i did not really understand
                !       what was previously being done in k=pver
                !    in the cam3_5_3 code, wtke(i,pver) appears to be equal to the
                !       droplet deposition velocity which is quite small
@@ -910,7 +910,7 @@ subroutine dropmixnuc( &
       do k = top_lev, pver-1
          ! rce-comment -- ekd(k) is eddy-diffusivity at k/k+1 interface
          !   want ekk(k) = ekd(k) * (density at k/k+1 interface)
-         !   so use pint(i,k+1) as pint is 1:pverp 
+         !   so use pint(i,k+1) as pint is 1:pverp
          !           ekk(k)=ekd(k)*2.*pint(i,k)/(rair*(temp(i,k)+temp(i,k+1)))
          !           ekk(k)=ekd(k)*2.*pint(i,k+1)/(rair*(temp(i,k)+temp(i,k+1)))
          ekk(k) = ekd(k)*csbot(k)
@@ -926,10 +926,10 @@ subroutine dropmixnuc( &
          !    for the layer.  for most layers, the activation loss rate
          !    (for interstitial particles) is accounted for by the loss by
          !    turb-transfer to the layer above.
-         !    k=pver is special, and the loss rate for activation within 
+         !    k=pver is special, and the loss rate for activation within
          !    the layer must be added to tinv.  if not, the time step
          !    can be too big, and explmix can produce negative values.
-         !    the negative values are reset to zero, resulting in an 
+         !    the negative values are reset to zero, resulting in an
          !    artificial source.
          if (k == pver) tinv = tinv + taumix_internal_pver_inv
 
@@ -1013,7 +1013,7 @@ subroutine dropmixnuc( &
          !    of a layer, and generally higher in the clear portion.  (we have/had
          !    a method for diagnosing the the clear/cloudy mixratios.)  the activation
          !    source terms involve clear air (from below) moving into cloudy air (above).
-         !    in theory, the clear-portion mixratio should be used when calculating 
+         !    in theory, the clear-portion mixratio should be used when calculating
          !    source terms
          do m = 1, ntot_amode
             mm = mam_idx(m,0)
@@ -1157,14 +1157,14 @@ subroutine dropmixnuc( &
    call outfld('NDROPMIX', ndropmix, pcols, lchnk)
    call outfld('WTKE    ', wtke,     pcols, lchnk)
 
-   if(called_from_spcam) then  
+   if(called_from_spcam) then
         call outfld('SPLCLOUD  ', cldn    , pcols, lchnk   )
         call outfld('SPKVH     ', kvh     , pcols, lchnk   )
    endif
 
    call ccncalc(state, pbuf, cs, ccn)
    do l = 1, psat
-      call outfld(ccn_name(l), ccn(1,1,l), pcols, lchnk)
+      call outfld(ccn_name(l), ccn(:,:,l), pcols, lchnk)
    enddo
 
    ! do column tendencies
@@ -1331,7 +1331,7 @@ subroutine activate_modal(wbar, sigw, wdiab, wminf, wmaxf, tair, rhoair,  &
    !    used for consistency check -- this should match (ekd(k)*zs(k))
    !    also, fluxm/flux_fullact gives fraction of aerosol mass flux
    !       that is activated
-  
+
    !      optional
    real(r8), optional, intent(in) :: smax_prescribed  ! prescribed max. supersaturation for secondary activation
    logical,  optional, intent(in) :: in_cloud_in      ! switch to modify calculations when above cloud base
@@ -1652,7 +1652,7 @@ subroutine activate_modal(wbar, sigw, wdiab, wminf, wmaxf, tair, rhoair,  &
       if(wnuc.gt.0._r8)then
 
          w=wbar
-              
+
          if(in_cloud) then
 
             if (smax_f > 0._r8) then
@@ -1869,7 +1869,7 @@ subroutine loadaer( &
    type(physics_buffer_desc),   pointer    :: pbuf(:)
 
    integer,  intent(in) :: istart      ! start column index (1 <= istart <= istop <= pcols)
-   integer,  intent(in) :: istop       ! stop column index  
+   integer,  intent(in) :: istop       ! stop column index
    integer,  intent(in) :: m           ! mode index
    integer,  intent(in) :: k           ! level index
    real(r8), intent(in) :: cs(:,:)     ! air density (kg/m3)
@@ -1965,7 +1965,3 @@ end subroutine loadaer
 !===============================================================================
 
 end module ndrop
-
-
-
-

--- a/src/physics/cam/ndrop_bam.F90
+++ b/src/physics/cam/ndrop_bam.F90
@@ -73,10 +73,10 @@ subroutine ndrop_bam_init
 
   use phys_control, only: phys_getopts
 
-   !----------------------------------------------------------------------- 
-   ! 
+   !-----------------------------------------------------------------------
+   !
    ! Initialize constants for droplet activation by bulk aerosols
-   ! 
+   !
    !-----------------------------------------------------------------------
 
    integer  :: l, m, iaer
@@ -172,7 +172,7 @@ subroutine ndrop_bam_init
 
       ! Skip aerosols that don't have a dispersion defined.
       if (dispersion_aer(m) == 0._r8) cycle
-      
+
       alogsig(m)     = log(dispersion_aer(m))
       exp45logsig(m) = exp(4.5_r8*alogsig(m)*alogsig(m))
       argfactor(m)   = 2._r8/(3._r8*sqrt(2._r8)*alogsig(m))
@@ -316,7 +316,7 @@ subroutine ndrop_bam_run( &
          smc(m) = smcrit(m) ! only for prescribed size dist
 
          if (hygro_aer(m) > 1.e-10_r8) then   ! loop only if variable size dist
-            smc(m) = 2._r8*aten*sqrt(aten/(27._r8*hygro_aer(m)*amcubeloc(m))) 
+            smc(m) = 2._r8*aten*sqrt(aten/(27._r8*hygro_aer(m)*amcubeloc(m)))
          else
             smc(m) = 100._r8
          endif
@@ -397,7 +397,7 @@ subroutine ndrop_bam_ccn(lchnk, ncol, maerosol, naer2)
          if (m == idxsul) then
             ! Lohmann treatment for sulfate has variable size distribution
             do i = 1, ncol
-               if (naer2(i,k,m) > 0._r8) then 
+               if (naer2(i,k,m) > 0._r8) then
                   amcubesulfate(i) = amcubefactor(m)*maerosol(i,k,m)/(naer2(i,k,m))
                   smcritsulfate(i) = smcritfactor(m)/sqrt(amcubesulfate(i))
                else
@@ -433,7 +433,7 @@ subroutine ndrop_bam_ccn(lchnk, ncol, maerosol, naer2)
    end do         ! level
 
    do l = 1, psat
-      call outfld(ccn_name(l), ccn(1,1,l), pcols, lchnk)
+      call outfld(ccn_name(l), ccn(:,:,l), pcols, lchnk)
    end do
 
    do l = 1, naer_all
@@ -489,9 +489,9 @@ subroutine maxsat(zeta, eta, nmode, smc, smax)
          sum=1.e20_r8
       endif
    enddo
-   
+
    smax=1._r8/sqrt(sum)
-   
+
 end subroutine maxsat
 
 !===============================================================================

--- a/src/physics/cam/vertical_diffusion.F90
+++ b/src/physics/cam/vertical_diffusion.F90
@@ -1053,16 +1053,16 @@ subroutine vertical_diffusion_tend( &
           tem2(:ncol,:), ftem(:ncol,:))
      ftem_prePBL(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
 
-     call outfld( 'qt_pre_PBL   ', qt_prePBL,                 pcols, lchnk )
-     call outfld( 'sl_pre_PBL   ', sl_prePBL,                 pcols, lchnk )
-     call outfld( 'slv_pre_PBL  ', slv_prePBL,                pcols, lchnk )
-     call outfld( 'u_pre_PBL    ', state%u,                   pcols, lchnk )
-     call outfld( 'v_pre_PBL    ', state%v,                   pcols, lchnk )
-     call outfld( 'qv_pre_PBL   ', state%q(:ncol,:,1),        pcols, lchnk )
-     call outfld( 'ql_pre_PBL   ', state%q(:ncol,:,ixcldliq), pcols, lchnk )
-     call outfld( 'qi_pre_PBL   ', state%q(:ncol,:,ixcldice), pcols, lchnk )
-     call outfld( 't_pre_PBL    ', state%t,                   pcols, lchnk )
-     call outfld( 'rh_pre_PBL   ', ftem_prePBL,               pcols, lchnk )
+     call outfld( 'qt_pre_PBL   ', qt_prePBL,             pcols, lchnk )
+     call outfld( 'sl_pre_PBL   ', sl_prePBL,             pcols, lchnk )
+     call outfld( 'slv_pre_PBL  ', slv_prePBL,            pcols, lchnk )
+     call outfld( 'u_pre_PBL    ', state%u,               pcols, lchnk )
+     call outfld( 'v_pre_PBL    ', state%v,               pcols, lchnk )
+     call outfld( 'qv_pre_PBL   ', state%q(:,:,1),        pcols, lchnk )
+     call outfld( 'ql_pre_PBL   ', state%q(:,:,ixcldliq), pcols, lchnk )
+     call outfld( 'qi_pre_PBL   ', state%q(:,:,ixcldice), pcols, lchnk )
+     call outfld( 't_pre_PBL    ', state%t,               pcols, lchnk )
+     call outfld( 'rh_pre_PBL   ', ftem_prePBL,           pcols, lchnk )
 
   end if
 
@@ -1149,7 +1149,7 @@ subroutine vertical_diffusion_tend( &
           p_dry , state%t      , rhoi_dry,  ztodt         , taux          , &
           tauy          , shflux             , cflux        , &
           kvh           , kvm                , kvq          , cgs           , cgh           , &
-          state%zi      , ksrftms            , dragblj      , & 
+          state%zi      , ksrftms            , dragblj      , &
           qmincg       , fieldlist_dry , fieldlist_molec,&
           u_tmp         , v_tmp              , q_tmp        , s_tmp         ,                 &
           tautmsx_temp  , tautmsy_temp       , dtk_temp     , topflx_temp   , errstring     , &
@@ -1386,33 +1386,33 @@ subroutine vertical_diffusion_tend( &
 
   if (.not. do_pbl_diags) then
 
-     call outfld( 'sl_aft_PBL'   , sl,                        pcols, lchnk )
-     call outfld( 'qt_aft_PBL'   , qt,                        pcols, lchnk )
-     call outfld( 'slv_aft_PBL'  , slv,                       pcols, lchnk )
-     call outfld( 'u_aft_PBL'    , u_aft_PBL,                 pcols, lchnk )
-     call outfld( 'v_aft_PBL'    , v_aft_PBL,                 pcols, lchnk )
-     call outfld( 'qv_aft_PBL'   , qv_aft_PBL,                pcols, lchnk )
-     call outfld( 'ql_aft_PBL'   , ql_aft_PBL,                pcols, lchnk )
-     call outfld( 'qi_aft_PBL'   , qi_aft_PBL,                pcols, lchnk )
-     call outfld( 't_aft_PBL '   , t_aftPBL,                  pcols, lchnk )
-     call outfld( 'rh_aft_PBL'   , ftem_aftPBL,               pcols, lchnk )
-     call outfld( 'slflx_PBL'    , slflx,                     pcols, lchnk )
-     call outfld( 'qtflx_PBL'    , qtflx,                     pcols, lchnk )
-     call outfld( 'uflx_PBL'     , uflx,                      pcols, lchnk )
-     call outfld( 'vflx_PBL'     , vflx,                      pcols, lchnk )
-     call outfld( 'slflx_cg_PBL' , slflx_cg,                  pcols, lchnk )
-     call outfld( 'qtflx_cg_PBL' , qtflx_cg,                  pcols, lchnk )
-     call outfld( 'uflx_cg_PBL'  , uflx_cg,                   pcols, lchnk )
-     call outfld( 'vflx_cg_PBL'  , vflx_cg,                   pcols, lchnk )
-     call outfld( 'slten_PBL'    , slten,                     pcols, lchnk )
-     call outfld( 'qtten_PBL'    , qtten,                     pcols, lchnk )
-     call outfld( 'uten_PBL'     , ptend%u(:ncol,:),          pcols, lchnk )
-     call outfld( 'vten_PBL'     , ptend%v(:ncol,:),          pcols, lchnk )
-     call outfld( 'qvten_PBL'    , ptend%q(:ncol,:,1),        pcols, lchnk )
-     call outfld( 'qlten_PBL'    , ptend%q(:ncol,:,ixcldliq), pcols, lchnk )
-     call outfld( 'qiten_PBL'    , ptend%q(:ncol,:,ixcldice), pcols, lchnk )
-     call outfld( 'tten_PBL'     , tten,                      pcols, lchnk )
-     call outfld( 'rhten_PBL'    , rhten,                     pcols, lchnk )
+     call outfld( 'sl_aft_PBL'   , sl,                    pcols, lchnk )
+     call outfld( 'qt_aft_PBL'   , qt,                    pcols, lchnk )
+     call outfld( 'slv_aft_PBL'  , slv,                   pcols, lchnk )
+     call outfld( 'u_aft_PBL'    , u_aft_PBL,             pcols, lchnk )
+     call outfld( 'v_aft_PBL'    , v_aft_PBL,             pcols, lchnk )
+     call outfld( 'qv_aft_PBL'   , qv_aft_PBL,            pcols, lchnk )
+     call outfld( 'ql_aft_PBL'   , ql_aft_PBL,            pcols, lchnk )
+     call outfld( 'qi_aft_PBL'   , qi_aft_PBL,            pcols, lchnk )
+     call outfld( 't_aft_PBL '   , t_aftPBL,              pcols, lchnk )
+     call outfld( 'rh_aft_PBL'   , ftem_aftPBL,           pcols, lchnk )
+     call outfld( 'slflx_PBL'    , slflx,                 pcols, lchnk )
+     call outfld( 'qtflx_PBL'    , qtflx,                 pcols, lchnk )
+     call outfld( 'uflx_PBL'     , uflx,                  pcols, lchnk )
+     call outfld( 'vflx_PBL'     , vflx,                  pcols, lchnk )
+     call outfld( 'slflx_cg_PBL' , slflx_cg,              pcols, lchnk )
+     call outfld( 'qtflx_cg_PBL' , qtflx_cg,              pcols, lchnk )
+     call outfld( 'uflx_cg_PBL'  , uflx_cg,               pcols, lchnk )
+     call outfld( 'vflx_cg_PBL'  , vflx_cg,               pcols, lchnk )
+     call outfld( 'slten_PBL'    , slten,                 pcols, lchnk )
+     call outfld( 'qtten_PBL'    , qtten,                 pcols, lchnk )
+     call outfld( 'uten_PBL'     , ptend%u(:,:),          pcols, lchnk )
+     call outfld( 'vten_PBL'     , ptend%v(:,:),          pcols, lchnk )
+     call outfld( 'qvten_PBL'    , ptend%q(:,:,1),        pcols, lchnk )
+     call outfld( 'qlten_PBL'    , ptend%q(:,:,ixcldliq), pcols, lchnk )
+     call outfld( 'qiten_PBL'    , ptend%q(:,:,ixcldice), pcols, lchnk )
+     call outfld( 'tten_PBL'     , tten,                  pcols, lchnk )
+     call outfld( 'rhten_PBL'    , rhten,                 pcols, lchnk )
 
   end if
 
@@ -1446,7 +1446,7 @@ subroutine vertical_diffusion_tend( &
   call outfld( 'DUV'          , ptend%u,                   pcols, lchnk )
   call outfld( 'DVV'          , ptend%v,                   pcols, lchnk )
   do m = 1, pcnst
-     call outfld( vdiffnam(m) , ptend%q(1,1,m),            pcols, lchnk )
+     call outfld( vdiffnam(m) , ptend%q(:,:,m),            pcols, lchnk )
   end do
   if( do_molec_diff ) then
      call outfld( 'TTPXMLC'  , topflx,                    pcols, lchnk )

--- a/src/physics/spcam/spcam_drivers.F90
+++ b/src/physics/spcam/spcam_drivers.F90
@@ -2053,7 +2053,7 @@ subroutine spcam_radiation_finalize_sam1mom(cam_in, state, pbuf, rad_avgdata, ca
     call outfld('FSN200  ',rad_avgdata%fsn200_m(:),pcols,lchnk)
     call outfld('FSN200C ',rad_avgdata%fsn200c_m(:),pcols,lchnk)
     call outfld('FSNR'    ,rad_avgdata%fsnr_m(:)  ,pcols,lchnk)
-    call outfld('SWCF    ',rad_avgdata%fsntoa_m(:ncol)-rad_avgdata%fsntoac_m(:ncol)  ,pcols,lchnk)
+    call outfld('SWCF    ',rad_avgdata%fsntoa_m(:ncol)-rad_avgdata%fsntoac_m(:ncol)  ,ncol,lchnk)
 
     do i=1, Nday
        do k=1, pver

--- a/src/physics/waccm/mo_aurora.F90
+++ b/src/physics/waccm/mo_aurora.F90
@@ -5,7 +5,7 @@
 ! Auroral oval parameterization. See reference:
 ! R.G. Roble, E.C. Ridley
 ! An auroral model for the NCAR thermospheric general circulation model (TGCM)
-! Annales Geophysicae,5A, (6), 369-382, 1987. 
+! Annales Geophysicae,5A, (6), 369-382, 1987.
 !
 ! The aurora oval is a circle in auroral circle coordinates.  Auroral circle
 !  coordinates are offset from magnetic coordinates by offa degrees (radians)
@@ -46,7 +46,7 @@
 !   1) sub aurora_cons called once per time step from advance.
 !   2) sub aurora called from dynamics, inside parallel latitude scan.
 !   3) subs aurora_cusp and aurora_heat called from sub aurora.
-!   4) sub aurora_ions called from sub aurora. 
+!   4) sub aurora_ions called from sub aurora.
 !
 !-----------------------------------------------------------------------
 
@@ -71,7 +71,7 @@
       private
       public :: aurora_inti, aurora_timestep_init, aurora
       public :: aurora_register
-      
+
       integer, parameter  :: isouth = 1
       integer, parameter  :: inorth = 2
 
@@ -143,7 +143,7 @@
 
       contains
 
-        
+
       !----------------------------------------------------------------------
       !----------------------------------------------------------------------
       subroutine aurora_register
@@ -342,9 +342,9 @@
 !-----------------------------------------------------------------------
 
       rh = (h2 - h1) / (h1 + h2)
-      h0     = 0.5_r8 * (h1 + h2) * d2r   
-      
-      
+      h0     = 0.5_r8 * (h1 + h2) * d2r
+
+
 ! roth = MLT of max width of aurora in hours
 ! rote = MLT of max energy flux of aurora in hours
 
@@ -471,14 +471,14 @@
 !-----------------------------------------------------------------------
 ! 	... output mag lons, lats
 !-----------------------------------------------------------------------
-      call outfld( 'ALONM', r2d*alonm(:ncol,lchnk), pcols, lchnk )
-      call outfld( 'ALATM', r2d*alatm(:ncol,lchnk), pcols, lchnk )
+      call outfld( 'ALONM', r2d*alonm(:,lchnk), pcols, lchnk )
+      call outfld( 'ALATM', r2d*alatm(:,lchnk), pcols, lchnk )
 
       if (indxQTe>0) then
         call pbuf_get_field(pbuf, indxQTe, qteaur)
         qteaur(:) = 0._r8
      endif
-     
+
 !-----------------------------------------------------------------------
 !    aurora is active for columns poleward of 30 deg
 !-----------------------------------------------------------------------
@@ -496,7 +496,7 @@
       do i = 1,ncol
         if( do_aurora(i) ) then
           dlat_aur(i) = alatm(i,lchnk)
-          dlon_aur(i) = alonm(i,lchnk) + rotation ! rotate it 
+          dlon_aur(i) = alonm(i,lchnk) + rotation ! rotate it
           if( dlon_aur(i) > pi ) then
              dlon_aur(i) = dlon_aur(i) - twopi
           else if( dlon_aur(i) < -pi ) then
@@ -654,7 +654,7 @@
       do i = 1,ncol
         if( do_aurora(i) ) then
           dlat_aur(i) = alatm(i,lchnk)
-          dlon_aur(i) = alonm(i,lchnk) + rotation ! rotate it 
+          dlon_aur(i) = alonm(i,lchnk) + rotation ! rotate it
           if( dlon_aur(i) > pi ) then
              dlon_aur(i) = dlon_aur(i) - twopi
           else if( dlon_aur(i) < -pi ) then
@@ -709,7 +709,7 @@
       call aurora_heat( flux, flux2, alfa, alfa2, &
                         drizl, do_aurora, hemis, &
                         alon, colat, ncol, pbuf )
- 
+
 !-----------------------------------------------------------------------
 ! 	... auroral additions to ionization rates
 !-----------------------------------------------------------------------
@@ -758,7 +758,7 @@
          cusp(:) = 0._r8
       endwhere
 
-      end subroutine aurora_cusp 
+      end subroutine aurora_cusp
 
       subroutine aurora_heat( flux, flux2, alfa, alfa2, &
                               drizl, do_aurora, hemis, &
@@ -767,7 +767,7 @@
 ! 	... calculate alfa, flux, and drizzle
 !-----------------------------------------------------------------------
       use physics_buffer,only: physics_buffer_desc,pbuf_get_field
-      
+
       implicit none
 
 !-----------------------------------------------------------------------
@@ -793,12 +793,12 @@
         halfwidth, &                            ! oval half-width
         wrk, &                                  ! temp wrk array
         dtheta                                  ! latitudinal variation (Gaussian)
-      real(r8) :: ekev 
+      real(r8) :: ekev
       real(r8), pointer   :: amie_efxg(:) ! Pointer to pbuf AMIE energy flux (mW m-2)
       real(r8), pointer   :: amie_kevg(:) ! Pointer to pbuf AMIE mean energy (keV)
       real(r8), pointer   :: qteaur(:)    ! for electron temperature
       integer  :: n
-      
+
 !-----------------------------------------------------------------------
 ! Low-energy protons:
 !
@@ -845,7 +845,7 @@
       endwhere
 
 !-----------------------------------------------------------------------
-! 	... for electron temperature (used in settei):  
+! 	... for electron temperature (used in settei):
 !-----------------------------------------------------------------------
       if (indxQTe>0) then
          call pbuf_get_field(pbuf, indxQTe, qteaur)
@@ -949,14 +949,14 @@
       real(r8) :: wrk(ncol,pver)
 
       real(r8), pointer   :: aurIPRateSum(:,:) ! Pointer to pbuf auroral ion production sum for O2+,O+,N2+ (s-1 cm-3)
-      
+
       qia(:) = 0._r8
       wrk(:,:) = 0._r8
 
       !-----------------------------------------------------------
-      !  Point to production rates array in physics buffer where 
-      !  rates will be stored for ionosphere module access.  Also, 
-      !  initialize rates to zero before column loop since only 
+      !  Point to production rates array in physics buffer where
+      !  rates will be stored for ionosphere module access.  Also,
+      !  initialize rates to zero before column loop since only
       !  daylight values are filled
       !-----------------------------------------------------------
       if (indxAIPRS>0) then
@@ -1036,15 +1036,15 @@ level_loop : &
       end do level_loop
 
       !----------------------------------------------------------------
-      !  Store the sum of the ion production rates in pbuf to be used 
-      !  in the ionosx module 
+      !  Store the sum of the ion production rates in pbuf to be used
+      !  in the ionosx module
       !----------------------------------------------------------------
       if (indxAIPRS>0) then
-      
-        aurIPRateSum(1:ncol,1:pver) = wrk(1:ncol,1:pver) 
-      
+
+        aurIPRateSum(1:ncol,1:pver) = wrk(1:ncol,1:pver)
+
       endif
-  
+
       call outfld( 'QSUM', wrk, ncol, lchnk )
 
       end subroutine aurora_ions
@@ -1160,9 +1160,9 @@ level_loop : &
 !-----------------------------------------------------------------------
 ! Calculates integrated f(x) needed for total auroral ionization.
 ! See equations (10-12) in Roble,1987.
-! Coefficients for equation (12) of Roble,1987 are in variable cc 
+! Coefficients for equation (12) of Roble,1987 are in variable cc
 ! (revised since 1987):
-! Uses the identity x**y = exp(y*ln(x)) for performance 
+! Uses the identity x**y = exp(y*ln(x)) for performance
 ! (fewer (1/2) trancendental functions are required).
 !------------------------------------------------------------------------
 


### PR DESCRIPTION
Summary: Address remaining NorESM2.1 GitHub issues

Contributors: @gold2718, @DirkOlivie, @mvertens 

Reviewers: @mvertens

Purpose of changes:
-  Bug in ice delimiter (#110)
-  Aerosol dry deposition bug (#111)
-  Some outfld calls have a ncol / pcols mismatch (#112)
-  Remove preprocessorDefinitions.h (#117)

Github PR URL: https://github.com/NorESMhub/CAM/pull/119

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

- Fixed questionable and incorrect outfld calls
- Remove processorDefinitions.h SourceMods files
- Fix aerosol dry deposition computation (see Issue #111)
- Replace ice limiter in microphysics (see Issue #110)

test suite: aux_cam_noresm on Betzy:
- Expected baseline and nlcomp differences, plus one new test:
- FAIL ERP_Ln9.f09_f09_mtn14.NF1850frc2norbc_aer2014.betzy_intel.cam-outfrq9s BASELINE cam_cesm2_1_rel_05-Nor_v1.0.7
- FAIL ERP_Ln9.f09_f09_mtn14.NF1850frc2norbc.betzy_intel.cam-outfrq9s BASELINE cam_cesm2_1_rel_05-Nor_v1.0.7
- FAIL ERP_Ln9.f09_f09_mtn14.NFHISTnorpddmsbc.betzy_intel.cam-outfrq9s BASELINE cam_cesm2_1_rel_05-Nor_v1.0.7
- FAIL ERP_Ln9.f19_f19_mtn14.F2000climo.betzy_intel.cam-outfrq9s NLCOMP
- FAIL ERP_Ln9.f19_f19_mtn14.F2000climo.betzy_intel.cam-outfrq9s BASELINE cam_cesm2_1_rel_05-Nor_v1.0.7: ERROR BFAIL baseline directory '/cluster/shared/noresm/noresm_baselines/cam_cesm2_1_rel_05-Nor_v1.0.7/ERP_Ln9.f19_f19_mtn14.F2000climo.betzy_intel.cam-outfrq9s' does not exist
- FAIL ERP_Ln9.f19_f19_mtn14.NF1850norbc_aer2014.betzy_intel.cam-aerocom NLCOMP
- FAIL ERP_Ln9.f19_f19_mtn14.NF1850norbc_aer2014.betzy_intel.cam-aerocom BASELINE cam_cesm2_1_rel_05-Nor_v1.0.7
-  FAIL ERP_Ln9.f19_f19_mtn14.NF1850norbc_aer2014.betzy_intel.cam-outfrq9s BASELINE cam_cesm2_1_rel_05-Nor_v1.0.7
- FAIL ERP_Ln9.f19_f19_mtn14.NF1850norbc.betzy_intel.cam-outfrq9s BASELINE cam_cesm2_1_rel_05-Nor_v1.0.7
- FAIL SMS_D_Ln9.f19_f19_mtn14.NF1850norbc_aer2014.betzy_intel.cam-outfrq9s BASELINE cam_cesm2_1_rel_05-Nor_v1.0.7
- FAIL SMS_D_Ln9.f19_f19_mtn14.NF1850norbc.betzy_intel.cam-outfrq9s BASELINE cam_cesm2_1_rel_05-Nor_v1.0.7

closes #110 
closes #111 
closes #112 
closes #117 