### PR TITLE
cam_noresm2_1_v1.0.1: Fix problems in config_compsets

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -17,7 +17,7 @@
     LND  = [CLM45, CLM50, SLND]
     ICE  = [CICE, DICE, SICE]
     OCN  = [DOCN, ,AQUAP, SOCN]
-    ROF  = [RTM, SROF]
+    ROF  = [RTM, MOSART, SROF]
     GLC  = [CISM1, CISM2, SGLC]
     WAV  = [SWAV]
     BGC  = optional BGC scenario
@@ -37,22 +37,22 @@
   </help>
 
   <!-- ****************************** -->
-  <!-- CAM science supported compsets -->
+  <!-- CAM compsets -->
   <!-- ****************************** -->
 
   <compset>
     <alias>F2000climo</alias>
-    <lname>2000_CAM60_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>2000_CAM60_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FHIST</alias>
-    <lname>HIST_CAM60_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>HIST_CAM60_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FHIST_BGC</alias>
-    <lname>HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
 
@@ -94,327 +94,273 @@ SST and sea-ice boundary conditions com from standard observation-based data set
 
 (4) grids
 f09_f09 and f19_f19 :
-When using NorESM-derived boundary conditions, we have opted to use the same land-sea mask
-in the atmosphere-only as in the fully-coupled simulations.
+When using NorESM-derived boundary conditions, we have opted to use the same land-sea mask (mtn14)
 
-f19_19_mg17
-stanard CAM land-sea mask will be used when using this grid
   -->
 
   <compset>
     <alias>NF1850</alias>
-    <lname>1850_CAM60%PTAERO_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <lname>1850_CAM60%NORESM_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>NFHIST</alias>
-    <lname>HIST_CAM60%PTAERO_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <lname>HIST_CAM60%NORESM_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>NFHISTfsst</alias>
     <lname>HIST_CAM60%NORESM%FSST_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09_mg17"/>
   </compset>
 
   <compset>
     <alias>NFHISTfsstfrc2</alias>
     <lname>HIST_CAM60%NORESM%FSST%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09_mg17"/>
   </compset>
 
   <!-- fSST : evolving from observations ; upper-ocean DMS : present-day constant NorESM derived -->
   <compset>
     <alias>NFHISTnorpddmsbc</alias>
     <lname>HIST_CAM60%NORESM%NORPDDMSBC_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09_mg17"/>
-    <science_support grid="f19_f19_mg17"/>
   </compset>
 
   <!-- fSST : evolving from observations ; upper-ocean DMS : present-day constant NorESM derived ; nudged meteorology -->
   <compset>
     <alias>NFHISTnorpddmsbcsdyn</alias>
     <lname>HIST_CAM60%NORESM%NORPDDMSBC%SDYN_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09_mg17"/>
   </compset>
 
   <compset>
     <alias>NFHISTfrc2norpddmsbc</alias>
     <lname>HIST_CAM60%NORESM%NORPDDMSBC%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09_mg17"/>
