### PR TITLE
fix problem with setting cam_in%cflx for dms in cap

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -65,7 +65,7 @@ required = True
 
 [oslo_aero]
 protocol = git
-hash = 2414f85
+tag = noresm_oslo_aero_v2
 repo_url = https://github.com/NorESMhub/OSLO_AERO
 local_path = src/chemistry/oslo_aero
 required = True

--- a/src/cpl/nuopc/atm_import_export.F90
+++ b/src/cpl/nuopc/atm_import_export.F90
@@ -893,11 +893,14 @@ contains
     call state_getfldptr(importState,  'Faoo_fdms_ocn', fldptr=fldptr1d, exists=exists, rc=rc)
     if (exists) then
        call cnst_get_ind('DMS', pndx_fdms, abort=.true.)
-       ! Ideally what should happen below is that cam_in%cflx(icol,pndx_fdms) should be set directory from
-       ! fldptr1d. However, the current code in initializes the chemistry consituents surface fluxes
-       ! (i.e.cam_in%cflx(:,:)) to zero in the routine chem_emissions in the module chemistry in
-       ! mozart/chemistry.F90. Introducing cam_in(c)%fdms below stores this information until it can be updated in
-       ! aero_model.F90 when oslo-aero is used.
+       ! Ideally what should happen below is that
+       ! cam_in%cflx(icol,pndx_fdms) should be set directly from
+       ! fldptr1d. However, the code initializes the chemistry
+       ! consituents surface fluxes (i.e.cam_in%cflx(:,:)) to zero in
+       ! the routine in mozart/chemistry.F90 at the start of every
+       ! time step.  Introducing cam_in(c)%fdms below stores this
+       ! information until it can be updated in aero_model.F90 when
+       ! oslo-aero is used.
        g = 1
        do c = begchunk,endchunk
           do i = 1,get_ncols_p(c)

--- a/src/cpl/nuopc/atm_import_export.F90
+++ b/src/cpl/nuopc/atm_import_export.F90
@@ -897,11 +897,10 @@ contains
        do c = begchunk,endchunk
           do i = 1,get_ncols_p(c)
              cam_in(c)%fdms(i) = -fldptr1d(g) * med2mod_areacor(g)
-             cam_in(c)%cflx(i,pndx_fdms) = cam_in(c)%fdms(i)
              g = g + 1
           end do
           ncols = get_ncols_p(c)
-          call outfld( sflxnam(pndx_fdms), cam_in(c)%cflx(:ncols,pndx_fdms), ncols, c)
+          call outfld( sflxnam(pndx_fdms), cam_in(c)%fdms, ncols, c)
        end do
     end if
 

--- a/src/cpl/nuopc/atm_import_export.F90
+++ b/src/cpl/nuopc/atm_import_export.F90
@@ -893,6 +893,11 @@ contains
     call state_getfldptr(importState,  'Faoo_fdms_ocn', fldptr=fldptr1d, exists=exists, rc=rc)
     if (exists) then
        call cnst_get_ind('DMS', pndx_fdms, abort=.true.)
+       ! Ideally what should happen below is that cam_in%cflx(icol,pndx_fdms) should be set directory from
+       ! fldptr1d. However, the current code in initializes the chemistry consituents surface fluxes
+       ! (i.e.cam_in%cflx(:,:)) to zero in the routine chem_emissions in the module chemistry in
+       ! mozart/chemistry.F90. Introducing cam_in(c)%fdms below stores this information until it can be updated in
+       ! aero_model.F90 when oslo-aero is used.
        g = 1
        do c = begchunk,endchunk
           do i = 1,get_ncols_p(c)


### PR DESCRIPTION
In atm_import_export.F90, cam_in%cflx(icol,pndx_fdms) is set correctly when dms is obtained from the ocean component.
However, it is reset to 0 in chemistry.F90. So what needs to be done in the short term is to set cam_in%cflx(icol,pndx_fdms) in aero_model.F90 parallel to how it is set when dms is read from a file rather than being obtained from the ocean component.

fixes NorESMhub/OSLO_AERO#39
