### PR TITLE
cam_noresm2_3_v1.0.0c: Allow co2_cycle with stratospheric chemistry

### DIFF
--- a/bld/configure
+++ b/bld/configure
@@ -132,7 +132,7 @@ OPTIONS
      -[no]clubb_sgs     Switch on [off] CLUBB_SGS.  Default: on for cam6, otherwise off.
      -clubb_opts <list> Comma separated list of CLUBB options to turn on/off.  By default they are all off.
                         Current option is: clubb_do_adv (Advect CLUBB moments)
-     -co2_cycle         This option is meant to be used with the -ccsm_seq option.  It modifies the
+     -[no]co2_cycle     This option is meant to be used with the -ccsm_seq option.  It modifies the
                         CAM configuration by increasing the number of advected constituents by 4.
      -cosp              Enable the COSP simulator.
      -cppdefs <string>  A string of user specified CPP defines.  Appended to
@@ -310,7 +310,7 @@ GetOptions(
     "chem=s"                    => \$opts{'chem'},
     "clubb_sgs!"                => \$opts{'clubb_sgs'},
     "clubb_opts=s"              => \$opts{'clubb_opts'},
-    "co2_cycle"                 => \$opts{'co2_cycle'},
+    "co2_cycle!"                => \$opts{'co2_cycle'},
     "cosp"                      => \$opts{'cosp'},
     "cosp_libdir=s"             => \$opts{'cosp_libdir'},
     "cppdefs=s"                 => \$opts{'cppdefs'},
@@ -1561,8 +1561,17 @@ else {
 
         # co2_cycle
         if ($co2_cycle) {
-            $nadv += 4;
-            if ($print>=2) { print "Advected constituents added by co2_cycle: 4$eol"; }
+            if ($chem_pkg =~ 'strat' or $chem_pkg =~ 'waccm') {
+                $nadv += 3;
+                if ($print>=2) {
+                    print "Advected constituents added by co2_cycle: 3$eol";
+                }
+            } else {
+                $nadv += 4;
+                if ($print>=2) {
+                    print "Advected constituents added by co2_cycle: 4$eol";
+                }
+            }
         }
 
         # CARMA package:

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -179,8 +179,8 @@
       <value compset="_CAM60%NORESM%NORPDDMSBC" >-chem trop_mam_oslo -camnor -cosp</value>
       <value compset="_CAM60%NORESM%NORPIBC"    >-chem trop_mam_oslo -camnor -cosp</value>
       <value compset="_CAM60%NORESM%NUDGE"      >-chem trop_mam_oslo -camnor -offline_dyn</value>
-      <value compset="_CAM60%NORESM%TROPSTRATCHEM"       >-chem tropstrat_mam_oslo -camnor </value>
-      <value compset="_CAM60%NORESM%NORBC%TROPSTRATCHEM" >-chem tropstrat_mam_oslo -camnor </value>
+      <value compset="_CAM60%NORESM%TROPSTRATCHEM"       >-chem tropstrat_mam_oslo </value>
+      <value compset="_CAM60%NORESM%NORBC%TROPSTRATCHEM" >-chem tropstrat_mam_oslo </value>
 
     </values>
     <group>build_component_cam</group>


### PR DESCRIPTION
Allow configuration override to turn off co2_cycle
Turn off co2_cycle for tropstrat chemistry
Allow co2_cycle with stratospheric chemistry

Summary: Fixes to allow co2_cycle with stratospheric chemistry

Contributors: gold2718

Reviewers: DirkOlivie 

Purpose of changes:  co2_cycle does not work with stratospheric chemistry #169 

Github PR URL: https://github.com/NorESMhub/CAM/pull/170

Changes made to build system: Allow co2_cycle to be turned off in configure

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

ERS_Ld5.f09_tn14.NHIST_tropstratchem.betzy_intel.allactive-defaultio

fixes #169 