-    <science_support grid="f19_f19_mg17"/>
   </compset>
 
   <!-- fSST : evolving NorESM derived ; DMS: evolving NorESM derived -->
   <compset>
     <alias>NFHISTnorbc</alias>
     <lname>HIST_CAM60%NORESM%NORBC_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFHISTnorbc_pintcf</alias>
     <lname>HIST_CAM60%NORESM%NORBC%PINTCF_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFHISTnorbc_piaer</alias>
     <lname>HIST_CAM60%NORESM%NORBC%PIAER_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <!-- constant pre-industrial NorESM derived ; DMS : constant pre-industrial NorESM derived -->
   <compset>
     <alias>NFHISTnorpibc</alias>
     <lname>HIST_CAM60%NORESM%NORPIBC_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFHISTnorpibc_ghgonly</alias>
     <lname>1850_CAM60%NORESM%NORPIBC%GHGONLY_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFHISTnorpibc_natonly</alias>
     <lname>1850_CAM60%NORESM%NORPIBC%NATONLY_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFHISTnorpibc_aeroxidonly</alias>
     <lname>1850_CAM60%NORESM%NORPIBC%AEROXIDONLY_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFHISTnorpibc_aeronly</alias>
     <lname>1850_CAM60%NORESM%NORPIBC%AERONLY_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFHISTnorpibc_oxidonly</alias>
     <lname>1850_CAM60%NORESM%NORPIBC%OXIDONLY_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFHISTnorpibc_ozoneonly</alias>
     <lname>1850_CAM60%NORESM%NORPIBC%OZONEONLY_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFHISTnorpibc_luonly</alias>
     <lname>1850_CAM60%NORESM%NORPIBC%LUONLY_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFSSP370frc2norbc</alias>
     <lname>SSP370_CAM60%NORESM%NORBC%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFSSP370frc2norbc_aerlow</alias>
     <lname>SSP370_CAM60%NORESM%NORBC%AERLOW%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFSSP245frc2norpibc</alias>
     <lname>SSP245_CAM60%NORESM%NORPIBC%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFSSP245frc2norpibc_ghgonly</alias>
     <lname>SSP245_CAM60%NORESM%NORPIBC%GHGONLY%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFSSP245frc2norpibc_natonly</alias>
     <lname>SSP245_CAM60%NORESM%NORPIBC%NATONLY%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFSSP245frc2norpibc_aeronly</alias>
     <lname>SSP245_CAM60%NORESM%NORPIBC%AERONLY%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NFSSP245frc2norpibc_aeroxidonly</alias>
     <lname>SSP245_CAM60%NORESM%NORPIBC%AEROXIDONLY%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF2000climo</alias>
-    <lname>2000_CAM60%PTAERO_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+    <lname>2000_CAM60%NORESM_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <!-- fSST : constant pre-industrial NorESM derived ; DMS : constant pre-industrial NorESM derived -->
   <compset>
     <alias>NF1850norbc</alias>
     <lname>1850_CAM60%NORESM%NORBC_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850frc2norbc</alias>
     <lname>1850_CAM60%NORESM%NORBC%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_4xco2</alias>
     <lname>1850_CAM60%NORESM%NORBC%4xCO2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850frc2norbc_4xco2</alias>
     <lname>1850_CAM60%NORESM%NORBC%FRC2%4xCO2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_2xco2</alias>
     <lname>1850_CAM60%NORESM%NORBC%2xCO2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_ghg2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%GHG2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_ghgnoh2o2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%GHGNOH2O2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_co22014</alias>
     <lname>1850_CAM60%NORESM%NORBC%CO22014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_n2o2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%N2O2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_ch42014</alias>
     <lname>1850_CAM60%NORESM%NORBC%CH42014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_ch4noh2o2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%CH4NOH2O2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_bc2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%BC2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_oc2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%OC2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_so22014</alias>
     <lname>1850_CAM60%NORESM%NORBC%SO22014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_aer2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%AER2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850frc2norbc_aer2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%AER2014%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_aeroxid2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%AEROXID2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850frc2norbc_aeroxid2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%AEROXID2014%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_ntcf2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%NTCF2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_anthro2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%ANTHRO2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_ghgozonelu2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%GHGOZONELU2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_so2oxid2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%SO2OXID2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_ozone2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%OZONE2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_h2o2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%H2O2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850norbc_oxid2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%OXID2014_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f19_f19"/>
   </compset>
 
   <compset>
     <alias>NF1850frc2norbc_oxid2014</alias>
     <lname>1850_CAM60%NORESM%NORBC%OXID2014%FRC2_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
-    <science_support grid="f09_f09"/>
   </compset>
 
   <!-- CAM simpler model compsets -->
@@ -422,23 +368,16 @@ stanard CAM land-sea mask will be used when using this grid
   <compset>
     <alias>FDABIP04</alias>
     <lname>2000_CAM%DABIP04_SLND_SICE_SOCN_SROF_SGLC_SWAV</lname>
