### PR TITLE
Parameterisation of secondary ice formation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ src/physics/silhs
 # Ignore compiled python
 buildnmlc
 buildcppc
+*.pyc
 
 # Ignore editor temporaries and backups
 *~

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -3038,9 +3038,26 @@ if ($cfg->get('microphys') =~ /^mg/) {
     add_default($nl, 'micro_mg_berg_eff_factor');
     add_default($nl, 'nucleate_ice_incloud');
     add_default($nl, 'nucleate_ice_strat');
+    add_default($nl, 'micro_mg_do_cldice');
+    add_default($nl, 'micro_mg_do_cldliq');
 
     # For CESM2, the decision was made to set micro_do_sb_physics to false
     add_default($nl, 'micro_do_sb_physics', 'val'=>'.false.');
+
+    # Check usage of random forests secondary ice production
+    add_default($nl, 'rafsip_on');
+    if ($nl->get_value('rafsip_on') =~ m/$TRUE/io) {
+        if ($nl->get_value('micro_mg_do_cldice') =~ m/$FALSE/io) {
+            # Generate an error since both of these variables would have to be
+            #    set manually for this condition
+            die "$ProgName - Error: Cannot set rafsip_on = .true. if micro_mg_do_cldice = .false.\n";
+        }
+        add_default($nl, 'forestfileALL');
+        add_default($nl, 'forestfileBRDS');
+        add_default($nl, 'forestfileBRHM');
+        add_default($nl, 'forestfileBR');
+        add_default($nl, 'forestfileBRwarm');
+    }
 }
 
 # Ice nucleation options

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1229,6 +1229,9 @@
 <micro_mg_berg_eff_factor                  >  1.0D0    </micro_mg_berg_eff_factor>
 <micro_mg_berg_eff_factor microphys="mg2"  >  1.0D0    </micro_mg_berg_eff_factor>
 
+<micro_mg_do_cldice>.true.</micro_mg_do_cldice>
+<micro_mg_do_cldliq>.true.</micro_mg_do_cldliq>
+
 <!-- djlo commented out as not used for MAM4-->
 <!--micro_do_sb_physics chem="trop_mam_oslo"> .true. </micro_do_sb_physics-->
 
@@ -1263,6 +1266,14 @@
 <nucleate_ice_incloud    phys="cam6" >.false.</nucleate_ice_incloud>
 <nucleate_ice_strat                  >1.0D0</nucleate_ice_strat>
 <nucleate_ice_use_troplev            >.true.</nucleate_ice_use_troplev>
+
+<!-- Secondary ice production -->
+<rafsip_on>.false.</rafsip_on>
+<forestfileALL>atm/cam/RaFSIP/forestALL.txt</forestfileALL>
+<forestfileBRDS>atm/cam/RaFSIP/forestBRDS.txt</forestfileBRDS>
+<forestfileBRHM>atm/cam/RaFSIP/forestBRHM.txt</forestfileBRHM>
+<forestfileBR>atm/cam/RaFSIP/forestBR.txt</forestfileBR>
+<forestfileBRwarm>atm/cam/RaFSIP/forestBRwarm.txt</forestfileBRwarm>
 
 <chem_use_chemtrop>.true.</chem_use_chemtrop>
 

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -2708,8 +2708,67 @@ level from 100 to 125 hPa applied only in the polar regions (false).
 Default: .true.
 </entry>
 
+<!-- Secondary ice production -->
+<entry id="rafsip_on" type="logical" category="microphys"
+       group="sec_ice_nl" valid_values="" >
+  If .true., compute secondary ice production using random forests method.
+  Default: .true.
+</entry>
 
+<entry id="forestfileALL" type="char*256" input_pathname="abs" category="microphys"
+       group="sec_ice_nl" valid_values="" >
+  ML parameters for the forestALL RFR model.
+  Georgakaki, P., &amp; Nenes, A. (2024).
+  RaFSIP: Parameterizing ice multiplication in models using a machine learning
+  approach. Journal of Advances in Modeling Earth Systems, 16,
+  e2023MS003923.
+  https://doi.org/10.1029/2023MS003923
+  Default: None
+</entry>
 
+<entry id="forestfileBRDS" type="char*256" input_pathname="abs" category="microphys"
+       group="sec_ice_nl" valid_values="" >
+  ML parameters for the forestBRDS RFR model.
+  Georgakaki, P., &amp; Nenes, A. (2024).
+  RaFSIP: Parameterizing ice multiplication in models using a machine learning
+  approach. Journal of Advances in Modeling Earth Systems, 16,
+  e2023MS003923.
+  https://doi.org/10.1029/2023MS003923
+  Default: None
+</entry>
+
+<entry id="forestfileBRHM" type="char*256" input_pathname="abs" category="microphys"
+       group="sec_ice_nl" valid_values="" >
+  ML parameters for the forestBRHM RFR model.
+  Georgakaki, P., &amp; Nenes, A. (2024).
+  RaFSIP: Parameterizing ice multiplication in models using a machine learning
+  approach. Journal of Advances in Modeling Earth Systems, 16,
+  e2023MS003923.
+  https://doi.org/10.1029/2023MS003923
+  Default: None
+</entry>
+
+<entry id="forestfileBR" type="char*256" input_pathname="abs" category="microphys"
+       group="sec_ice_nl" valid_values="" >
+  ML parameters for the forestBR RFR model.
+  Georgakaki, P., &amp; Nenes, A. (2024).
+  RaFSIP: Parameterizing ice multiplication in models using a machine learning
+  approach. Journal of Advances in Modeling Earth Systems, 16,
+  e2023MS003923.
+  https://doi.org/10.1029/2023MS003923
+  Default: None
+</entry>
+
+<entry id="forestfileBRwarm" type="char*256" input_pathname="abs" category="microphys"
+       group="sec_ice_nl" valid_values="" >
+  ML parameters for the forestBRwarm RFR model.
+  Georgakaki, P., &amp; Nenes, A. (2024).
+  RaFSIP: Parameterizing ice multiplication in models using a machine learning
+  approach. Journal of Advances in Modeling Earth Systems, 16,
+  e2023MS003923.
+  https://doi.org/10.1029/2023MS003923
+  Default: None
+</entry>
 
 <!-- hkconv Moist Convection -->
 <entry id="hkconv_cmftau" type="real" category="conv"

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -41,6 +41,16 @@
     </options>
   </test>
 
+  <test compset="NF1850norbc" grid="f19_f19_mtn14" name="ERP_Ln9" testmods="cam/secice">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+    </machines>
+    <options>
+      <option name="comment">Test secondary ice scheme</option>
+      <option name="wallclock">00:10:00</option>
+    </options>
+  </test>
+
   <test compset="NF1850frc2norbc" grid="f09_f09_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>

--- a/cime_config/testdefs/testmods_dirs/cam/secice/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/secice/shell_commands
@@ -1,0 +1,2 @@
+./xmlchange ROF_NCPL=\$ATM_NCPL
+./xmlchange GLC_NCPL=\$ATM_NCPL

--- a/cime_config/testdefs/testmods_dirs/cam/secice/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/secice/user_nl_cam
@@ -1,0 +1,6 @@
+mfilt = 1,1,1,1,1,1
+ndens = 1,1,1,1,1,1
+nhtfrq = 9,9,9,9,9,9
+inithist = 'ENDOFRUN'
+
+rafsip_on = .true.

--- a/cime_config/testdefs/testmods_dirs/cam/secice/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/cam/secice/user_nl_clm
@@ -1,0 +1,26 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes below in the form of
+! namelist_var = new_namelist_value
+!
+! Include namelist variables for drv_flds_in ONLY if -megan and/or -drydep options
+! are set in the CLM_NAMELIST_OPTS env variable.
+!
+! EXCEPTIONS:
+! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting
+! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting
+! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting
+! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting
+! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting
+! Set irrigate           by the CLM_BLDNML_OPTS -irrig           setting
+! Set dtime              with L_NCPL                             option
+! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options
+! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases
+!                        (includes $inst_string for multi-ensemble cases)
+! Set glc_grid           with CISM_GRID                          option
+! Set glc_smb            with GLC_SMB                            option
+! Set maxpatch_glcmec    with GLC_NEC                            option
+! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable
+!----------------------------------------------------------------------------------
+hist_nhtfrq = 9
+hist_mfilt  = 1
+hist_ndens  = 1

--- a/src/NorESM/micro_mg2_0.F90
+++ b/src/NorESM/micro_mg2_0.F90
@@ -133,6 +133,9 @@ use micro_mg_utils, only: &
      mi0, &
      rising_factorial
 
+!RaFSIP GS/PG
+use module_random_forests
+
 implicit none
 private
 save
@@ -227,6 +230,7 @@ real(r8)           :: micro_mg_berg_eff_factor     ! berg efficiency factor
 
 logical  :: allow_sed_supersat ! Allow supersaturated conditions after sedimentation loop
 logical  :: do_sb_physics ! do SB 2001 autoconversion or accretion physics
+logical  :: rafsip_on
 
 !===============================================================================
 contains
