### PR TITLE
noresm2_5_017_cam6_4_041: Update Oslo aero to oslo_aero_2_5a08d

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -84,7 +84,7 @@
 [submodule "oslo_aero"]
 	path = src/chemistry/oslo_aero
 	url = https://github.com/NorESMhub/OSLO_AERO
-	fxtag = noresm_oslo_aero_v3
+	fxtag = oslo_aero_2_5a08d
 	fxrequired = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/NorESMhub/OSLO_AERO.git
 


### PR DESCRIPTION
Summary: Update Oslo Aero to fix problems with updating changes from ESCOMP/CAM

Updated the tag for OSLO Aero to oslo_aero_2_5a08d

Contributors: gold2718, mvertens
Reviewers: mvertens
Purpose of changes: Problems in OSLO_AERO port to cam6_4_041: #183 
Github PR URL: https://github.com/NorESMhub/CAM/pull/184
Changes made to build system: None
Changes made to the namelist: None
Changes to the defaults for the boundary datasets: None
Substantial timing or memory changes: None

Testing: See test results:
/cluster/work/users/mvertens/archive/nf1850_alpha08cam_ne30pg3_ne30pg3_mtn14_20241202/atm/hist

Issues addressed by this PR:
fixes #183 