-    <science_support grid="T42z30_T42_mg17"/>
-    <science_support grid="T85z30_T85_mg17"/>
-    <science_support grid="T85z60_T85_mg17"/>
   </compset>
 
   <compset>
     <alias>FSCAM</alias>
     <lname>2000_CAM60%SCAM_CLM50%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
-    <science_support grid="T42_T42"/>
   </compset>
 
   <compset>
     <alias>FHS94</alias>
     <lname>2000_CAM%HS94_SLND_SICE_SOCN_SROF_SGLC_SWAV</lname>
-    <science_support grid="T42z30_T42_mg17"/>
-    <science_support grid="T85z30_T85_mg17"/>
-    <science_support grid="T85z60_T85_mg17"/>
   </compset>
 
   <!-- CAM aquaplanet compsets -->
@@ -607,39 +546,11 @@ stanard CAM land-sea mask will be used when using this grid
 
   <compset>
     <alias>QSC6O</alias>
-    <lname>2000_CAM60%PTAERO_SLND_SICE_DOCN%SOMAQP_SROF_SGLC_SWAV</lname>
+    <lname>2000_CAM60%NORESM_SLND_SICE_DOCN%SOMAQP_SROF_SGLC_SWAV</lname>
   </compset>
-
-  <compset>
-    <alias>NFPTAERO</alias>
-    <lname>2000_CAM5%PTAEROUPD1_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</lname>
-  </compset>
-  <compset>
-    <alias>NFPTAERO60</alias>
-    <!--lname>2000_CAM60%PTAERO_CLM50%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</lname-->
-    <lname>2000_CAM60%PTAERO_CLM50%BGC_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
-  </compset>
-  <compset>
-    <alias>NFPTAERO60NC</alias>
-    <lname>2000_CAM54%PTAERO_CLM50%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</lname>
-  </compset>
-  <compset>
-    <alias>NFAMIPNUDGEPTAEROUPD1</alias>
-    <lname>2000_CAM5%NUDGEPTAEROUPD1_CLM45%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</lname>
-  </compset>
-  <compset>
-    <alias>NFAMIPNUDGEPTAERONCLB</alias>
-    <lname>2000_CAM54%NUDGEPTAERO_CLM50%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</lname>
-  </compset>
-  <compset>
-    <alias>NFAMIPNUDGEPTAEROCLB</alias>
-    <lname>2000_CAM60%NUDGEPTAERO_CLM50%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</lname>
-  </compset>
-
-  <!-- PORT compsets -->
 
   <!-- ****************************** -->
-  <!-- WACCM science supported compsets -->
+  <!-- WACCM compsets -->
   <!-- ****************************** -->
 
   <compset>
