### PR TITLE
increase char length for cpp path

### DIFF
--- a/chem_proc/src/cam_chempp/mozpp.main.f
+++ b/chem_proc/src/cam_chempp/mozpp.main.f
@@ -71,7 +71,7 @@
       character(len=580) :: command, cpp_command
       character(len=256) :: errcom, filout, filin
       character(len=64)  :: oper_flpth
-      character(len=64)  :: cpp_dir, cpp_opts
+      character(len=256)  :: cpp_dir, cpp_opts
       character(len=64)  :: wrk_dir
       character(len=64)  :: tar_flnm
       character(len=64)  :: subfile


### PR DESCRIPTION
Summary: Increase the char length for path to compiler in chem_pp code

Contributors: @annlew, @sarambl

Reviewers: @gold2718

Purpose of changes: Avoid chemistry preprocessor failure at compilation when path to compiler exceeds 64 characters

Github PR URL: 

Changes made to build system: Only chemistry preprocessor when usr_mech_infile is specified in env_build.xml

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Change the char length for cpp path from 64 to 256 in chem_pp code.

Test: SMS allactive test with grid = f19_tn14 and compset=NF2000climo with a testmod (mychem) to run the chemistry preprocessor. Fails with current HEAD of noresm2_3_develop, passes with this PR branch.

Issues addressed by this PR:
cam_chempp issue with usr_mech_infile when path to compiler is too long (https://github.com/NorESMhub/CAM/issues/160)

addresses https://github.com/NorESMhub/CAM/issues/160