### PR TITLE
update dms exchange and add 10m winds to mediator

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -65,7 +65,7 @@ required = True
 
 [oslo_aero]
 protocol = git
-hash = 87f76b3
+hash = 2414f85
 repo_url = https://github.com/NorESMhub/OSLO_AERO
 local_path = src/chemistry/oslo_aero
 required = True

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -9644,6 +9644,12 @@ created from AeroTab
 <entry id="lwkcomp9_file" type="char*256" input_pathname="abs" category="cam_oslo" group="aerotab_ctl_nl" valid_values="" > AeroTab file</entry>
 <entry id="lwkcomp10_file" type="char*256" input_pathname="abs" category="cam_oslo" group="aerotab_ctl_nl" valid_values="" > AeroTab file</entry>
 
+<entry id="use_dms_from_ocean" type="logical" category="cam_oslo"
+       group="oslo_ctl_nl" valid_values="" >
+If true, obtain dms flux from ocean component.
+Default: false
+</entry>
+
 <entry id="dms_source" type="char*20" category="cam_oslo"
        group="oslo_ctl_nl" valid_values="" >
 Type of DMS data source
@@ -9691,5 +9697,8 @@ Default: name
 Path to ocean file
 Default: path
 </entry>
+
+
+
 
 </namelist_definition>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -9644,12 +9644,6 @@ created from AeroTab
 <entry id="lwkcomp9_file" type="char*256" input_pathname="abs" category="cam_oslo" group="aerotab_ctl_nl" valid_values="" > AeroTab file</entry>
 <entry id="lwkcomp10_file" type="char*256" input_pathname="abs" category="cam_oslo" group="aerotab_ctl_nl" valid_values="" > AeroTab file</entry>
 
-<entry id="use_dms_from_ocean" type="logical" category="cam_oslo"
-       group="oslo_ctl_nl" valid_values="" >
-If true, obtain dms flux from ocean component.
-Default: false
-</entry>
-
 <entry id="dms_source" type="char*20" category="cam_oslo"
        group="oslo_ctl_nl" valid_values="" >
 Type of DMS data source
@@ -9697,8 +9691,5 @@ Default: name
 Path to ocean file
 Default: path
 </entry>
-
-
-
 
 </namelist_definition>

--- a/src/control/camsrfexch.F90
+++ b/src/control/camsrfexch.F90
@@ -510,7 +510,11 @@ subroutine cam_export(state,cam_out,pbuf)
       ! Direction of bottom level wind
       ubot = state%u(i,pver)
       vbot = state%v(i,pver)
-      cam_out%wind_dir(i) = atan2(vbot,ubot)
+      if ((ubot == 0.0_r8) .and. (vbot == 0.0_r8)) then
+         cam_out%wind_dir(i) = 0.0_r8 ! Default to U for zero wind
+      else
+         cam_out%wind_dir(i) = atan2(vbot,ubot)
+      end if
    end do
    do m = 1, pcnst
      do i = 1, ncol

--- a/src/control/camsrfexch.F90
+++ b/src/control/camsrfexch.F90
@@ -44,6 +44,7 @@ module camsrfexch
      real(r8) :: topo(pcols)         ! surface topographic height (m)
      real(r8) :: ubot(pcols)         ! bot level u wind
      real(r8) :: vbot(pcols)         ! bot level v wind
+     real(r8) :: wind_dir(pcols)     ! direction of bottom level wind
      real(r8) :: qbot(pcols,pcnst)   ! bot level specific humidity
      real(r8) :: pbot(pcols)         ! bot level pressure
      real(r8) :: rho(pcols)          ! bot level density
@@ -296,6 +297,7 @@ CONTAINS
        cam_out(c)%topo(:)     = 0._r8
        cam_out(c)%ubot(:)     = 0._r8
        cam_out(c)%vbot(:)     = 0._r8
+       cam_out(c)%wind_dir(:) = 0._r8
        cam_out(c)%qbot(:,:)   = 0._r8
        cam_out(c)%pbot(:)     = 0._r8
        cam_out(c)%rho(:)      = 0._r8
@@ -436,6 +438,7 @@ subroutine cam_export(state,cam_out,pbuf)
    integer :: prec_dp_idx, snow_dp_idx, prec_sh_idx, snow_sh_idx
    integer :: prec_sed_idx,snow_sed_idx,prec_pcw_idx,snow_pcw_idx
    integer :: srf_ozone_idx, lightning_idx
+   real(r8):: ubot, vbot
 
    real(r8), pointer :: psl(:)
 
@@ -503,6 +506,11 @@ subroutine cam_export(state,cam_out,pbuf)
       cam_out%pbot(i)  = state%pmid(i,pver)
       cam_out%psl(i)   = psl(i)
       cam_out%rho(i)   = cam_out%pbot(i)/(rair*cam_out%tbot(i))
+
+      ! Direction of bottom level wind
+      ubot = state%u(i,pver)
+      vbot = state%v(i,pver)
+      cam_out%wind_dir(i) = atan2(vbot,ubot)
    end do
    do m = 1, pcnst
      do i = 1, ncol