@@ -791,51 +702,29 @@ stanard CAM land-sea mask will be used when using this grid
 
     <entry id="RUN_TYPE">
       <values match="first">
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"     compset="HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"      >hybrid</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"     compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"      >hybrid</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%null_w%null_m%gx1v7"   compset="2000_CAM60%PTAERO_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV"             >hybrid</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v6"                 compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM1%NOEVOLVE_SWAV"      >hybrid</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v6"                 compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"      >hybrid</value>
-
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v7"                 compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM1%NOEVOLVE_SWAV"      >hybrid</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v7"                 compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"      >hybrid</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7" compset="HIST_CAM60%WC.*_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV" >hybrid</value>
+	      <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%null_w%null_m%tnx1v4" compset="2000_CAM60%NORESM_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV" >hybrid</value>
+	      <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_g%null_w%null_m%gx1v7"  compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV"        >hybrid</value>
       </values>
     </entry>
 
     <entry id="RUN_REFCASE">
       <values match="first">
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"     compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"      >b.e20.BHIST.f09_g17.20thC.297_01_v2</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"     compset="HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"      >b.e20.BHIST.f09_g17.20thC.297_01_v2</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%null_w%null_m%gx1v7"   compset="2000_CAM60%PTAERO_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV"             >b.e20.BHIST.f09_g17.20thC.297_01_v2</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v6"                 compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM1%NOEVOLVE_SWAV"      >b.e16.B1850_WW3.f09_g16.lang_redi_2hr_frz_chl.003</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v6"                 compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"      >b.e20.B1850.f09_g16.pi_control.all.123</value>
-
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v7"                 compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM1%NOEVOLVE_SWAV"      >b.e16.B1850_WW3.f09_g16.lang_redi_2hr_frz_chl.003</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v7"                 compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"      >b.e20.B1850.f09_g16.pi_control.all.123</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7" compset="HIST_CAM60%WC.*_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV" >b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.001</value>
+	      <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%null_w%null_m%tnx1v4" compset="2000_CAM60%NORESM_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV" >b.e20.BHIST.f09_g17.20thC.297_01_v2</value>
+	      <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_g%null_w%null_m%gx1v7"  compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV"        >b.e16.B1850_WW3.f09_g16.lang_redi_2hr_frz_chl.003</value>
       </values>
     </entry>
 
     <entry id="RUN_REFDATE">
       <values match="first">
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"     compset="HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"   >1979-01-01</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"     compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"   >2000-01-01</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%null_w%null_m%gx1v7"       compset="2000_CAM60%PTAERO_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV"      >2000-01-01</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v6"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM1%NOEVOLVE_SWAV">0097-01-01</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v6"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">0010-01-01</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v7"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM1%NOEVOLVE_SWAV">0097-01-01</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v7"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">0010-01-01</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7" compset="HIST_CAM60%WC.*_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">1950-01-01</value>
+	      <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%null_w%null_m%tnx1v4"  compset="2000_CAM60%NORESM_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV" >2000-01-01</value>
+	      <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_g%null_w%null_m%gx1v7"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV"        >0097-01-01</value>
       </values>
     </entry>
 
     <entry id="RUN_REFDIR">
       <values match="first">
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"     compset="HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"   >cesm2_init</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"     compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"   >cesm2_init</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%null_w%null_m%gx1v7"       compset="2000_CAM60%PTAERO_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV"      >cesm2_init</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7" compset="HIST_CAM60%WC.*_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">cesm2_init</value>
+	      <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%null_w%null_m%tnx1v4"  compset="2000_CAM60%NORESM_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV" >cesm2_init</value>
+	      <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_g%null_w%null_m%gx1v7"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV"        >cesm2_init</value>
       </values>
     </entry>
 

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -398,32 +398,22 @@ When using NorESM-derived boundary conditions, we have opted to use the same lan
 
   <compset>
     <alias>F2010climo</alias>
-    <lname>2010_CAM60_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>2010_CAM60_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>F1850</alias>
-    <lname>1850_CAM60_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>FSPCAMM</alias>
-    <lname>2000_CAM%SPCAMM_CLM50%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>FSPCAMS</alias>
-    <lname>2000_CAM%SPCAMS_CLM50%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</lname>
+    <lname>1850_CAM60_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>F1850_BDRD</alias>
-    <lname>1850_CAM60_CLM50%BGC_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD</lname>
+    <lname>1850_CAM60_CLM50%BGC_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>FHIST_BDRD</alias>
-    <lname>HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD</lname>
+    <lname>HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV_BGC%BDRD</lname>
   </compset>
 
   <!-- CAM simpler model compsets -->
@@ -469,42 +459,29 @@ When using NorESM-derived boundary conditions, we have opted to use the same lan
   <!-- CAM untested compsets -->
   <!-- ****************************** -->
 
-  <!-- spcam untested compsets -->
-
-  <compset>
-    <alias>FSPCAMCLBS</alias>
-    <lname>2000_CAM%SPCAMCLBS_CLM50%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>FSPCAMCLBM</alias>
-    <lname>2000_CAM%SPCAMCLBM_CLM50%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV</lname>
-  </compset>
-
-
   <!-- cam-chem untested compsets -->
 
   <compset>
     <alias>FC2000climo</alias>
-    <lname>2000_CAM60%CCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>2000_CAM60%CCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FC2010climo</alias>
-    <lname>2010_CAM60%CCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>2010_CAM60%CCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FCHIST</alias>
-    <lname>HIST_CAM60%CCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>HIST_CAM60%CCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
   <compset>
     <alias>FCvbsxHIST</alias>