@@ -345,6 +349,45 @@ subroutine micro_mg_init( &
 
   xxlv_squared=xxlv**2
   xxls_squared=xxls**2
+  
+  rafsip_on=.false.
+  if (rafsip_on) then
+!-----------------------------------------------------------------------------------
+! RaFSIP: INITIALIZE THE RANDOM FOREST PARAMETERS CALLING THE SUBROUTINES THAT
+!ARE DEFINED IN THE MODULE_RANDOM_FOREST.F FILE !GS/PG                  
+!----------------------------------------------------------------------------------
+
+     IF (FIRST_RAFSIP) THEN
+
+        forestfileALL  = '/cluster/shared/noresm/inputdata/atm/cam/RaFSIP/forestALL.txt'
+        forestfileBR   = '/cluster/shared/noresm/inputdata/atm/cam/RaFSIP/forestBR.txt'
+        forestfileBRDS = '/cluster/shared/noresm/inputdata/atm/cam/RaFSIP/forestBRDS.txt'
+        forestfileBRHM = '/cluster/shared/noresm/inputdata/atm/cam/RaFSIP/forestBRHM.txt'
+        forestfileBRwarm = '/cluster/shared/noresm/inputdata/atm/cam/RaFSIP/forestBRwarm.txt'
+
+
+        CALL forestbrhm(jbt,max_nodes1,leftchild1,rightchild1,splitfeat1, &
+                               nrnodes1,thresh1,out11,out12,out13)
+
+        CALL forestbr(jbt,max_nodes2,leftchild2,rightchild2,splitfeat2, &
+                               nrnodes2,thresh2,out21)
+
+        CALL forestall(jbt,max_nodes3,leftchild3,rightchild3,splitfeat3, &
+                               nrnodes3,thresh3,out31,out32,out33,out34,out35)
+
+        CALL forestbrds(jbt,max_nodes4,leftchild4,rightchild4,splitfeat4, &
+                               nrnodes4,thresh4,out41,out42,out43)
+
+        CALL forestbrwarm(jbt,max_nodes5,leftchild5,rightchild5,splitfeat5, &
+                               nrnodes5,thresh5,out51)
+
+         
+        FIRST_RAFSIP = .FALSE.
+
+
+     ENDIF
+  end if     
+
 
 end subroutine micro_mg_init
 
@@ -801,6 +844,7 @@ subroutine micro_mg_tend ( &
 
   ! relative humidity
   real(r8) :: relhum(mgncol,nlev)
+  real(r8) :: relhumi(mgncol,nlev)
 
   ! parameters for cloud water and cloud ice sedimentation calculations
   real(r8) :: fc(mgncol,nlev)
@@ -836,6 +880,24 @@ subroutine micro_mg_tend ( &
   real(r8) :: faltndns
 
   real(r8) :: rainrt(mgncol,nlev)     ! rain rate for reflectivity calculation
+
+  ! RaFSIP additional parameters ! GS/PG
+
+  !Inputs to SIP parameterization
+  real(r8) ::  IWC(mgncol,nlev)       ! TOTAL ICE WATER CONTENT IN KG/KG INPUT TO RaFSIP 
+  real(r8) ::  RIMC(mgncol,nlev)      ! TOTAL CLOUD DROPLET RIMING IN KG/KG/S INPUT TO RaFSIP
+  real(r8) ::  RIMR(mgncol,nlev)      ! TOTAL RAINDROP RIMING IN KG/KG/S INPUT TO RaFSIP
+  real(r8) ::  TEMPK(mgncol,nlev)     ! TEMPERATURE IN K INPUT TO RaFSIP
+  real(r8) ::  RHI(mgncol,nlev)       ! RELATIVE HUMIDITY WRT ICE INPUT TO RaFSIP
+  real(r8) ::  LWC(mgncol,nlev)       ! TOTAL LIQUID WATER CONTENT IN KG/KG INPUT TO RaFSIP
+  !Outputs
+  real(r8) ::  BR_RATE(mgncol,nlev)   ! SIP RATE DUE TO COLLISIONAL BREAK-UP
+  real(r8) ::  DS_RATE(mgncol,nlev)   ! SIP RATE DUE TO DROPLET-SHATTERING
+  real(r8) ::  HM_RATE(mgncol,nlev)   ! SIP RATE DUE TO HALLETT-MOSSOP
+  real(r8) ::  SIP_RATE(mgncol,nlev)  ! TOTAL SIP rate predicted by the RaFSIP (kg-1 s-1)
+  real(r8) ::  QIRSIP(mgncol,nlev)    ! MASS TRASFERRED FROM RAINDROPS TO CLOUD ICE DUE TO HM OR DS
+  real(r8) ::  QICSIP(mgncol,nlev)    ! MASS TRASFERRED FROM CLOUD DROPLETS TO CLOUD ICE DUE TO THE DS
+
 
   ! dummy variables
   real(r8) :: dum
@@ -874,6 +936,17 @@ subroutine micro_mg_tend ( &
   ! Varaibles to scale fall velocity between small and regular ice regimes.
   real(r8) :: irad
   real(r8) :: ifrac
+
+!  RaFSIP: dummy variables used to define the inputs/features and outputs/targets of the RaFSIP parameterization !GS/PG
+  real(r8) :: IWCRF1,RIMCRF1,TEMPRF1,RHIRF1,RIMRRF1,LWCRF1
+  real(r8) :: IWCRF2, RIMCRF2, TEMPRF2, RHIRF2, LWCRF2
+  real(r8) :: IWCRF3,RIMCRF3,TEMPRF3,RHIRF3,RIMRRF3,LWCRF3
+  real(r8) :: IWCRF4, RIMCRF4, TEMPRF4, RHIRF4, LWCRF4
+  real(r8) :: IWCRF5, RIMCRF5, TEMPRF5, RHIRF5, LWCRF5
+  real(r8) :: FEATURES5(MDIM5),FEATURES6(MDIM6)
+  real(r8) :: YPRED1,YPRED2,YPRED3,YPRED4,YPRED5
+
+
 
   !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
@@ -979,6 +1052,9 @@ subroutine micro_mg_tend ( &
   end do
 
   relhum = q / max(qvl, qsmall)
+  if (rafsip_on) then
+     relhumi = q / max(qvi, qsmall)
+  end if
 
   !===============================================
 
@@ -1162,6 +1238,60 @@ subroutine micro_mg_tend ( &
   ncai = 0._r8
 
   nfice = 0._r8
+
+! RaFSIP Inputs to the 4 RaFSIP models GS/PG
+  IWCRF1=0._r8
+  LWCRF1=0._r8
+  RHIRF1=0._r8
+  TEMPRF1=0._r8
+  RIMCRF1=0._r8
+  RIMRRF1=0._r8
+  IWCRF2=0._r8
+  LWCRF2=0._r8
+  RHIRF2=0._r8
+  TEMPRF2=0._r8
+  RIMCRF2=0._r8
+  IWCRF3=0._r8
+  RHIRF3=0._r8
+  TEMPRF3=0._r8
+  RIMCRF3=0._r8
+  RIMRRF3=0._r8
+  LWCRF3=0._r8
+  IWCRF4=0._r8
+  LWCRF4=0._r8
+  RHIRF4=0._r8
+  TEMPRF4=0._r8
+  RIMCRF4=0._r8
+  IWCRF5=0._r8
+  LWCRF5=0._r8
+  RHIRF5=0._r8
+  TEMPRF5=0._r8
+  RIMCRF5=0._r8
+ !All inputs combined into an 1D array
+  FEATURES5(:)=0._r8
+  FEATURES6(:)=0._r8
+ !The predictions of the RaFSIP model
+  YPRED1=0._r8
+  YPRED2=0._r8
+  YPRED3=0._r8
+  YPRED4=0._r8
+  YPRED5=0._r8
+
+ ! RaFSIP zero process rates
+  IWC=0._r8
+  RIMR=0._r8
+  LWC=0._r8
+  RIMC=0._r8
+  TEMPK=0._r8
+  RHI=0._r8
+  BR_RATE=0._r8
+  DS_RATE=0._r8
+  HM_RATE=0._r8
+  SIP_RATE=0._r8
+  QIRSIP=0._r8
+  QICSIP=0._r8
+
+
 
   !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
   ! droplet activation
@@ -1570,13 +1700,17 @@ subroutine micro_mg_tend ( &
      call accrete_cloud_water_snow(t(:,k), rho(:,k), asn(:,k), uns(:,k), mu(:,k), &
           qcic(1:mgncol,k), ncic(:,k), qsic(:,k), pgam(:,k), lamc(:,k), lams(:,k), n0s(:,k), &
           psacws(:,k), npsacws(:,k), mgncol)
-
-     if (do_cldice) then
-        call secondary_ice_production(t(:,k), psacws(:,k), msacwi(:,k), nsacwi(:,k), mgncol)
-     else
-        nsacwi(:,k) = 0.0_r8
-        msacwi(:,k) = 0.0_r8
-     end if
+        if (.NOT.rafsip_on) then
+           if (do_cldice) then
+              call secondary_ice_production(t(:,k), psacws(:,k), msacwi(:,k), nsacwi(:,k), mgncol)
+           else
+              nsacwi(:,k) = 0.0_r8
+              msacwi(:,k) = 0.0_r8
+           end if
+        else
+           nsacwi(:,k) = 0.0_r8
+           msacwi(:,k) = 0.0_r8
+        end if
 
      call accrete_rain_snow(t(:,k), rho(:,k), umr(:,k), ums(:,k), unr(:,k), uns(:,k), &
           qric(:,k), qsic(:,k), lamr(:,k), n0r(:,k), lams(:,k), n0s(:,k), &
@@ -1636,6 +1770,240 @@ subroutine micro_mg_tend ( &
         !in fact, nothing in this entire file makes nsubc nonzero.
         nsubc(:,k) = 0._r8
 
+
+
+        IF (rafsip_on) THEN
+
+           DO i=1,mgncol
+
+      !! First we define all the useful parameters that will be used as inputs to the parameterization
+      !The total ice water content in kg/kg
+              IWC(i,k) = qiic(i,k)+qsic(i,k)
+      !The total amount of cloud droplets rimed onto ice particles in kg/kg/s
+              RIMC(i,k) = psacws(i,k)
+      !The total amount of raindrops rimed onto ice particles in kg/kg/s
+              RIMR(i,k) = pracs(i,k)
+      !Ambient temperature in K
+              TEMPK(i,k) = t(i,k)
+      !Relative humidity with respect to ice
+              RHI(i,k) = relhumi(i,k)
+      !The total liquid water content in kg/kg
+              LWC(i,k) = qcic(i,k)+qric(i,k)
+
+
+      !Lower bounds
+              IF (RIMC(i,k).GT.0._r8.AND.IWC(i,k).GT.0._r8.AND.LWC(i,k).GT.0._r8.AND.RHI(i,k).GT.0._r8) THEN
+
+      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ! IF WE ARE WITHIN THE HALLETT-MOSSOP TEMPERATURE RANGE                   
+      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 IF (t(i,k).LT.270.15_r8.AND.t(i,k).GE.265.15_r8) THEN
+
+         !Activation of all secondary ice production processes within the HM
+         !temperature range, in the presence of rimed raindrops: forestALL
+
+                    IF (RIMR(i,k).GT.0._r8) THEN
+                       IWCRF1 = LOG10(IWC(i,k))
+                       RIMCRF1 = LOG10(RIMC(i,k))
+                       RIMRRF1 = LOG10(RIMR(i,k))
+                       TEMPRF1 = LOG10(TEMPK(i,k))
+                       RHIRF1 = LOG10(RHI(i,k))
+                       LWCRF1 = LOG10(LWC(i,k))
+
+            !! Combine all features into one vector
+                       FEATURES6(:) = (/ IWCRF1,RIMCRF1,TEMPRF1,RHIRF1,RIMRRF1,LWCRF1 /)
+!            PRINT*, "FEATURESALL=",FEATURES6            
+
+            !This subroutine reads the 6 inputs and gives 5 predictions for
+            !the SIP rates due to BR (BR_RATE), HM (HM_RATE) and DS (DS_RATE),
+            !as well as the mass of cloud droplets (QICSIP) and raindrops (QIRSIP)
+            !rimed onto the ice particle that will be transferred to the cloud ice category.
+
+                       CALL runforestmulti(mdim6,max_nodes3,jbt,features6,ypred1,ypred2,ypred3,ypred4,ypred5, &
+                            & leftchild3,rightchild3,splitfeat3,thresh3,out31,out32,out33,out34,out35)
+
+                       BR_RATE(i,k) = 10._r8**(ypred1)
+                       BR_RATE(i,k) = MAX(BR_RATE(i,k),0._r8)
+
+                       HM_RATE(i,k) = 10._r8**(ypred2)
+                       HM_RATE(i,k) = MAX(HM_RATE(i,k),0._r8)
+
+                       DS_RATE(i,k) = 10._r8**(ypred3)
+                       DS_RATE(i,k) = MAX(DS_RATE(i,k),0._r8)
+
+              !! Mass transfer from cloud droplets/raindrops to cloud ice if HM_RATE>0 and/or DS_RATE>0
+                       IF (HM_RATE(i,k).GT.0._r8) THEN
+                          QICSIP(i,k) = 10._r8**(ypred4)
+                          QICSIP(i,k) = MIN(QICSIP(i,k),0.01_r8*RIMC(i,k))  !RIMC=PSACWS, only max 1% of the rimed mass can be used for SIP
+                          QICSIP(i,k) = MAX(QICSIP(i,k),0._r8)
+               !Remove the mass of rimed cloud droplets that is involved in SIP
+                          PSACWS(i,k) = PSACWS(i,k) - QICSIP(i,k)
+                       ENDIF !MASS TRANSFER
+
+                       IF (HM_RATE(i,k).GT.0._r8.OR.DS_RATE(i,k).GT.0._r8) THEN
+                          QIRSIP(i,k) = 10._r8**(ypred5)
+                          QIRSIP(i,k) = MIN(QIRSIP(i,k),0.01_r8*RIMR(i,k))  !RIMR=PRACS, only max 1% of the rimed mass can be used for SIP
+                          QIRSIP(i,k) = MAX(QIRSIP(i,k),0._r8)
+               !Remove the mass of rimed raindrops that is involved in SIP
+                          PRACS(i,k) = PRACS(i,k) - QIRSIP(i,k)
+                       ENDIF !MASS TRANSFER
+
+
+         !Activation of the collisional break-up and the hallett-mossop process
+         !if temperature is  between -8<=T<-3 C, in the absence of rimed raindrops: forestbrhm
+
+                    ELSE
+
+                       IWCRF2 = LOG10(IWC(i,k))
+                       RIMCRF2 = LOG10(RIMC(i,k))
+                       LWCRF2 = LOG10(LWC(i,k))
+                       TEMPRF2 = LOG10(TEMPK(i,k))
+                       RHIRF2 = LOG10(RHI(i,k))
+
+             !! Combine all features into one vector
+                       FEATURES5(:) = (/ IWCRF2, RIMCRF2, TEMPRF2, RHIRF2, LWCRF2 /)
+!             PRINT*, "FEATURESBRHM",FEATURES5
+
+          !This subroutine reads the 5 inputs and gives 3 predictions for the
+          !SIP rates due to BR (BR_RATE)  and HM (HM_RATE), as well as
+          !the mass of cloud droplets rimed onto the ice particle that will be
+          !transferred to the cloud ice category (QICSIP).
+
+                       CALL runforestriv(mdim5,max_nodes1,jbt,features5,ypred1,ypred2,ypred3,&
+                            & leftchild1,rightchild1,splitfeat1,thresh1,out11,out12,out13)
+ 
+                       BR_RATE(i,k) = 10._r8**(ypred1)
+                       BR_RATE(i,k) = MAX(BR_RATE(i,k),0._r8)
+
+                       HM_RATE(i,k) = 10._r8**(ypred2)
+                       HM_RATE(i,k) = MAX(HM_RATE(i,k),0._r8)
+
+             !! Mass transfer from cloud droplets to cloud ice if HM_RATE>0
+                       IF (HM_RATE(i,k).GT.0._r8) THEN
+                          QICSIP(i,k) = 10._r8**(ypred3)
+                          QICSIP(i,k) = MIN(QICSIP(i,k),0.01_r8*RIMC(i,k))  !RIMC=PSACWS, only max 1% of the rimed mass can be used for SIP
+                          QICSIP(i,k) = MAX(QICSIP(i,k),0._r8)
+               !Remove the mass of rimed cloud droplets that is involved in SIP
+                          PSACWS(i,k) = PSACWS(i,k) - QICSIP(i,k)
+                       ENDIF !Mass transfer
+
+
+                    ENDIF  !RIMR>0...
+
+         
+      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ! FOR LOWER TEMPERATURES BETWEEN -20 AND -8 C
+      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 ELSEIF (t(i,k).LT.265.15_r8.AND.t(i,k).GE.253.15_r8) THEN
+
+        !Activation of the collisional break-up and the droplet shattering
+        !process in the presence of rimed raidrops: forestbrds
+
+                    IF (RIMR(i,k).GT.0._r8) THEN
+                       IWCRF3 = LOG10(IWC(i,k))
+                       RIMCRF3 = LOG10(RIMC(i,k))
+                       RIMRRF3 = LOG10(RIMR(i,k))
+                       TEMPRF3 = LOG10(TEMPK(i,k))
+                       RHIRF3 = LOG10(RHI(i,k))
+                       LWCRF3 = LOG10(LWC(i,k))
+
+             !! Combine all features into one vector
+                       FEATURES6(:) = (/ IWCRF3,RIMCRF3,TEMPRF3,RHIRF3,RIMRRF3,LWCRF3/)
+!             PRINT*, "FEATURESBRDS",FEATURES6
+
+          !This subroutine reads the 6 inputs and gives 3 predictions for the
+          !SIP rates due to BR (BR_RATE)  and DS (DS_RATE), as well as
+          !the mass of raindrops rimed onto the ice particle that will be
+          !transferred to the cloud ice category (QIRSIP).
+
+                       CALL runforestriv(mdim6,max_nodes4,jbt,features6,ypred1,ypred2,ypred3, &
+                            & leftchild4,rightchild4,splitfeat4,thresh4,out41,out42,out43)
+
+                       BR_RATE(i,k) = 10._r8**(ypred1)
+                       BR_RATE(i,k) = MAX(BR_RATE(i,k),0._r8)
+                       
+                       DS_RATE(i,k) = 10._r8**(ypred2)
+                       DS_RATE(i,k) = MAX(DS_RATE(i,k),0._r8)
+
+             !! Mass transfer from cloud droplets/raindrops to cloud ice if HM_RATE>0 and RIMC,RIMR>0
+                       IF (DS_RATE(i,k).GT.0._r8) THEN
+                          QIRSIP(i,k) = 10._r8**(ypred3)
+                          QIRSIP(i,k) = MIN(QIRSIP(i,k),0.01_r8*RIMR(i,k))  !RIMR=PRACS, only max 1% of the rimed mass can be used for SIP
+                          QIRSIP(i,k) = MAX(QIRSIP(i,k),0._r8)
+               !Remove the mass of rimed raindrops that is involved in SIP
+                          PRACS(i,k) = PRACS(i,k) - QIRSIP(i,k)
+                       ENDIF !Mass transfer
+
+         !Activation of the collisional break-up process when temperature is below
+         !the HM range, in the absence of raidrops: forestbr
+                    ELSE
+
+                       IWCRF4 = LOG10(IWC(i,k))
+                       RIMCRF4 = LOG10(RIMC(i,k))
+                       TEMPRF4 = LOG10(TEMPK(i,k))
+                       RHIRF4 = LOG10(RHI(i,k))
+                       LWCRF4 = LOG10(LWC(i,k))
+                       
+             !! Combine all features into one vector
+                       FEATURES5(:) = (/ IWCRF4, RIMCRF4, TEMPRF4, RHIRF4, LWCRF4 /)
+!             PRINT*, "FEATURESBR",FEATURES5
+
+             !This subroutine reads the 5 inputs and predicts the SIP rate due to BR (BR_RATE)
+                       CALL runforest(mdim5,max_nodes2,jbt,features5,ypred1,leftchild2,rightchild2, &
+                            &  splitfeat2,thresh2,out21)
+
+                       BR_RATE(i,k) = 10._r8**(ypred1)
+                       BR_RATE(i,k) = MAX(BR_RATE(i,k),0._r8)
+
+                    ENDIF ! IF RIMR>0...
+
+
+      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      ! FOR WARMER TEMPERATURES BETWEEN -3 AND 0 C
+      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      !Activation of the collisional break-up process when temperature is warmer
+      !than -3 C, in the absence of raidrops: forestbr
+                 ELSEIF (t(i,k).LE.273.15_r8.AND.t(i,k).GE.270.15_r8) THEN
+
+                    IWCRF5 = LOG10(IWC(i,k))
+                    RIMCRF5 = LOG10(RIMC(i,k))
+                    TEMPRF5 = LOG10(TEMPK(i,k))
+                    RHIRF5 = LOG10(RHI(i,k))
+                    LWCRF5 = LOG10(LWC(i,k))
+
+             !! Combine all features into one vector
+                    FEATURES5(:) = (/ IWCRF5, RIMCRF5, TEMPRF5, RHIRF5, LWCRF5 /)
+!             PRINT*, "FEATURESBR",FEATURES5
+
+             !This subroutine reads the 5 inputs and predicts the SIP rate due to BR (BR_RATE)
+                    CALL runforest(mdim5,max_nodes5,jbt,features5,ypred1,leftchild5,rightchild5, &
+                         &  splitfeat5,thresh5,out51)
+
+                    BR_RATE(i,k) = 10._r8**(ypred1)
+                    BR_RATE(i,k) = MAX(BR_RATE(i,k),0._r8)
+
+
+                 ENDIF !Temperature range
+
+              ENDIF !lower bounds
+
+
+      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      !Combine the effect of all SIP processes into one SIP_RATE that will be added 
+      !in the conservation law of ice crystals at the end of the model time-step 
+      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              SIP_RATE(i,k) = BR_RATE(i,k)+DS_RATE(i,k)+HM_RATE(i,k)
+              SIP_RATE(i,k) = MAX(SIP_RATE(i,k),0._r8)
+              SIP_RATE(i,k) = MIN(SIP_RATE(i,k),10._r8) !10 particles /kg/s is the maximum SIP rate in the training dataset
+
+      !PRINT*, "SIP_RATE=",SIP_RATE(i,k), "BR_RATE=",BR_RATE(i,k), "HM_RATE=",HM_RATE(i,k), "DSRATE=",DS_RATE(i,k)
+      !PRINT*, "QIRSIP=",QIRSIP(i,k), "QICSIP=",QICSIP(i,k)
+
+           END DO ! i =1, mgcol
+
+        ENDIF  !GS/PG RaFSIP
+
+
      end if !do_cldice
      !---PMC 12/3/12
 
@@ -1651,12 +2019,22 @@ subroutine micro_mg_tend ( &
         ! conservation of qc
         !-------------------------------------------------------------------
 
-        dum = ((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+msacwi(i,k)+ &
+        if (rafsip_on) then
+           dum = ((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+msacwi(i,k)+ &
+                psacws(i,k)+bergs(i,k))*lcldm(i,k)+berg(i,k)+QICSIP(i,k)*lcldm(i,k))*deltat !GS/PG -RaFSIP
+        else
+           dum = ((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+msacwi(i,k)+ &
              psacws(i,k)+bergs(i,k))*lcldm(i,k)+berg(i,k))*deltat
-
+        end if
         if (dum.gt.qc(i,k)) then
-           ratio = qc(i,k)/deltat/((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+ &
-                msacwi(i,k)+psacws(i,k)+bergs(i,k))*lcldm(i,k)+berg(i,k))*omsm
+           if (rafsip_on) then
+              ratio = qc(i,k)/deltat/((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+ &
+                   msacwi(i,k)+psacws(i,k)+bergs(i,k)+QICSIP(i,k))*lcldm(i,k)+berg(i,k))*omsm
+              QICSIP(i,k) = QICSIP(i,k)*ratio !RaFSIP
+           else
+              ratio = qc(i,k)/deltat/((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+ &
+                   msacwi(i,k)+psacws(i,k)+bergs(i,k))*lcldm(i,k)+berg(i,k))*omsm
+           end if
            prc(i,k) = prc(i,k)*ratio
            pra(i,k) = pra(i,k)*ratio
            mnuccc(i,k) = mnuccc(i,k)*ratio
@@ -1749,20 +2127,36 @@ subroutine micro_mg_tend ( &
 
         ! conservation of rain mixing ratio
         !-------------------------------------------------------------------
-        dum = ((-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k))*precip_frac(i,k)- &
-             (pra(i,k)+prc(i,k))*lcldm(i,k))*deltat
-
-        ! note that qrtend is included below because of instantaneous freezing/melt
-        if (dum.gt.qr(i,k).and. &
-             (-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k)).ge.qsmall) then
-           ratio = (qr(i,k)/deltat+(pra(i,k)+prc(i,k))*lcldm(i,k))/   &
-                precip_frac(i,k)/(-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k))*omsm
-           pre(i,k)=pre(i,k)*ratio
-           pracs(i,k)=pracs(i,k)*ratio
-           mnuccr(i,k)=mnuccr(i,k)*ratio
-           mnuccri(i,k)=mnuccri(i,k)*ratio
+        if (rafsip_on) then
+           dum = ((-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k)+QIRSIP(i,k))*precip_frac(i,k)- & !RaFSIP
+                (pra(i,k)+prc(i,k))*lcldm(i,k))*deltat
+        else
+           dum = ((-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k))*precip_frac(i,k)- &
+                (pra(i,k)+prc(i,k))*lcldm(i,k))*deltat
         end if
-
+        ! note that qrtend is included below because of instantaneous freezing/melt
+        if (rafsip_on) then
+           if (dum.gt.qr(i,k).and. &
+                (-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k)+QIRSIP(i,k)).ge.qsmall) then
+              ratio = (qr(i,k)/deltat+(pra(i,k)+prc(i,k))*lcldm(i,k))/   &
+                   precip_frac(i,k)/(-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k)+QIRSIP(i,k))*omsm
+              pre(i,k)=pre(i,k)*ratio
+              pracs(i,k)=pracs(i,k)*ratio
+              mnuccr(i,k)=mnuccr(i,k)*ratio
+              mnuccri(i,k)=mnuccri(i,k)*ratio
+              QIRSIP(i,k)=QIRSIP(i,k)*ratio !RaFSIP
+           end if
+        else
+           if (dum.gt.qr(i,k).and. &
+                (-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k)).ge.qsmall) then
+              ratio = (qr(i,k)/deltat+(pra(i,k)+prc(i,k))*lcldm(i,k))/   &
+                   precip_frac(i,k)/(-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k))*omsm
+              pre(i,k)=pre(i,k)*ratio
+              pracs(i,k)=pracs(i,k)*ratio
+              mnuccr(i,k)=mnuccr(i,k)*ratio
+              mnuccri(i,k)=mnuccri(i,k)*ratio
+           end if
+        end if
      end do
 
      do i=1,mgncol
@@ -1836,22 +2230,36 @@ subroutine micro_mg_tend ( &
            else
               tmpfrz = 0._r8
            end if
-           dum = ((-nnucct(i,k)-tmpfrz-nnudep(i,k)-nsacwi(i,k))*lcldm(i,k)+(nprci(i,k)+ &
-                nprai(i,k)-nsubi(i,k))*icldm(i,k)-nnuccri(i,k)*precip_frac(i,k)- &
-                nnuccd(i,k))*deltat
+           if (rafsip_on) then
+              dum = ((-nnucct(i,k)-tmpfrz-nnudep(i,k)-nsacwi(i,k))*lcldm(i,k)-(SIP_RATE(i,k)*lcldm(i,k))+(nprci(i,k)+ &
+                   nprai(i,k)-nsubi(i,k))*icldm(i,k)-nnuccri(i,k)*precip_frac(i,k)- &
+                   nnuccd(i,k))*deltat
 
-           if (dum.gt.ni(i,k)) then
-              ratio = (ni(i,k)/deltat+nnuccd(i,k)+ &
-                   (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k))*lcldm(i,k)+ &
-                   nnuccri(i,k)*precip_frac(i,k))/ &
-                   ((nprci(i,k)+nprai(i,k)-nsubi(i,k))*icldm(i,k))*omsm
-              nprci(i,k) = nprci(i,k)*ratio
-              nprai(i,k) = nprai(i,k)*ratio
-              nsubi(i,k) = nsubi(i,k)*ratio
+              if (dum.gt.ni(i,k)) then
+                 ratio = (ni(i,k)/deltat+nnuccd(i,k)+ &
+                      (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k))*lcldm(i,k)+(SIP_RATE(i,k)*lcldm(i,k))+ &
+                      nnuccri(i,k)*precip_frac(i,k))/ &
+                      ((nprci(i,k)+nprai(i,k)-nsubi(i,k))*icldm(i,k))*omsm
+                 nprci(i,k) = nprci(i,k)*ratio
+                 nprai(i,k) = nprai(i,k)*ratio
+                 nsubi(i,k) = nsubi(i,k)*ratio
+              end if
+           else
+              dum = ((-nnucct(i,k)-tmpfrz-nnudep(i,k)-nsacwi(i,k))*lcldm(i,k)+(nprci(i,k)+ &
+                   nprai(i,k)-nsubi(i,k))*icldm(i,k)-nnuccri(i,k)*precip_frac(i,k)- &
+                   nnuccd(i,k))*deltat
+
+              if (dum.gt.ni(i,k)) then
+                 ratio = (ni(i,k)/deltat+nnuccd(i,k)+ &
+                      (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k))*lcldm(i,k)+ &
+                      nnuccri(i,k)*precip_frac(i,k))/ &
+                      ((nprci(i,k)+nprai(i,k)-nsubi(i,k))*icldm(i,k))*omsm
+                 nprci(i,k) = nprci(i,k)*ratio
+                 nprai(i,k) = nprai(i,k)*ratio
+                 nsubi(i,k) = nsubi(i,k)*ratio
+              end if
            end if
-
         end do
-
      end if
 
      do i=1,mgncol
@@ -1960,26 +2368,50 @@ subroutine micro_mg_tend ( &
         qvlat(i,k) = qvlat(i,k)-(pre(i,k)+prds(i,k))*precip_frac(i,k)-&
              vap_dep(i,k)-ice_sublim(i,k)-mnuccd(i,k)-mnudep(i,k)*lcldm(i,k)
 
-        tlat(i,k) = tlat(i,k)+((pre(i,k)*precip_frac(i,k)) &
-             *xxlv+(prds(i,k)*precip_frac(i,k)+vap_dep(i,k)+ice_sublim(i,k)+mnuccd(i,k)+mnudep(i,k)*lcldm(i,k))*xxls+ &
-             ((bergs(i,k)+psacws(i,k)+mnuccc(i,k)+mnucct(i,k)+msacwi(i,k))*lcldm(i,k)+(mnuccr(i,k)+ &
-             pracs(i,k)+mnuccri(i,k))*precip_frac(i,k)+berg(i,k))*xlf)
+        if (rafsip_on) then
 
-        qctend(i,k) = qctend(i,k)+ &
-             (-pra(i,k)-prc(i,k)-mnuccc(i,k)-mnucct(i,k)-msacwi(i,k)- &
-             psacws(i,k)-bergs(i,k))*lcldm(i,k)-berg(i,k)
+           tlat(i,k) = tlat(i,k)+((pre(i,k)*precip_frac(i,k)) &
+                *xxlv+(prds(i,k)*precip_frac(i,k)+vap_dep(i,k)+ice_sublim(i,k)+mnuccd(i,k)+mnudep(i,k)*lcldm(i,k))*xxls+ &
+                ((bergs(i,k)+psacws(i,k)+mnuccc(i,k)+mnucct(i,k)+msacwi(i,k))*lcldm(i,k)+(mnuccr(i,k)+ &
+                pracs(i,k)+mnuccri(i,k))*precip_frac(i,k)+berg(i,k)+QICSIP(i,k)*lcldm(i,k)+QIRSIP(i,k)*precip_frac(i,k))*xlf)
 
-        if (do_cldice) then
-           qitend(i,k) = qitend(i,k)+ &
-                (mnuccc(i,k)+mnucct(i,k)+mnudep(i,k)+msacwi(i,k))*lcldm(i,k)+(-prci(i,k)- &
-                prai(i,k))*icldm(i,k)+vap_dep(i,k)+berg(i,k)+ice_sublim(i,k)+ &
-                mnuccd(i,k)+mnuccri(i,k)*precip_frac(i,k)
+           qctend(i,k) = qctend(i,k)+ &
+                (-pra(i,k)-prc(i,k)-mnuccc(i,k)-mnucct(i,k)-msacwi(i,k)- &
+                psacws(i,k)-bergs(i,k)-QICSIP(i,k))*lcldm(i,k)-berg(i,k) !RaFSIP
+
+           if (do_cldice) then
+              qitend(i,k) = qitend(i,k)+ &
+                   (mnuccc(i,k)+mnucct(i,k)+mnudep(i,k)+msacwi(i,k)+QICSIP(i,k))*lcldm(i,k)+(-prci(i,k)- &
+                   prai(i,k))*icldm(i,k)+vap_dep(i,k)+berg(i,k)+ice_sublim(i,k)+ &
+                   mnuccd(i,k)+(mnuccri(i,k)+QIRSIP(i,k))*precip_frac(i,k)  !RaFSIP
+           end if
+
+           qrtend(i,k) = qrtend(i,k)+ &
+                (pra(i,k)+prc(i,k))*lcldm(i,k)+(pre(i,k)-pracs(i,k)- &
+                mnuccr(i,k)-mnuccri(i,k)-QIRSIP(i,k))*precip_frac(i,k) !RaFSIP
+
+        else
+           tlat(i,k) = tlat(i,k)+((pre(i,k)*precip_frac(i,k)) &
+                *xxlv+(prds(i,k)*precip_frac(i,k)+vap_dep(i,k)+ice_sublim(i,k)+mnuccd(i,k)+mnudep(i,k)*lcldm(i,k))*xxls+ &
+                ((bergs(i,k)+psacws(i,k)+mnuccc(i,k)+mnucct(i,k)+msacwi(i,k))*lcldm(i,k)+(mnuccr(i,k)+ &
+                pracs(i,k)+mnuccri(i,k))*precip_frac(i,k)+berg(i,k))*xlf)
+
+           qctend(i,k) = qctend(i,k)+ &
+                (-pra(i,k)-prc(i,k)-mnuccc(i,k)-mnucct(i,k)-msacwi(i,k)- &
+                psacws(i,k)-bergs(i,k))*lcldm(i,k)-berg(i,k)
+
+           if (do_cldice) then
+              qitend(i,k) = qitend(i,k)+ &
+                   (mnuccc(i,k)+mnucct(i,k)+mnudep(i,k)+msacwi(i,k))*lcldm(i,k)+(-prci(i,k)- &
+                   prai(i,k))*icldm(i,k)+vap_dep(i,k)+berg(i,k)+ice_sublim(i,k)+ &
+                   mnuccd(i,k)+mnuccri(i,k)*precip_frac(i,k)
+           end if
+
+           qrtend(i,k) = qrtend(i,k)+ &
+                (pra(i,k)+prc(i,k))*lcldm(i,k)+(pre(i,k)-pracs(i,k)- &
+                mnuccr(i,k)-mnuccri(i,k))*precip_frac(i,k)
+           
         end if
-
-        qrtend(i,k) = qrtend(i,k)+ &
-             (pra(i,k)+prc(i,k))*lcldm(i,k)+(pre(i,k)-pracs(i,k)- &
-             mnuccr(i,k)-mnuccri(i,k))*precip_frac(i,k)
-
         qstend(i,k) = qstend(i,k)+ &
              (prai(i,k)+prci(i,k))*icldm(i,k)+(psacws(i,k)+bergs(i,k))*lcldm(i,k)+(prds(i,k)+ &
              pracs(i,k)+mnuccr(i,k))*precip_frac(i,k)
@@ -2046,7 +2478,11 @@ subroutine micro_mg_tend ( &
         nprc1tot(i,k)=nprc1(i,k)*lcldm(i,k)
 
            ! for ice
-        nsacwitot(i,k)=nsacwi(i,k)*lcldm(i,k)
+        if (rafsip_on) then
+           nsacwitot(i,k)=SIP_RATE(i,k)*lcldm(i,k) !GS/PG RaFSIP
+        else
+           nsacwitot(i,k)=nsacwi(i,k)*lcldm(i,k)
+        end if
         nsubitot(i,k)=nsubi(i,k)*icldm(i,k)
         nprcitot(i,k)=nprci(i,k)*icldm(i,k)
         npraitot(i,k)=nprai(i,k)*icldm(i,k)
@@ -2067,9 +2503,15 @@ subroutine micro_mg_tend ( &
            else
               tmpfrz = 0._r8
            end if
-           nitend(i,k) = nitend(i,k)+ nnuccd(i,k)+ &
-                (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k))*lcldm(i,k)+(nsubi(i,k)-nprci(i,k)- &
-                nprai(i,k))*icldm(i,k)+nnuccri(i,k)*precip_frac(i,k)
+           if (rafsip_on) then
+              nitend(i,k) = nitend(i,k)+ nnuccd(i,k) + SIP_RATE(i,k)*lcldm(i,k) +  &   !RaFSIP
+                   (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k))*lcldm(i,k)+(nsubi(i,k)-nprci(i,k)- &
+                   nprai(i,k))*icldm(i,k)+nnuccri(i,k)*precip_frac(i,k)
+           else
+              nitend(i,k) = nitend(i,k)+ nnuccd(i,k)+ &
+                   (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k))*lcldm(i,k)+(nsubi(i,k)-nprci(i,k)- &
+                   nprai(i,k))*icldm(i,k)+nnuccri(i,k)*precip_frac(i,k)
+           end if
         end if
 
         nstend(i,k) = nstend(i,k)+(nsubs(i,k)+ &
@@ -2092,10 +2534,15 @@ subroutine micro_mg_tend ( &
 
         !================================================================
         !shofer---
-        if (nnucct(i,k)+nnuccc(i,k)+nnudep(i,k) > 0._r8) then
-           nimax(i,k) = nimax(i,k)+(nnucct(i,k)+nnuccc(i,k)+nnudep(i,k))*lcldm(i,k)*deltat
+        if (rafsip_on) then
+           if (nnucct(i,k)+nnuccc(i,k)+nnudep(i,k)+SIP_RATE(i,k).gt.0._r8) then
+              nimax(i,k) = nimax(i,k)+(nnucct(i,k)+nnuccc(i,k)+nnudep(i,k)+SIP_RATE(i,k))*lcldm(i,k)*deltat
+           end if
+        else
+           if (nnucct(i,k)+nnuccc(i,k)+nnudep(i,k) > 0._r8) then
+              nimax(i,k) = nimax(i,k)+(nnucct(i,k)+nnuccc(i,k)+nnudep(i,k))*lcldm(i,k)*deltat
+           end if
         end if
-
         if (do_cldice .and. (nitend(i,k) > 0._r8) .and.                    &
             (ni(i,k) + (nitend(i,k)*deltat) > nimax(i,k))) then
            nitncons(i,k) = nitncons(i,k) + nitend(i,k) - max(0._r8,(nimax(i,k)-ni(i,k))/deltat)

--- a/src/NorESM/micro_mg2_0.F90
+++ b/src/NorESM/micro_mg2_0.F90
@@ -350,7 +350,7 @@ subroutine micro_mg_init( &
   xxlv_squared=xxlv**2
   xxls_squared=xxls**2
   
-  rafsip_on=.false.
+  rafsip_on=.true.
   if (rafsip_on) then
 !-----------------------------------------------------------------------------------
 ! RaFSIP: INITIALIZE THE RANDOM FOREST PARAMETERS CALLING THE SUBROUTINES THAT

--- a/src/NorESM/micro_mg2_0.F90
+++ b/src/NorESM/micro_mg2_0.F90
@@ -2493,12 +2493,6 @@ subroutine micro_mg_tend ( &
              nprc(i,k)*lcldm(i,k)+(nsubr(i,k)-npracs(i,k)-nnuccr(i,k) &
              -nnuccri(i,k)+nragg(i,k))*precip_frac(i,k)
 
-!! In NorESM, there was an artificial limit on the number of ice particles.
-!! By default, NorESM2.1 is using a 'corrected' ice delimiter
-!! Uncomment the line below to recover the NorESM2 ice delimiter behavior
-!! See the NorESM2.1 release notes for more information.
-!#define NORESM2_ICE_DELIMITER
-#ifndef NORESM2_ICE_DELIMITER
         ! make sure that ni at advanced time step does not exceed
         ! maximum (existing N + source terms*dt), which is possible
         ! if mtime < deltat
@@ -2521,12 +2515,6 @@ subroutine micro_mg_tend ( &
            nitend(i,k)=max(0._r8,(nimax(i,k)-ni(i,k))/deltat)
         end if
         !shofer---
-#else
-        if (do_cldice .and. nitend(i,k).gt.0._r8.and.ni(i,k)+nitend(i,k)*deltat.gt.nimax(i,k)) then
-           nitncons(i,k) = nitncons(i,k) + nitend(i,k)-max(0._r8,(nimax(i,k)-ni(i,k))/deltat) !AL
-           nitend(i,k)=max(0._r8,(nimax(i,k)-ni(i,k))/deltat)
-        end if
-#endif
 
      end do
 

--- a/src/NorESM/micro_mg2_0.F90
+++ b/src/NorESM/micro_mg2_0.F90
@@ -134,7 +134,17 @@ use micro_mg_utils, only: &
      rising_factorial
 
 !RaFSIP GS/PG
-use module_random_forests
+use module_random_forests, only: rafsip_on, jbt
+use module_random_forests, only: max_nodes1, leftchild1, rightchild1, splitfeat1
+use module_random_forests, only: thresh1, out11, out12, out13
+use module_random_forests, only: max_nodes2, leftchild2, rightchild2, splitfeat2
+use module_random_forests, only: thresh2, out21
+use module_random_forests, only: max_nodes3, leftchild3, rightchild3, splitfeat3
+use module_random_forests, only: thresh3, out31, out32, out33, out34, out35
+use module_random_forests, only: max_nodes4, leftchild4, rightchild4, splitfeat4
+use module_random_forests, only: thresh4, out41, out42, out43
+use module_random_forests, only: max_nodes5, leftchild5, rightchild5, splitfeat5
+use module_random_forests, only: thresh5, out51
 
 implicit none
 private
@@ -230,7 +240,6 @@ real(r8)           :: micro_mg_berg_eff_factor     ! berg efficiency factor
 
 logical  :: allow_sed_supersat ! Allow supersaturated conditions after sedimentation loop
 logical  :: do_sb_physics ! do SB 2001 autoconversion or accretion physics
-logical  :: rafsip_on
 
 !===============================================================================
 contains
@@ -245,7 +254,8 @@ subroutine micro_mg_init( &
      allow_sed_supersat_in, do_sb_physics_in, &
      nccons_in, nicons_in, ncnst_in, ninst_in, errstring)
 
-  use micro_mg_utils, only: micro_mg_utils_init
+  use module_random_forests, only: sec_ice_init
+  use micro_mg_utils,        only: micro_mg_utils_init
 
   !-----------------------------------------------------------------------
   !
@@ -349,44 +359,11 @@ subroutine micro_mg_init( &
 
   xxlv_squared=xxlv**2
   xxls_squared=xxls**2
-  
-  rafsip_on=.true.
+
   if (rafsip_on) then
-!-----------------------------------------------------------------------------------
-! RaFSIP: INITIALIZE THE RANDOM FOREST PARAMETERS CALLING THE SUBROUTINES THAT
-!ARE DEFINED IN THE MODULE_RANDOM_FOREST.F FILE !GS/PG                  
-!----------------------------------------------------------------------------------
-
-     IF (FIRST_RAFSIP) THEN
-
-        forestfileALL  = '/cluster/shared/noresm/inputdata/atm/cam/RaFSIP/forestALL.txt'
-        forestfileBR   = '/cluster/shared/noresm/inputdata/atm/cam/RaFSIP/forestBR.txt'
-        forestfileBRDS = '/cluster/shared/noresm/inputdata/atm/cam/RaFSIP/forestBRDS.txt'
-        forestfileBRHM = '/cluster/shared/noresm/inputdata/atm/cam/RaFSIP/forestBRHM.txt'
-        forestfileBRwarm = '/cluster/shared/noresm/inputdata/atm/cam/RaFSIP/forestBRwarm.txt'
-
-
-        CALL forestbrhm(jbt,max_nodes1,leftchild1,rightchild1,splitfeat1, &
-                               nrnodes1,thresh1,out11,out12,out13)
-
-        CALL forestbr(jbt,max_nodes2,leftchild2,rightchild2,splitfeat2, &
-                               nrnodes2,thresh2,out21)
-
-        CALL forestall(jbt,max_nodes3,leftchild3,rightchild3,splitfeat3, &
-                               nrnodes3,thresh3,out31,out32,out33,out34,out35)
-
-        CALL forestbrds(jbt,max_nodes4,leftchild4,rightchild4,splitfeat4, &
-                               nrnodes4,thresh4,out41,out42,out43)
-
-        CALL forestbrwarm(jbt,max_nodes5,leftchild5,rightchild5,splitfeat5, &
-                               nrnodes5,thresh5,out51)
-
-         
-        FIRST_RAFSIP = .FALSE.
-
-
-     ENDIF
-  end if     
+     ! RaFSIP: INITIALIZE THE RANDOM FOREST PARAMETERS
+     call sec_ice_init()
+  end if
 
 
 end subroutine micro_mg_init
@@ -493,6 +470,11 @@ subroutine micro_mg_tend ( &
        accrete_cloud_ice_snow, &
        evaporate_sublimate_precip, &
        bergeron_process_snow
+
+  use module_random_forests, only: MDIM5, MDIM6
+  use module_random_forests, only: runforestmulti
+  use module_random_forests, only: runforestriv
+  use module_random_forests, only: runforest
 
   !Authors: Hugh Morrison, Andrew Gettelman, NCAR, Peter Caldwell, LLNL
   ! e-mail: morrison@ucar.edu, andrew@ucar.edu
@@ -884,7 +866,7 @@ subroutine micro_mg_tend ( &
   ! RaFSIP additional parameters ! GS/PG
 
   !Inputs to SIP parameterization
-  real(r8) ::  IWC(mgncol,nlev)       ! TOTAL ICE WATER CONTENT IN KG/KG INPUT TO RaFSIP 
+  real(r8) ::  IWC(mgncol,nlev)       ! TOTAL ICE WATER CONTENT IN KG/KG INPUT TO RaFSIP
   real(r8) ::  RIMC(mgncol,nlev)      ! TOTAL CLOUD DROPLET RIMING IN KG/KG/S INPUT TO RaFSIP
   real(r8) ::  RIMR(mgncol,nlev)      ! TOTAL RAINDROP RIMING IN KG/KG/S INPUT TO RaFSIP
   real(r8) ::  TEMPK(mgncol,nlev)     ! TEMPERATURE IN K INPUT TO RaFSIP
@@ -1053,7 +1035,7 @@ subroutine micro_mg_tend ( &
 
   relhum = q / max(qvl, qsmall)
   if (rafsip_on) then
-     relhumi = q / max(qvi, qsmall)
+    relhumi = q / max(qvi, qsmall)
   end if
 
   !===============================================
@@ -1700,17 +1682,17 @@ subroutine micro_mg_tend ( &
      call accrete_cloud_water_snow(t(:,k), rho(:,k), asn(:,k), uns(:,k), mu(:,k), &
           qcic(1:mgncol,k), ncic(:,k), qsic(:,k), pgam(:,k), lamc(:,k), lams(:,k), n0s(:,k), &
           psacws(:,k), npsacws(:,k), mgncol)
-        if (.NOT.rafsip_on) then
-           if (do_cldice) then
-              call secondary_ice_production(t(:,k), psacws(:,k), msacwi(:,k), nsacwi(:,k), mgncol)
-           else
-              nsacwi(:,k) = 0.0_r8
-              msacwi(:,k) = 0.0_r8
-           end if
-        else
+     if (do_cldice) then
+        if (rafsip_on) then
            nsacwi(:,k) = 0.0_r8
            msacwi(:,k) = 0.0_r8
+        else
+           call secondary_ice_production(t(:,k), psacws(:,k), msacwi(:,k), nsacwi(:,k), mgncol)
         end if
+     else
+        nsacwi(:,k) = 0.0_r8
+        msacwi(:,k) = 0.0_r8
+     end if
 
      call accrete_rain_snow(t(:,k), rho(:,k), umr(:,k), ums(:,k), unr(:,k), uns(:,k), &
           qric(:,k), qsic(:,k), lamr(:,k), n0r(:,k), lams(:,k), n0s(:,k), &
@@ -1770,37 +1752,35 @@ subroutine micro_mg_tend ( &
         !in fact, nothing in this entire file makes nsubc nonzero.
         nsubc(:,k) = 0._r8
 
-
-
         IF (rafsip_on) THEN
 
            DO i=1,mgncol
 
-      !! First we define all the useful parameters that will be used as inputs to the parameterization
-      !The total ice water content in kg/kg
+              !! First we define all the useful parameters that will be used as inputs to the parameterization
+              !The total ice water content in kg/kg
               IWC(i,k) = qiic(i,k)+qsic(i,k)
-      !The total amount of cloud droplets rimed onto ice particles in kg/kg/s
+              !The total amount of cloud droplets rimed onto ice particles in kg/kg/s
               RIMC(i,k) = psacws(i,k)
-      !The total amount of raindrops rimed onto ice particles in kg/kg/s
+              !The total amount of raindrops rimed onto ice particles in kg/kg/s
               RIMR(i,k) = pracs(i,k)
-      !Ambient temperature in K
+              !Ambient temperature in K
               TEMPK(i,k) = t(i,k)
-      !Relative humidity with respect to ice
+              !Relative humidity with respect to ice
               RHI(i,k) = relhumi(i,k)
-      !The total liquid water content in kg/kg
+              !The total liquid water content in kg/kg
               LWC(i,k) = qcic(i,k)+qric(i,k)
 
 
-      !Lower bounds
+              !Lower bounds
               IF (RIMC(i,k).GT.0._r8.AND.IWC(i,k).GT.0._r8.AND.LWC(i,k).GT.0._r8.AND.RHI(i,k).GT.0._r8) THEN
 
-      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      ! IF WE ARE WITHIN THE HALLETT-MOSSOP TEMPERATURE RANGE                   
-      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 ! IF WE ARE WITHIN THE HALLETT-MOSSOP TEMPERATURE RANGE
+                 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                  IF (t(i,k).LT.270.15_r8.AND.t(i,k).GE.265.15_r8) THEN
 
-         !Activation of all secondary ice production processes within the HM
-         !temperature range, in the presence of rimed raindrops: forestALL
+                    !Activation of all secondary ice production processes within the HM
+                    !temperature range, in the presence of rimed raindrops: forestALL
 
                     IF (RIMR(i,k).GT.0._r8) THEN
                        IWCRF1 = LOG10(IWC(i,k))
@@ -1810,14 +1790,13 @@ subroutine micro_mg_tend ( &
                        RHIRF1 = LOG10(RHI(i,k))
                        LWCRF1 = LOG10(LWC(i,k))
 
-            !! Combine all features into one vector
+                       !! Combine all features into one vector
                        FEATURES6(:) = (/ IWCRF1,RIMCRF1,TEMPRF1,RHIRF1,RIMRRF1,LWCRF1 /)
-!            PRINT*, "FEATURESALL=",FEATURES6            
 
-            !This subroutine reads the 6 inputs and gives 5 predictions for
-            !the SIP rates due to BR (BR_RATE), HM (HM_RATE) and DS (DS_RATE),
-            !as well as the mass of cloud droplets (QICSIP) and raindrops (QIRSIP)
-            !rimed onto the ice particle that will be transferred to the cloud ice category.
+                       !This subroutine reads the 6 inputs and gives 5 predictions for
+                       !the SIP rates due to BR (BR_RATE), HM (HM_RATE) and DS (DS_RATE),
+                       !as well as the mass of cloud droplets (QICSIP) and raindrops (QIRSIP)
+                       !rimed onto the ice particle that will be transferred to the cloud ice category.
 
                        CALL runforestmulti(mdim6,max_nodes3,jbt,features6,ypred1,ypred2,ypred3,ypred4,ypred5, &
                             & leftchild3,rightchild3,splitfeat3,thresh3,out31,out32,out33,out34,out35)
@@ -1831,12 +1810,12 @@ subroutine micro_mg_tend ( &
                        DS_RATE(i,k) = 10._r8**(ypred3)
                        DS_RATE(i,k) = MAX(DS_RATE(i,k),0._r8)
 
-              !! Mass transfer from cloud droplets/raindrops to cloud ice if HM_RATE>0 and/or DS_RATE>0
+                       !! Mass transfer from cloud droplets/raindrops to cloud ice if HM_RATE>0 and/or DS_RATE>0
                        IF (HM_RATE(i,k).GT.0._r8) THEN
                           QICSIP(i,k) = 10._r8**(ypred4)
                           QICSIP(i,k) = MIN(QICSIP(i,k),0.01_r8*RIMC(i,k))  !RIMC=PSACWS, only max 1% of the rimed mass can be used for SIP
                           QICSIP(i,k) = MAX(QICSIP(i,k),0._r8)
-               !Remove the mass of rimed cloud droplets that is involved in SIP
+                          !Remove the mass of rimed cloud droplets that is involved in SIP
                           PSACWS(i,k) = PSACWS(i,k) - QICSIP(i,k)
                        ENDIF !MASS TRANSFER
 
@@ -1844,13 +1823,13 @@ subroutine micro_mg_tend ( &
                           QIRSIP(i,k) = 10._r8**(ypred5)
                           QIRSIP(i,k) = MIN(QIRSIP(i,k),0.01_r8*RIMR(i,k))  !RIMR=PRACS, only max 1% of the rimed mass can be used for SIP
                           QIRSIP(i,k) = MAX(QIRSIP(i,k),0._r8)
-               !Remove the mass of rimed raindrops that is involved in SIP
+                          !Remove the mass of rimed raindrops that is involved in SIP
                           PRACS(i,k) = PRACS(i,k) - QIRSIP(i,k)
                        ENDIF !MASS TRANSFER
 
 
-         !Activation of the collisional break-up and the hallett-mossop process
-         !if temperature is  between -8<=T<-3 C, in the absence of rimed raindrops: forestbrhm
+                       !Activation of the collisional break-up and the hallett-mossop process
+                       !if temperature is  between -8<=T<-3 C, in the absence of rimed raindrops: forestbrhm
 
                     ELSE
 
@@ -1860,44 +1839,43 @@ subroutine micro_mg_tend ( &
                        TEMPRF2 = LOG10(TEMPK(i,k))
                        RHIRF2 = LOG10(RHI(i,k))
 
-             !! Combine all features into one vector
+                       !! Combine all features into one vector
                        FEATURES5(:) = (/ IWCRF2, RIMCRF2, TEMPRF2, RHIRF2, LWCRF2 /)
-!             PRINT*, "FEATURESBRHM",FEATURES5
 
-          !This subroutine reads the 5 inputs and gives 3 predictions for the
-          !SIP rates due to BR (BR_RATE)  and HM (HM_RATE), as well as
-          !the mass of cloud droplets rimed onto the ice particle that will be
-          !transferred to the cloud ice category (QICSIP).
+                       !This subroutine reads the 5 inputs and gives 3 predictions for the
+                       !SIP rates due to BR (BR_RATE)  and HM (HM_RATE), as well as
+                       !the mass of cloud droplets rimed onto the ice particle that will be
+                       !transferred to the cloud ice category (QICSIP).
 
                        CALL runforestriv(mdim5,max_nodes1,jbt,features5,ypred1,ypred2,ypred3,&
                             & leftchild1,rightchild1,splitfeat1,thresh1,out11,out12,out13)
- 
+
                        BR_RATE(i,k) = 10._r8**(ypred1)
                        BR_RATE(i,k) = MAX(BR_RATE(i,k),0._r8)
 
                        HM_RATE(i,k) = 10._r8**(ypred2)
                        HM_RATE(i,k) = MAX(HM_RATE(i,k),0._r8)
 
-             !! Mass transfer from cloud droplets to cloud ice if HM_RATE>0
+                       !! Mass transfer from cloud droplets to cloud ice if HM_RATE>0
                        IF (HM_RATE(i,k).GT.0._r8) THEN
                           QICSIP(i,k) = 10._r8**(ypred3)
                           QICSIP(i,k) = MIN(QICSIP(i,k),0.01_r8*RIMC(i,k))  !RIMC=PSACWS, only max 1% of the rimed mass can be used for SIP
                           QICSIP(i,k) = MAX(QICSIP(i,k),0._r8)
-               !Remove the mass of rimed cloud droplets that is involved in SIP
+                          !Remove the mass of rimed cloud droplets that is involved in SIP
                           PSACWS(i,k) = PSACWS(i,k) - QICSIP(i,k)
                        ENDIF !Mass transfer
 
 
                     ENDIF  !RIMR>0...
 
-         
-      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      ! FOR LOWER TEMPERATURES BETWEEN -20 AND -8 C
-      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+                    !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    ! FOR LOWER TEMPERATURES BETWEEN -20 AND -8 C
+                    !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                  ELSEIF (t(i,k).LT.265.15_r8.AND.t(i,k).GE.253.15_r8) THEN
 
-        !Activation of the collisional break-up and the droplet shattering
-        !process in the presence of rimed raidrops: forestbrds
+                    !Activation of the collisional break-up and the droplet shattering
+                    !process in the presence of rimed raidrops: forestbrds
 
                     IF (RIMR(i,k).GT.0._r8) THEN
                        IWCRF3 = LOG10(IWC(i,k))
@@ -1907,35 +1885,34 @@ subroutine micro_mg_tend ( &
                        RHIRF3 = LOG10(RHI(i,k))
                        LWCRF3 = LOG10(LWC(i,k))
 
-             !! Combine all features into one vector
+                       !! Combine all features into one vector
                        FEATURES6(:) = (/ IWCRF3,RIMCRF3,TEMPRF3,RHIRF3,RIMRRF3,LWCRF3/)
-!             PRINT*, "FEATURESBRDS",FEATURES6
 
-          !This subroutine reads the 6 inputs and gives 3 predictions for the
-          !SIP rates due to BR (BR_RATE)  and DS (DS_RATE), as well as
-          !the mass of raindrops rimed onto the ice particle that will be
-          !transferred to the cloud ice category (QIRSIP).
+                       !This subroutine reads the 6 inputs and gives 3 predictions for the
+                       !SIP rates due to BR (BR_RATE)  and DS (DS_RATE), as well as
+                       !the mass of raindrops rimed onto the ice particle that will be
+                       !transferred to the cloud ice category (QIRSIP).
 
                        CALL runforestriv(mdim6,max_nodes4,jbt,features6,ypred1,ypred2,ypred3, &
                             & leftchild4,rightchild4,splitfeat4,thresh4,out41,out42,out43)
 
                        BR_RATE(i,k) = 10._r8**(ypred1)
                        BR_RATE(i,k) = MAX(BR_RATE(i,k),0._r8)
-                       
+
                        DS_RATE(i,k) = 10._r8**(ypred2)
                        DS_RATE(i,k) = MAX(DS_RATE(i,k),0._r8)
 
-             !! Mass transfer from cloud droplets/raindrops to cloud ice if HM_RATE>0 and RIMC,RIMR>0
+                       !! Mass transfer from cloud droplets/raindrops to cloud ice if HM_RATE>0 and RIMC,RIMR>0
                        IF (DS_RATE(i,k).GT.0._r8) THEN
                           QIRSIP(i,k) = 10._r8**(ypred3)
                           QIRSIP(i,k) = MIN(QIRSIP(i,k),0.01_r8*RIMR(i,k))  !RIMR=PRACS, only max 1% of the rimed mass can be used for SIP
                           QIRSIP(i,k) = MAX(QIRSIP(i,k),0._r8)
-               !Remove the mass of rimed raindrops that is involved in SIP
+                          !Remove the mass of rimed raindrops that is involved in SIP
                           PRACS(i,k) = PRACS(i,k) - QIRSIP(i,k)
                        ENDIF !Mass transfer
 
-         !Activation of the collisional break-up process when temperature is below
-         !the HM range, in the absence of raidrops: forestbr
+                       !Activation of the collisional break-up process when temperature is below
+                       !the HM range, in the absence of raidrops: forestbr
                     ELSE
 
                        IWCRF4 = LOG10(IWC(i,k))
@@ -1943,12 +1920,11 @@ subroutine micro_mg_tend ( &
                        TEMPRF4 = LOG10(TEMPK(i,k))
                        RHIRF4 = LOG10(RHI(i,k))
                        LWCRF4 = LOG10(LWC(i,k))
-                       
-             !! Combine all features into one vector
-                       FEATURES5(:) = (/ IWCRF4, RIMCRF4, TEMPRF4, RHIRF4, LWCRF4 /)
-!             PRINT*, "FEATURESBR",FEATURES5
 
-             !This subroutine reads the 5 inputs and predicts the SIP rate due to BR (BR_RATE)
+                       !! Combine all features into one vector
+                       FEATURES5(:) = (/ IWCRF4, RIMCRF4, TEMPRF4, RHIRF4, LWCRF4 /)
+
+                       !This subroutine reads the 5 inputs and predicts the SIP rate due to BR (BR_RATE)
                        CALL runforest(mdim5,max_nodes2,jbt,features5,ypred1,leftchild2,rightchild2, &
                             &  splitfeat2,thresh2,out21)
 
@@ -1958,11 +1934,11 @@ subroutine micro_mg_tend ( &
                     ENDIF ! IF RIMR>0...
 
 
-      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      ! FOR WARMER TEMPERATURES BETWEEN -3 AND 0 C
-      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      !Activation of the collisional break-up process when temperature is warmer
-      !than -3 C, in the absence of raidrops: forestbr
+                    !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    ! FOR WARMER TEMPERATURES BETWEEN -3 AND 0 C
+                    !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    !Activation of the collisional break-up process when temperature is warmer
+                    !than -3 C, in the absence of raidrops: forestbr
                  ELSEIF (t(i,k).LE.273.15_r8.AND.t(i,k).GE.270.15_r8) THEN
 
                     IWCRF5 = LOG10(IWC(i,k))
@@ -1971,11 +1947,10 @@ subroutine micro_mg_tend ( &
                     RHIRF5 = LOG10(RHI(i,k))
                     LWCRF5 = LOG10(LWC(i,k))
 
-             !! Combine all features into one vector
+                    !! Combine all features into one vector
                     FEATURES5(:) = (/ IWCRF5, RIMCRF5, TEMPRF5, RHIRF5, LWCRF5 /)
-!             PRINT*, "FEATURESBR",FEATURES5
 
-             !This subroutine reads the 5 inputs and predicts the SIP rate due to BR (BR_RATE)
+                    !This subroutine reads the 5 inputs and predicts the SIP rate due to BR (BR_RATE)
                     CALL runforest(mdim5,max_nodes5,jbt,features5,ypred1,leftchild5,rightchild5, &
                          &  splitfeat5,thresh5,out51)
 
@@ -1988,16 +1963,13 @@ subroutine micro_mg_tend ( &
               ENDIF !lower bounds
 
 
-      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      !Combine the effect of all SIP processes into one SIP_RATE that will be added 
-      !in the conservation law of ice crystals at the end of the model time-step 
-      !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              !Combine the effect of all SIP processes into one SIP_RATE that will be added
+              !in the conservation law of ice crystals at the end of the model time-step
+              !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
               SIP_RATE(i,k) = BR_RATE(i,k)+DS_RATE(i,k)+HM_RATE(i,k)
               SIP_RATE(i,k) = MAX(SIP_RATE(i,k),0._r8)
               SIP_RATE(i,k) = MIN(SIP_RATE(i,k),10._r8) !10 particles /kg/s is the maximum SIP rate in the training dataset
-
-      !PRINT*, "SIP_RATE=",SIP_RATE(i,k), "BR_RATE=",BR_RATE(i,k), "HM_RATE=",HM_RATE(i,k), "DSRATE=",DS_RATE(i,k)
-      !PRINT*, "QIRSIP=",QIRSIP(i,k), "QICSIP=",QICSIP(i,k)
 
            END DO ! i =1, mgcol
 
@@ -2021,20 +1993,20 @@ subroutine micro_mg_tend ( &
 
         if (rafsip_on) then
            dum = ((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+msacwi(i,k)+ &
-                psacws(i,k)+bergs(i,k))*lcldm(i,k)+berg(i,k)+QICSIP(i,k)*lcldm(i,k))*deltat !GS/PG -RaFSIP
-        else
+                psacws(i,k)+bergs(i,k))*lcldm(i,k)+berg(i,k)+QICSIP(i,k)*lcldm(i,k))*deltat
+        else !RaFSIP
            dum = ((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+msacwi(i,k)+ &
-             psacws(i,k)+bergs(i,k))*lcldm(i,k)+berg(i,k))*deltat
-        end if
+                psacws(i,k)+bergs(i,k))*lcldm(i,k)+berg(i,k))*deltat
+        end if !RaFSIP
         if (dum.gt.qc(i,k)) then
            if (rafsip_on) then
               ratio = qc(i,k)/deltat/((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+ &
                    msacwi(i,k)+psacws(i,k)+bergs(i,k)+QICSIP(i,k))*lcldm(i,k)+berg(i,k))*omsm
               QICSIP(i,k) = QICSIP(i,k)*ratio !RaFSIP
-           else
+           else !RaFSIP
               ratio = qc(i,k)/deltat/((prc(i,k)+pra(i,k)+mnuccc(i,k)+mnucct(i,k)+ &
                    msacwi(i,k)+psacws(i,k)+bergs(i,k))*lcldm(i,k)+berg(i,k))*omsm
-           end if
+           end if !RaFSIP
            prc(i,k) = prc(i,k)*ratio
            pra(i,k) = pra(i,k)*ratio
            mnuccc(i,k) = mnuccc(i,k)*ratio
@@ -2130,10 +2102,10 @@ subroutine micro_mg_tend ( &
         if (rafsip_on) then
            dum = ((-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k)+QIRSIP(i,k))*precip_frac(i,k)- & !RaFSIP
                 (pra(i,k)+prc(i,k))*lcldm(i,k))*deltat
-        else
+        else !RaFSIP
            dum = ((-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k))*precip_frac(i,k)- &
                 (pra(i,k)+prc(i,k))*lcldm(i,k))*deltat
-        end if
+        end if !RaFSIP
         ! note that qrtend is included below because of instantaneous freezing/melt
         if (rafsip_on) then
            if (dum.gt.qr(i,k).and. &
@@ -2146,7 +2118,7 @@ subroutine micro_mg_tend ( &
               mnuccri(i,k)=mnuccri(i,k)*ratio
               QIRSIP(i,k)=QIRSIP(i,k)*ratio !RaFSIP
            end if
-        else
+        else !RaFSIP
            if (dum.gt.qr(i,k).and. &
                 (-pre(i,k)+pracs(i,k)+mnuccr(i,k)+mnuccri(i,k)).ge.qsmall) then
               ratio = (qr(i,k)/deltat+(pra(i,k)+prc(i,k))*lcldm(i,k))/   &
@@ -2156,7 +2128,7 @@ subroutine micro_mg_tend ( &
               mnuccr(i,k)=mnuccr(i,k)*ratio
               mnuccri(i,k)=mnuccri(i,k)*ratio
            end if
-        end if
+        end if !RaFSIP
      end do
 
      do i=1,mgncol
@@ -2244,7 +2216,7 @@ subroutine micro_mg_tend ( &
                  nprai(i,k) = nprai(i,k)*ratio
                  nsubi(i,k) = nsubi(i,k)*ratio
               end if
-           else
+           else !RaFSIP
               dum = ((-nnucct(i,k)-tmpfrz-nnudep(i,k)-nsacwi(i,k))*lcldm(i,k)+(nprci(i,k)+ &
                    nprai(i,k)-nsubi(i,k))*icldm(i,k)-nnuccri(i,k)*precip_frac(i,k)- &
                    nnuccd(i,k))*deltat
@@ -2258,7 +2230,7 @@ subroutine micro_mg_tend ( &
                  nprai(i,k) = nprai(i,k)*ratio
                  nsubi(i,k) = nsubi(i,k)*ratio
               end if
-           end if
+           end if !RaFSIP
         end do
      end if
 
@@ -2390,7 +2362,7 @@ subroutine micro_mg_tend ( &
                 (pra(i,k)+prc(i,k))*lcldm(i,k)+(pre(i,k)-pracs(i,k)- &
                 mnuccr(i,k)-mnuccri(i,k)-QIRSIP(i,k))*precip_frac(i,k) !RaFSIP
 
-        else
+        else !RaFSIP
            tlat(i,k) = tlat(i,k)+((pre(i,k)*precip_frac(i,k)) &
                 *xxlv+(prds(i,k)*precip_frac(i,k)+vap_dep(i,k)+ice_sublim(i,k)+mnuccd(i,k)+mnudep(i,k)*lcldm(i,k))*xxls+ &
                 ((bergs(i,k)+psacws(i,k)+mnuccc(i,k)+mnucct(i,k)+msacwi(i,k))*lcldm(i,k)+(mnuccr(i,k)+ &
@@ -2410,8 +2382,8 @@ subroutine micro_mg_tend ( &
            qrtend(i,k) = qrtend(i,k)+ &
                 (pra(i,k)+prc(i,k))*lcldm(i,k)+(pre(i,k)-pracs(i,k)- &
                 mnuccr(i,k)-mnuccri(i,k))*precip_frac(i,k)
-           
-        end if
+
+        end if !RaFSIP
         qstend(i,k) = qstend(i,k)+ &
              (prai(i,k)+prci(i,k))*icldm(i,k)+(psacws(i,k)+bergs(i,k))*lcldm(i,k)+(prds(i,k)+ &
              pracs(i,k)+mnuccr(i,k))*precip_frac(i,k)
@@ -2480,9 +2452,9 @@ subroutine micro_mg_tend ( &
            ! for ice
         if (rafsip_on) then
            nsacwitot(i,k)=SIP_RATE(i,k)*lcldm(i,k) !GS/PG RaFSIP
-        else
+        else !RaFSIP
            nsacwitot(i,k)=nsacwi(i,k)*lcldm(i,k)
-        end if
+        end if !RaFSIP
         nsubitot(i,k)=nsubi(i,k)*icldm(i,k)
         nprcitot(i,k)=nprci(i,k)*icldm(i,k)
         npraitot(i,k)=nprai(i,k)*icldm(i,k)
@@ -2507,11 +2479,11 @@ subroutine micro_mg_tend ( &
               nitend(i,k) = nitend(i,k)+ nnuccd(i,k) + SIP_RATE(i,k)*lcldm(i,k) +  &   !RaFSIP
                    (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k))*lcldm(i,k)+(nsubi(i,k)-nprci(i,k)- &
                    nprai(i,k))*icldm(i,k)+nnuccri(i,k)*precip_frac(i,k)
-           else
+           else !RaFSIP
               nitend(i,k) = nitend(i,k)+ nnuccd(i,k)+ &
                    (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k))*lcldm(i,k)+(nsubi(i,k)-nprci(i,k)- &
                    nprai(i,k))*icldm(i,k)+nnuccri(i,k)*precip_frac(i,k)
-           end if
+           end if !RaFSIP
         end if
 
         nstend(i,k) = nstend(i,k)+(nsubs(i,k)+ &
@@ -2535,14 +2507,14 @@ subroutine micro_mg_tend ( &
         !================================================================
         !shofer---
         if (rafsip_on) then
-           if (nnucct(i,k)+nnuccc(i,k)+nnudep(i,k)+SIP_RATE(i,k).gt.0._r8) then
+           if (nnucct(i,k)+nnuccc(i,k)+nnudep(i,k)+SIP_RATE(i,k) > 0._r8) then
               nimax(i,k) = nimax(i,k)+(nnucct(i,k)+nnuccc(i,k)+nnudep(i,k)+SIP_RATE(i,k))*lcldm(i,k)*deltat
            end if
-        else
+        else !RaFSIP
            if (nnucct(i,k)+nnuccc(i,k)+nnudep(i,k) > 0._r8) then
               nimax(i,k) = nimax(i,k)+(nnucct(i,k)+nnuccc(i,k)+nnudep(i,k))*lcldm(i,k)*deltat
            end if
-        end if
+        end if !RaFSIP
         if (do_cldice .and. (nitend(i,k) > 0._r8) .and.                    &
             (ni(i,k) + (nitend(i,k)*deltat) > nimax(i,k))) then
            nitncons(i,k) = nitncons(i,k) + nitend(i,k) - max(0._r8,(nimax(i,k)-ni(i,k))/deltat)

--- a/src/NorESM/micro_mg_cam.F90
+++ b/src/NorESM/micro_mg_cam.F90
@@ -254,10 +254,11 @@ contains
 
 subroutine micro_mg_cam_readnl(nlfile)
 
-  use namelist_utils,  only: find_group_name
-  use units,           only: getunit, freeunit
-  use spmd_utils,      only: mpicom, mstrid=>masterprocid, mpi_integer, mpi_real8, &
-                             mpi_logical, mpi_character
+  use namelist_utils,        only: find_group_name
+  use units,                 only: getunit, freeunit
+  use spmd_utils,            only: mpicom, mstrid=>masterprocid, mpi_integer, &
+                                   mpi_real8, mpi_logical, mpi_character
+  use module_random_forests, only: sec_ice_readnl
 
   character(len=*), intent(in) :: nlfile  ! filepath for file containing namelist input
 
@@ -385,6 +386,8 @@ subroutine micro_mg_cam_readnl(nlfile)
      write(iulog,*) '  micro_mg_ncnst              = ', micro_mg_ncnst
      write(iulog,*) '  micro_mg_ninst              = ', micro_mg_ninst
   end if
+
+  call sec_ice_readnl(nlfile)
 
 contains
 

--- a/src/NorESM/module_random_forests.F90
+++ b/src/NorESM/module_random_forests.F90
@@ -144,10 +144,10 @@ end subroutine sec_ice_readnl
 
    integer :: unitn, ierr, i
 !      unitn = 137
-      open( 137, file=trim(forestfileBRHM), form='formatted',status='old' )
-         !Open the ASCII file
+!      open( 137, file=trim(forestfileBRHM), form='formatted',status='old' )
+!         !Open the ASCII file
 !         OPEN(unit=137,file="forestBRHM.txt",status="old",action="read")
-!         OPEN(unit=137,file=forestfileBRHM,status="old",action="read")
+         OPEN(unit=137,file=forestfileBRHM,status="old",action="read")
          DO jb=1,jbt
             read (137,*) nrnodes1(jb)
             read (137,*) (leftchild1(jb,n),rightchild1(jb,n),out11(jb,n),out12(jb,n),out13(jb,n), &

--- a/src/NorESM/module_random_forests.F90
+++ b/src/NorESM/module_random_forests.F90
@@ -1,0 +1,452 @@
+!PG RaFSIP PARAMETERS
+
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+!This MODULE holds the subroutines which are used to initialize all  +
+!built random forest regressors.                                     +
+!This MODULE CONTAINS the following routines:                        +
+!  *forestbrhm                                                       +
+!  *forestbr                                                         +
+!  *forestall                                                        +
+!  *forestbrds                                                       +
+!  *forestbrwarm                                                     +
+!Each subroutine opens, reads and stores the parameters of all 4     +
+!random forest regressors. The initial .txt files are first          +
+!converted into binary files so that the processing is faster.       +
+!                                                                    +
+!This module also includes the three subroutines that make all the   +
+!random forest predictions needed in the microphysics routine.       +
+!These are the following:                                            +
+!  *runforest                                                        +
+!  *runforestriv                                                     +
+!  *runforestmulti                                                   +     
+!+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+ MODULE module_random_forests
+
+      use micro_mg_utils, only: r8
+      use spmd_utils,     only: masterproc
+      use phys_control,   only: use_simple_phys
+      use cam_abortutils, only: endrun
+
+      IMPLICIT NONE
+      
+      PUBLIC :: sec_ice_readnl
+
+      PUBLIC  :: forestbrhm,forestbr,forestall,forestbrds,forestbrwarm,runforest,runforestriv,runforestmulti
+
+      !!MDIM DEFINES THE NUMBER OF FEATURES/INPUTS TO THE RaFSIP PARAMETERIZATION
+      INTEGER, PARAMETER, PUBLIC :: MDIM5=5
+      INTEGER, PARAMETER, PUBLIC :: MDIM6=6
+      INTEGER, PARAMETER, PUBLIC :: JBT=10  !!The number of trees in each random forest regressor
+
+      !!The maximum number of nodes across trees
+      INTEGER, PARAMETER, PUBLIC :: MAX_NODES1=7705  !forestBRHM
+      INTEGER, PARAMETER, PUBLIC :: MAX_NODES2=8219  !forestBR
+      INTEGER, PARAMETER, PUBLIC :: MAX_NODES3=7833  !forestALL
+      INTEGER, PARAMETER, PUBLIC :: MAX_NODES4=7093  !forestBRDS
+      INTEGER, PARAMETER, PUBLIC :: MAX_NODES5=8593  !forestBRwarm
+
+      !!Thresh = threshold value at each internal node
+      !!Outi = prediction for a given node
+      REAL(r8), DIMENSION(JBT,MAX_NODES1), PUBLIC    :: THRESH1,OUT11,OUT12,OUT13
+      REAL(r8), DIMENSION(JBT,MAX_NODES2), PUBLIC    :: THRESH2,OUT21
+      REAL(r8), DIMENSION(JBT,MAX_NODES3), PUBLIC    :: THRESH3,OUT31,OUT32,OUT33,OUT34,OUT35
+      REAL(r8), DIMENSION(JBT,MAX_NODES4), PUBLIC    :: THRESH4,OUT41,OUT42,OUT43
+      REAL(r8), DIMENSION(JBT,MAX_NODES5), PUBLIC    :: THRESH5,OUT51
+
+      !!Splitfeat = feature used for splitting the node
+      !!Leftchild = left child of node 
+      !!Rightchild = right child of node
+      INTEGER, DIMENSION(JBT,MAX_NODES1), PUBLIC :: SPLITFEAT1,LEFTCHILD1,RIGHTCHILD1
+      INTEGER, DIMENSION(JBT,MAX_NODES2), PUBLIC :: SPLITFEAT2,LEFTCHILD2,RIGHTCHILD2
+      INTEGER, DIMENSION(JBT,MAX_NODES3), PUBLIC :: SPLITFEAT3,LEFTCHILD3,RIGHTCHILD3
+      INTEGER, DIMENSION(JBT,MAX_NODES4), PUBLIC :: SPLITFEAT4,LEFTCHILD4,RIGHTCHILD4
+      INTEGER, DIMENSION(JBT,MAX_NODES5), PUBLIC :: SPLITFEAT5,LEFTCHILD5,RIGHTCHILD5
+
+      !!The exact number of nodes across in consecutive trees of the forest
+      INTEGER, DIMENSION(JBT) :: NRNODES1,NRNODES2,NRNODES3,NRNODES4,NRNODES5
+
+      LOGICAL, PUBLIC :: FIRST_RAFSIP = .TRUE.
+      
+      character(len=256), public :: forestfileALL,forestfileBRDS
+      character(len=256), public :: forestfileBRHM,forestfileBR
+      character(len=256), public :: forestfileBRwarm
+ 
+  CONTAINS
+
+
+!---------------------------------------------------------------------------------------------------------------
+
+
+ subroutine sec_ice_readnl(nlfile)
+       ! Read files needed for random forest tables of seconary ice formation
+    
+   use namelist_utils,  only: find_group_name
+   use units,           only: getunit, freeunit
+   use mpishorthand
+
+   character(len=*), intent(in) :: nlfile  ! filepath for file containing namelist input
+
+
+   ! Local variables
+   integer :: unitn, ierr, i
+   character(len=2) :: suffix
+   character(len=1), pointer   :: ctype(:)
+   character(len=*), parameter :: subname = 'sec_ice_readnl'
+
+
+   namelist /sec_ice_nl/ forestfileALL,    &
+                             forestfileBRDS,   &
+                             forestfileBRHM,   &
+                             forestfileBR,     &
+                             forestfileBRwarm
+
+   if (use_simple_phys) return
+
+
+   if (masterproc) then
+      unitn = getunit()
+      open( unitn, file=trim(nlfile), status='old' )
+      call find_group_name(unitn, 'sec_ice_nl', status=ierr)
+      if (ierr == 0) then
+         read(unitn, sec_ice_nl, iostat=ierr)
+         if (ierr /= 0) then
+            call endrun(subname // ':: ERROR reading namelist')
+         end if
+      end if
+      close(unitn)
+      call freeunit(unitn)
+   end if
+
+#ifdef SPMD
+
+   call mpibcast (forestfileALL,   len(forestfileALL),    mpichar, 0, mpicom)
+   call mpibcast (forestfileBRDS,  len(forestfileBRDS),   mpichar, 0, mpicom)
+   call mpibcast (forestfileBRHM,  len(forestfileBRHM),   mpichar, 0, mpicom)
+   call mpibcast (forestfileBR,    len(forestfileBR),     mpichar, 0, mpicom)
+   call mpibcast (forestfileBRwarm,len(forestfileBRwarm), mpichar, 0, mpicom)
+
+#endif
+end subroutine sec_ice_readnl
+
+      SUBROUTINE forestbrhm(jbt,max_nodes1,leftchild1,rightchild1,splitfeat1, &
+                               nrnodes1,thresh1,out11,out12,out13)
+      use units,           only: getunit, freeunit
+      IMPLICIT NONE
+
+      INTEGER,intent(in) :: jbt, max_nodes1
+
+      REAL (r8),DIMENSION(jbt,max_nodes1),intent(inout) :: thresh1,out11,out12,out13
+      INTEGER,DIMENSION(jbt,max_nodes1),intent(inout) :: splitfeat1,leftchild1,rightchild1
+      INTEGER,DIMENSION(jbt),intent(inout) :: nrnodes1
+
+      INTEGER :: jb,n
+
+   integer :: unitn, ierr, i
+!      unitn = 137
+      open( 137, file=trim(forestfileBRHM), form='formatted',status='old' )
+         !Open the ASCII file
+!         OPEN(unit=137,file="forestBRHM.txt",status="old",action="read")
+!         OPEN(unit=137,file=forestfileBRHM,status="old",action="read")
+         DO jb=1,jbt
+            read (137,*) nrnodes1(jb)
+            read (137,*) (leftchild1(jb,n),rightchild1(jb,n),out11(jb,n),out12(jb,n),out13(jb,n), &
+                    & thresh1(jb,n),splitfeat1(jb,n), n=1,nrnodes1(jb))
+         ENDDO
+         CLOSE(137)
+!      call freeunit(unitn)
+
+      END subroutine forestbrhm
+!---------------------------------------------------------------------------------------------------------------
+
+
+!---------------------------------------------------------------------------------------------------------------
+      SUBROUTINE forestbr(jbt,max_nodes2,leftchild2,rightchild2,splitfeat2, &
+                               nrnodes2,thresh2,out21)
+
+      IMPLICIT NONE
+
+      INTEGER,intent(in) :: jbt, max_nodes2
+
+      REAL(r8),DIMENSION(jbt,max_nodes2),intent(inout) :: thresh2,out21
+      INTEGER,DIMENSION(jbt,max_nodes2),intent(inout) :: splitfeat2,leftchild2,rightchild2
+      INTEGER,DIMENSION(jbt),intent(inout) :: nrnodes2
+
+      INTEGER :: jb,n
+
+!         OPEN(unit=138,file="forestBR.txt",status="old",action="read")
+         OPEN(unit=138,file=forestfileBR,status="old",action="read")
+         DO jb=1,jbt
+            read (138,*) nrnodes2(jb)
+            read (138,*) (leftchild2(jb,n),rightchild2(jb,n),out21(jb,n), &
+                    & thresh2(jb,n),splitfeat2(jb,n), n=1,nrnodes2(jb))
+         ENDDO
+         CLOSE(138)
+
+      END subroutine forestbr
+!---------------------------------------------------------------------------------------------------------------
+
+
+!---------------------------------------------------------------------------------------------------------------
+      SUBROUTINE forestall(jbt,max_nodes3,leftchild3,rightchild3,splitfeat3, &
+                               nrnodes3,thresh3,out31,out32,out33,out34,out35)
+
+      IMPLICIT NONE
+
+      INTEGER,intent(in) :: jbt, max_nodes3
+
+      REAL(r8),DIMENSION(jbt,max_nodes3),intent(inout) :: thresh3,out31,out32,out33,out34,out35
+      INTEGER,DIMENSION(jbt,max_nodes3),intent(inout) :: splitfeat3,leftchild3,rightchild3
+      INTEGER,DIMENSION(jbt),intent(inout) :: nrnodes3
+
+      INTEGER :: jb,n
+
+!         OPEN(unit=139,file="forestALL.txt",status="old",action="read")
+         OPEN(unit=139,file=forestfileALL,status="old",action="read")
+         DO jb=1,jbt
+            read (139,*) nrnodes3(jb)
+            read (139,*) (leftchild3(jb,n),rightchild3(jb,n),out31(jb,n),out32(jb,n),out33(jb,n), &
+                    & out34(jb,n),out35(jb,n),thresh3(jb,n),splitfeat3(jb,n), n=1,nrnodes3(jb))
+         ENDDO
+         CLOSE(139)
+
+      END subroutine forestall
+!---------------------------------------------------------------------------------------------------------------
+
+
+
+!---------------------------------------------------------------------------------------------------------------
+      SUBROUTINE forestbrds(jbt,max_nodes4,leftchild4,rightchild4,splitfeat4, &
+                               nrnodes4,thresh4,out41,out42,out43)
+
+      IMPLICIT NONE
+
+      INTEGER,intent(in) :: jbt, max_nodes4
+
+      REAL(r8),DIMENSION(jbt,max_nodes4),intent(inout) :: thresh4,out41,out42,out43
+      INTEGER,DIMENSION(jbt,max_nodes4),intent(inout) :: splitfeat4,leftchild4,rightchild4
+      INTEGER,DIMENSION(jbt),intent(inout) :: nrnodes4
+
+      INTEGER :: jb,n
+
+!         OPEN(unit=140,file="forestBRDS.txt",status="old",action="read")
+         OPEN(unit=140,file=forestfileBRDS,status="old",action="read")
+         DO jb=1,jbt
+            read (140,*) nrnodes4(jb)
+            read (140,*) (leftchild4(jb,n),rightchild4(jb,n),out41(jb,n),out42(jb,n),out43(jb,n), &
+                    & thresh4(jb,n),splitfeat4(jb,n), n=1,nrnodes4(jb))
+         ENDDO
+         CLOSE(140)
+
+      END subroutine forestbrds
+!---------------------------------------------------------------------------------------------------------------
+
+
+!---------------------------------------------------------------------------------------------------------------
+      SUBROUTINE forestbrwarm(jbt,max_nodes5,leftchild5,rightchild5,splitfeat5, &
+                               nrnodes5,thresh5,out51)
+
+      IMPLICIT NONE
+
+      INTEGER,intent(in) :: jbt, max_nodes5
+
+      REAL(r8),DIMENSION(jbt,max_nodes5),intent(inout) :: thresh5,out51
+      INTEGER,DIMENSION(jbt,max_nodes5),intent(inout) :: splitfeat5,leftchild5,rightchild5
+      INTEGER,DIMENSION(jbt),intent(inout) :: nrnodes5
+
+      INTEGER :: jb,n
+
+!         OPEN(unit=141,file="forestBRwarm.txt",status="old",action="read")
+         OPEN(unit=141,file=forestfileBRwarm,status="old",action="read")
+         DO jb=1,jbt
+            read (141,*) nrnodes5(jb)
+            read (141,*) (leftchild5(jb,n),rightchild5(jb,n),out51(jb,n), &
+                    & thresh5(jb,n),splitfeat5(jb,n), n=1,nrnodes5(jb))
+         ENDDO
+         CLOSE(141)
+
+      END subroutine forestbrwarm
+!---------------------------------------------------------------------------------------------------------------
+
+
+
+!======================================================================+
+!   THREE SUBROUTINES CALLED BY THE RaFSIP PARAMETERIZATION            !
+!======================================================================+
+
+     !This subroutine is called only when the requirements for the
+     !activation of the forestBR model are met (i.e., -25<T<-8 in
+     !the absence of rainwater). In this case only the BR process
+     !can contribute to the ice production, and hence the RF gives
+     !only one prediction: log(IEFBR)
+     SUBROUTINE runforest(mdim,max_nodes,jbt,features,ypred1,leftchild,rightchild, &
+        & splitfeat,thresh,out1)
+
+      IMPLICIT NONE
+      integer,intent(in) :: jbt,mdim,max_nodes
+      integer,dimension(jbt,max_nodes),intent(in) :: splitfeat,leftchild,rightchild
+      real(r8),dimension(jbt,max_nodes),intent(in)    :: out1,thresh
+      real(r8),dimension(mdim),intent(in) :: features
+      real(r8), intent(out)   :: ypred1
+      integer :: jb,inode,next_node
+
+!      PRINT*, "runforest_feature",features
+
+      ! Initialize variables
+      ypred1 = 0._r8
+
+      ! START DOWN FOREST TO CALCULATE THE PREDICTED VALUES
+      ! loop over trees in forest
+      DO jb=1,jbt
+         
+         ! set current node to root node         
+         inode = 1
+
+         ! loop as long as we reach a leaf node
+         do while (leftchild(jb,inode) .ne. rightchild(jb,inode))
+             if (features(splitfeat(jb,inode)).le.thresh(jb,inode)) then
+                next_node = leftchild(jb,inode)
+             else
+                next_node = rightchild(jb,inode)
+             endif
+
+             inode = next_node
+
+          enddo  !do while
+
+          YPRED1 = YPRED1 + out1(jb,inode)
+
+      ENDDO  !tree loop
+
+
+      YPRED1 = YPRED1/jbt  !YPRED1=log10(IEFBR)
+
+
+      End subroutine runforest
+
+
+!-------------------------------------------------------------------------------------+
+     !This subroutine is called when the requirements for either the forestBRDS
+     !or the forestBRHM are met (i.e., -25<T<-8 in the presence of raindrops or 
+     !-8<T<-3 without raindrops). In this case the RF gives in total 3
+     !predictions: log(IEFBR), log(IEFDS) or log(IEFHM), log(QIRSIP) or log(QICSIP) 
+      SUBROUTINE runforestriv(mdim,max_nodes,jbt,features,ypred1,ypred2,ypred3, &
+            & leftchild,rightchild,splitfeat,thresh,out1,out2,out3)
+
+      IMPLICIT NONE
+      integer,intent(in) :: jbt,mdim,max_nodes
+      integer,dimension(jbt,max_nodes),intent(in) :: splitfeat,leftchild,rightchild
+      real(r8),dimension(jbt,max_nodes),intent(in)    :: out1,out2,out3,thresh
+      real(r8),dimension(mdim),intent(in) :: features
+      real(r8), intent(out)   :: ypred1,ypred2,ypred3
+      integer :: jb,inode,next_node
+
+!      PRINT*, "runforestriv_feature",features
+
+      ! Initialize variables
+      ypred1 = 0._r8
+      ypred2 = 0._r8
+      ypred3 = 0._r8
+
+      ! START DOWN FOREST TO CALCULATE THE PREDICTED VALUES
+      ! loop over trees in forest
+      DO jb=1,jbt
+
+          ! set current node to root node
+          inode = 1
+
+          ! loop as long as we reach a leaf node
+          do while (leftchild(jb,inode) .ne. rightchild(jb,inode))
+             if (features(splitfeat(jb,inode)).le.thresh(jb,inode)) then
+                next_node = leftchild(jb,inode)
+             else 
+                next_node = rightchild(jb,inode)
+             endif
+
+             inode = next_node
+       
+          enddo  !do while
+
+          YPRED1 = YPRED1 + out1(jb,inode)
+          YPRED2 = YPRED2 + out2(jb,inode)  
+          YPRED3 = YPRED3 + out3(jb,inode)
+
+      ENDDO  !tree loop
+
+
+      YPRED1 = YPRED1/jbt  !YPRED1=log10(IEFBR)
+      YPRED2 = YPRED2/jbt  !YPRED2=log10(IEFDS) or log10(IEFHM)
+      YPRED3 = YPRED3/jbt  !YPRED3=log10(QIRSIP) or log10(QICSIP)
+
+
+      End subroutine runforestriv
+
+
+!-------------------------------------------------------------------------------------+
+     !This subroutine is called when the requirements for the forestALL are met 
+     !(i.e., -8<T<-3 in the presence of raindrops). In this case the RF gives 5
+     !predictions: log(IEFBR), log(IEFHM), log(IEFDS), log(QICSIP), log(QIRSIP)
+      SUBROUTINE runforestmulti(mdim,max_nodes,jbt,features,ypred1,ypred2,ypred3,ypred4,ypred5, &
+        & leftchild,rightchild,splitfeat,thresh,out1,out2,out3,out4,out5)
+
+      IMPLICIT NONE
+      integer,intent(in) :: jbt,mdim,max_nodes
+      integer,dimension(jbt,max_nodes),intent(in) :: splitfeat,leftchild,rightchild
+      real(r8),dimension(jbt,max_nodes),intent(in)    :: out1,out2,out3,out4,out5,thresh
+      real(r8),dimension(mdim),intent(in) :: features
+      real(r8), intent(out)   :: ypred1,ypred2,ypred3,ypred4,ypred5
+      integer :: jb,inode,next_node
+
+!      PRINT*, "runforest_multi",features
+
+      ! Initialize variables
+      ypred1 = 0._r8
+      ypred2 = 0._r8
+      ypred3 = 0._r8
+      ypred4 = 0._r8
+      ypred5 = 0._r8
+
+      ! START DOWN FOREST TO CALCULATE THE PREDICTED VALUES
+      ! loop over trees in forest
+      DO jb=1,jbt
+
+!         PRINT*, "forestALL_nrnodes", nrnodes3(jb)
+
+          ! set current node to root node
+          inode = 1
+
+          ! loop as long as we reach a leaf node
+          do while (leftchild(jb,inode) .ne. rightchild(jb,inode))
+            if (features(splitfeat(jb,inode)).le.thresh(jb,inode)) then
+                next_node = leftchild(jb,inode)
+             else
+                next_node = rightchild(jb,inode)
+             endif
+
+             inode = next_node
+
+          enddo  !do while
+
+          YPRED1 = YPRED1 + out1(jb,inode)
+          YPRED2 = YPRED2 + out2(jb,inode)
+          YPRED3 = YPRED3 + out3(jb,inode)
+          YPRED4 = YPRED4 + out4(jb,inode)
+          YPRED5 = YPRED5 + out5(jb,inode)
+
+      ENDDO  !tree loop
+
+
+      YPRED1 = YPRED1/jbt  !YPRED1=log10(IEFBR)
+      YPRED2 = YPRED2/jbt  !YPRED2=log10(IEFHM)
+      YPRED3 = YPRED3/jbt  !YPRED3=log10(IEFDS)
+      YPRED4 = YPRED4/jbt  !YPRED4=log10(QICSIP)
+      YPRED5 = YPRED5/jbt  !YPRED5=log10(QIRSIP)
+
+
+      End subroutine runforestmulti
+
+!+---+-----------------------------------------------------------------+
+
+
+
+ END module module_random_forests


### PR DESCRIPTION
Summary: Added new and extended parameterisation of secondary ice formation.

Contributors: @oyvindseland 

Reviewers: @gold2718 

Purpose of changes:   #152  Add parameteriation of secondary ice

Github PR URL: https://github.com/NorESMhub/CAM/pull/165

Changes made to build system: None

Changes made to the namelist: 5 new namelist parameters
- `rafsip_on`: If .true., compute secondary ice production using random forests method, Default: .false.
- `forestfileALL`: ML parameters for the forestALL RFR model, Default: None
- `forestfileBRDS`: ML parameters for the forestBRDS RFR model., Default: None
- `forestfileBRHM`: ML parameters for the forestBRHM RFR model., Default: None
- `forestfileBR`: ML parameters for the forestBR RFR model., Default: None
- `forestfileBRwarm`: ML parameters for the forestBRwarm RFR model., Default: None

Changes to the defaults for the boundary datasets: 5 ASCII files for reading in AI results used for calculating secondary ice formation.

Substantial timing or memory changes: None

Code changes to micro_mg2.0.F90 and added new subroutine module_random_forests.F90
Parameterisation is independent of Oslo-Aero and will in principle also work with MAM4.

1) New module contains random forest regressors for calculations of secondary ice formation for different physical domains (e.g. temperature ranges)
2) The main microphysics module is modified to include the new fluxes; the old limited parameterisation removed ; ice particle delimiter takes into account the new fluxes
3) The parameterisation is governed by  a logical rafsip_on. It is hardcoded and set to .true. Should be included as a namelist option.
4) The name of the files are hardcoded into the routine. The commit also include a  subroutine sec_ice_readnl that was used for reading in the file names from CAM namelist in project Forces simulations.

Georgakaki, P., &amp; Nenes, A. (2024). RaFSIP: Parameterizing ice multiplication in models using a machine learning approach. Journal of Advances in Modeling Earth Systems, 16, e2023MS003923.
https://doi.org/10.1029/2023MS003923

Only tested with compset NF2000climo at Betzy. Tested that the logical parameter set to .false. using the same model set-up give bit-identical results to model code built directly from the noresm2_3_develop branch

Issues addressed by this PR: Completes #152 for noresm2_3_develop

closes #152