--- a/src/cpl/nuopc/atm_comp_nuopc.F90
+++ b/src/cpl/nuopc/atm_comp_nuopc.F90
@@ -241,8 +241,6 @@ contains
     call set_component_logging(gcomp, localpet==0, iulog, shrlogunit, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    call shr_log_setLogUnit (iulog)
-
     !----------------------------------------------------------------------------
     ! advertise import/export fields
     !----------------------------------------------------------------------------
@@ -316,6 +314,8 @@ contains
        call shr_sys_abort(subname//'Need to set attribute mediator_present')
     endif
 
+    ! reset shr logging to original values
+    call shr_log_setLogUnit (shrlogunit)
     if (dbug_flag > 5) then
        call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO)
     end if

--- a/src/cpl/nuopc/atm_import_export.F90
+++ b/src/cpl/nuopc/atm_import_export.F90
@@ -1102,6 +1102,12 @@ contains
     call state_getfldptr(importState, 'Sx_u10' , fldptr=fldptr_wind10m, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
+    ! The 10m wind speed over ocean obtained from the atm/ocn flux computation in the mediator
+    ! and is merged with the 10m wind speed obtained from the land ice ice components
+    ! This computation for 10m wind speed will have used the bottom level winds from cam sent
+    ! at the previous time
+    ! The decomposition of the 10m wind into its zonal and meridional components is done using
+    ! the bottom level u and v fields from cam (at the current time)
     g = 1
     do c = begchunk,endchunk
        do i = 1,get_ncols_p(c)

--- a/src/physics/cam/phys_control.F90
+++ b/src/physics/cam/phys_control.F90
@@ -14,7 +14,6 @@ use spmd_utils,        only: masterproc
 use cam_logfile,       only: iulog
 use cam_abortutils,    only: endrun
 use shr_kind_mod,      only: r8 => shr_kind_r8, cl=>shr_kind_cl
-use atm_import_export, only: drv_dms_from_ocn => dms_from_ocn
 
 implicit none
 private
@@ -105,9 +104,6 @@ logical, public, protected :: fv_am_correction = .false.
 
 ! Option for Harmonized Emissions Component (HEMCO)
 logical, public, protected :: use_hemco = .false.
-
-! Take DMS from ocean?
-logical, public, protected :: dms_from_ocn = .false.
 
 ! CAM snapshot before/after file numbers and control
 character(len=32) :: cam_take_snapshot_before = ''  ! Physics routine to take a snopshot "before"
@@ -280,9 +276,6 @@ subroutine phys_ctl_readnl(nlfile)
 
    ! prog_modal_aero determines whether prognostic modal aerosols are present in the run.
    prog_modal_aero = index(cam_chempkg,'_mam')>0
-
-   ! Set this from the driver namelist (always read first)
-   dms_from_ocn = drv_dms_from_ocn
 
 end subroutine phys_ctl_readnl
 

--- a/src/physics/cam/phys_control.F90
+++ b/src/physics/cam/phys_control.F90
@@ -10,10 +10,11 @@ module phys_control
 !                             Add vars to indicate physics version and chemistry type.
 !-----------------------------------------------------------------------
 
-use spmd_utils,     only: masterproc
-use cam_logfile,    only: iulog
-use cam_abortutils, only: endrun
-use shr_kind_mod,   only: r8 => shr_kind_r8, cl=>shr_kind_cl
+use spmd_utils,        only: masterproc
+use cam_logfile,       only: iulog
+use cam_abortutils,    only: endrun
+use shr_kind_mod,      only: r8 => shr_kind_r8, cl=>shr_kind_cl
+use atm_import_export, only: drv_dms_from_ocn => dms_from_ocn
 
 implicit none
 private
@@ -56,7 +57,7 @@ logical           :: history_vdiag        = .false.    ! output the variables us
 logical           :: history_aerosol      = .false.    ! output the MAM aerosol variables and tendencies
 logical           :: history_aero_optics  = .false.    ! output the aerosol
 logical           :: history_eddy         = .false.    ! output the eddy variables
-logical           :: history_budget       = .false.    ! output tendencies and state variables for T, water vapor, 
+logical           :: history_budget       = .false.    ! output tendencies and state variables for T, water vapor,
                                                        ! cloud ice and cloud liquid budgets
 logical           :: convproc_do_aer      = .false.    ! switch for new convective scavenging treatment for modal aerosols
 
@@ -104,6 +105,9 @@ logical, public, protected :: fv_am_correction = .false.
 
 ! Option for Harmonized Emissions Component (HEMCO)
 logical, public, protected :: use_hemco = .false.
+
+! Take DMS from ocean?
+logical, public, protected :: dms_from_ocn = .false.
 
 ! CAM snapshot before/after file numbers and control
 character(len=32) :: cam_take_snapshot_before = ''  ! Physics routine to take a snopshot "before"
@@ -276,6 +280,9 @@ subroutine phys_ctl_readnl(nlfile)
 
    ! prog_modal_aero determines whether prognostic modal aerosols are present in the run.
    prog_modal_aero = index(cam_chempkg,'_mam')>0
+
+   ! Set this from the driver namelist (always read first)
+   dms_from_ocn = drv_dms_from_ocn
 
 end subroutine phys_ctl_readnl
 


### PR DESCRIPTION
- update Externals_CAM to point to new oslo_aero code that only computes ocean dms flux if its not obtained from the the mediator 
- add 10m winds to send to mediator (this is needed for WW3)

Summary: update dms exchange and add 10m winds to mediator

Contributors: mvertens

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Testing:
./create_test --xml-category aux_cam_noresm --xml-machine betzy --compare noresm2_5_013_cam6_3_158 --generate noresm2_5_014_cam6_3_158 --baseline-root ~/baselines/cam_develop

The results were bfb.