-    <lname>HIST_CAM60%CVBSX_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>HIST_CAM60%CVBSX_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
   <compset>
     <alias>FCfireHIST</alias>
-    <lname>HIST_CAM60%CFIRE_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>HIST_CAM60%CFIRE_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -555,37 +532,37 @@ When using NorESM-derived boundary conditions, we have opted to use the same lan
 
   <compset>
     <alias>FWHIST</alias>
-    <lname>HIST_CAM60%WCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>HIST_CAM60%WCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FWHIST_BGC</alias>
-    <lname>HIST_CAM60%WCTS_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>HIST_CAM60%WCTS_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FWsc2010climo</alias>
-    <lname>2010_CAM60%WCSC_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>2010_CAM60%WCSC_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FWsc2000climo</alias>
-    <lname>2000_CAM60%WCSC_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>2000_CAM60%WCSC_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FWsc1850</alias>
-    <lname>1850_CAM60%WCSC_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>1850_CAM60%WCSC_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FWscHIST</alias>
-    <lname>HIST_CAM60%WCSC_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>HIST_CAM60%WCSC_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FW1850</alias>
-    <lname>1850_CAM60%WCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>1850_CAM60%WCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <!-- ****************************** -->
@@ -594,12 +571,12 @@ When using NorESM-derived boundary conditions, we have opted to use the same lan
 
   <compset>
     <alias>FW2000climo</alias>
-    <lname>2000_CAM60%WCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>2000_CAM60%WCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>FW2010climo</alias>
-    <lname>2010_CAM60%WCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>2010_CAM60%WCTS_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -614,7 +591,7 @@ When using NorESM-derived boundary conditions, we have opted to use the same lan
 
   <compset>
     <alias>FWmaHIST</alias>
-    <lname>HIST_CAM60%WCCM_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>HIST_CAM60%WCCM_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -624,7 +601,7 @@ When using NorESM-derived boundary conditions, we have opted to use the same lan
 
   <compset>
     <alias>FWmadHIST</alias>
-    <lname>HIST_CAM60%WCMD_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>HIST_CAM60%WCMD_CLM50%SP_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>


### PR DESCRIPTION
Fix problems found in config_compsets

Summary: This fixes problems in config_compsets that were not caught in the initial testing of the release code

Contributors: @mvertens

Reviewers: @gold2718 

Purpose of changes: Remove science support from NorESM2 supported compsets (#120) 

Github PR URL: https://github.com/NorESMhub/CAM/pull/123

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes:  None

Details:
-  the %PTAERO in compset names was replaced with %NORESM
- compsets that had PTAERO in the alias name were removed
```
NFPTAERO              : 2000_CAM5%PTAEROUPD1_CLM40%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV
NFPTAERO60            : 2000_CAM60%PTAERO_CLM50%BGC_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV
NFPTAERO60NC          : 2000_CAM54%PTAERO_CLM50%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV
NFAMIPNUDGEPTAEROUPD1 : 2000_CAM5%NUDGEPTAEROUPD1_CLM45%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV
NFAMIPNUDGEPTAERONCLB : 2000_CAM54%NUDGEPTAERO_CLM50%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV
NFAMIPNUDGEPTAEROCLB  : 2000_CAM60%NUDGEPTAERO_CLM50%SP_CICE%PRES_DOCN%DOM_RTM_SGLC_SWAV
```
- CISM%NOEVOLVE in the compset name was replace with SGLC
- the science support tags were removed for all compsets
- RUN_REFDATE,  RUN_TYPE, RUN_REFCASE and REFDATE were simlified to reflect the new default for f19_f19 and f09_f09 to have the mtn14 mask

Testing: 
verified that the following create_newcase commands gave the same results as before these changes
./create_newcase --compset NF1850norbc --res f19_f19_mtn14
./create_newcase --compset N1850 --res f19_tn14 

closes #120 