### PR TITLE
noresm2_5_018_cam6_4_041: Fix SFDMS restart error

### DIFF
--- a/src/cpl/nuopc/atm_import_export.F90
+++ b/src/cpl/nuopc/atm_import_export.F90
@@ -15,7 +15,6 @@ module atm_import_export
   use cam_logfile       , only : iulog
   use cam_history       , only: outfld
   use spmd_utils        , only : masterproc, mpicom
-  use constituents      , only : cnst_get_ind, sflxnam
   use srf_field_check   , only : set_active_Sl_ram1
   use srf_field_check   , only : set_active_Sl_fv
   use srf_field_check   , only : set_active_Sl_soilw
@@ -555,7 +554,6 @@ contains
     ! local variables
     type(ESMF_State)   :: importState
     integer            :: i,n,c,g, num  ! indices
-    integer            :: ncols         ! number of columns
     integer            :: nstep
     logical            :: overwrite_flds
     logical            :: exists
@@ -893,7 +891,6 @@ contains
 
     call state_getfldptr(importState,  'Faoo_fdms_ocn', fldptr=fldptr1d, exists=exists, rc=rc)
     if (exists) then
-       call cnst_get_ind('DMS', pndx_fdms, abort=.true.)
        ! Ideally what should happen below is that
        ! cam_in%cflx(icol,pndx_fdms) should be set directly from
        ! fldptr1d. However, the code initializes the chemistry
@@ -908,8 +905,6 @@ contains
              cam_in(c)%fdms(i) = -fldptr1d(g) * med2mod_areacor(g)
              g = g + 1
           end do
-          ncols = get_ncols_p(c)
-          call outfld( sflxnam(pndx_fdms), cam_in(c)%fdms, ncols, c)
        end do
     end if
 
@@ -1046,7 +1041,6 @@ contains
     type(ESMF_State)  :: importState
     type(ESMF_Clock)  :: clock
     integer           :: i,m,c,n,g  ! indices
-    integer           :: ncols      ! Number of columns
     integer           :: nstep
     logical           :: exists
     real(r8)          :: scale_ndep

--- a/src/physics/cam/restart_physics.F90
+++ b/src/physics/cam/restart_physics.F90
@@ -46,6 +46,11 @@ module restart_physics
     type(var_desc_t) :: wsy_desc
     type(var_desc_t) :: shf_desc
 
+    type(var_desc_t) :: fdms_desc
+    type(var_desc_t) :: fbrf_desc
+    type(var_desc_t) :: fn2o_ocn_desc
+    type(var_desc_t) :: fnh3_ocn_desc
+
   CONTAINS
     subroutine init_restart_physics ( File, pbuf2d)
 
@@ -127,6 +132,11 @@ module restart_physics
     ierr = pio_def_var(File, 'wsx',  pio_double, hdimids, wsx_desc)
     ierr = pio_def_var(File, 'wsy',  pio_double, hdimids, wsy_desc)
     ierr = pio_def_var(File, 'shf',  pio_double, hdimids, shf_desc)
+
+    ierr = pio_def_var(File, 'fdms',      pio_double, hdimids, fdms_desc)
+    ierr = pio_def_var(File, 'fbrf',      pio_double, hdimids, fbrf_desc)
+    ierr = pio_def_var(File, 'fn2o_ocn',  pio_double, hdimids, fn2o_ocn_desc)
+    ierr = pio_def_var(File, 'fnh3_ocn',  pio_double, hdimids, fnh3_ocn_desc)
 
     call radiation_define_restart(file)
 
@@ -327,6 +337,30 @@ module restart_physics
         tmpfield(:ncol,i) = cam_in(i)%shf(:ncol)
       end do
       call pio_write_darray(File, shf_desc, iodesc, tmpfield, ierr)
+
+      do i = begchunk, endchunk
+        ncol = cam_in(i)%ncol
+        tmpfield(:ncol,i) = cam_in(i)%fdms(:ncol)
+      end do
+      call pio_write_darray(File, fdms_desc, iodesc, tmpfield, ierr)
+
+      do i = begchunk, endchunk
+        ncol = cam_in(i)%ncol
+        tmpfield(:ncol,i) = cam_in(i)%fbrf(:ncol)
+      end do
+      call pio_write_darray(File, fbrf_desc, iodesc, tmpfield, ierr)
+
+      do i = begchunk, endchunk
+        ncol = cam_in(i)%ncol
+        tmpfield(:ncol,i) = cam_in(i)%fn2o_ocn(:ncol)
+      end do
+      call pio_write_darray(File, fn2o_ocn_desc, iodesc, tmpfield, ierr)
+
+      do i = begchunk, endchunk
+        ncol = cam_in(i)%ncol
+        tmpfield(:ncol,i) = cam_in(i)%fnh3_ocn(:ncol)
+      end do
+      call pio_write_darray(File, fnh3_ocn_desc, iodesc, tmpfield, ierr)
 
       call radiation_write_restart(file)
 
@@ -583,7 +617,43 @@ module restart_physics
            cam_in(c)%shf(i) = tmpfield2(i, c)
          end do
        end do
-     endif
+     end if
+     ierr = pio_inq_varid(File, 'fdms', vardesc)
+     if (ierr == PIO_NOERR) then ! variable found on restart file
+       call pio_read_darray(File, vardesc, iodesc, tmpfield2, ierr)
+       do c= begchunk, endchunk
+         do i = 1, pcols
+           cam_in(c)%fdms(i) = tmpfield2(i, c)
+         end do
+       end do
+     end if
+     ierr = pio_inq_varid(File, 'fbrf', vardesc)
+     if (ierr == PIO_NOERR) then ! variable found on restart file
+       call pio_read_darray(File, vardesc, iodesc, tmpfield2, ierr)
+       do c= begchunk, endchunk
+         do i = 1, pcols
+           cam_in(c)%fbrf(i) = tmpfield2(i, c)
+         end do
+       end do
+     end if
+     ierr = pio_inq_varid(File, 'fn2o_ocn', vardesc)
+     if (ierr == PIO_NOERR) then ! variable found on restart file
+       call pio_read_darray(File, vardesc, iodesc, tmpfield2, ierr)
+       do c= begchunk, endchunk
+         do i = 1, pcols
+           cam_in(c)%fn2o_ocn(i) = tmpfield2(i, c)
+         end do
+       end do
+     end if
+     ierr = pio_inq_varid(File, 'fnh3_ocn', vardesc)
+     if (ierr == PIO_NOERR) then ! variable found on restart file
+       call pio_read_darray(File, vardesc, iodesc, tmpfield2, ierr)
+       do c= begchunk, endchunk
+         do i = 1, pcols
+           cam_in(c)%fnh3_ocn(i) = tmpfield2(i, c)
+         end do
+       end do
+     end if
      call pio_seterrorhandling(File, err_handling)
 
      deallocate(tmpfield2)


### PR DESCRIPTION
Summary: Fix SFDMS history output restart error

Contributors: gold2718

Reviewers: oyvindseland

Purpose of changes: [FAIL ERR_Ld3.ne30pg3_tn14.N1850.betzy_intel.allactive-defaultio COMPARE_base_rest failing with latest alpha tag](https://github.com/NorESMhub/CAM/issues/193)

Github PR URL: https://github.com/NorESMhub/CAM/pull/194

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None]

Substantial timing or memory changes: None

- Add fdms, fbrf, fn2o_ocn and fnh3_ocn to the restart file
- Remove bad outfld call in atm_import_export

ERR_Ld3.ne30pg3_tn14.N1850.betzy_intel.allactive-defaultio
- Still fails COMPARE_base_rest but due only to a BLOM field:
```
/cluster/work/users/goldy/work/test_N1850_2025_02_10_19_46/ERR_Ld3.ne30pg3_tn14.N1850.betzy_intel.allactive-defaultio.20250210_194627_7wl8qh/run/ERR_Ld3.ne30pg3_tn14.N1850.betzy_intel.allactive-defaultio.20250210_194627_7wl8qh.blom.hbgcd.0001-01-03.nc.base.cprnc.out

 dustflx0100   (x,y,time)  t_index =      1     1
          5   138600  (   128,   282,     1) (   274,    18,     1) (   142,   35
6,     1) (   142,   356,     1)
               81619   8.952484309432407E-10   0.000000000000000E+00 1.6E-16  4.1
00062981184441E-15 9.3E-07  4.100062981184441E-15
               81619   8.952484309432407E-10   0.000000000000000E+00          3.9
39141120766227E-15          3.939141120766227E-15
              138600  (   128,   282,     1) (   274,    18,     1)
          avg abs field values:    8.886212078673683E-13    rms diff: 5.7E-19   a
vg rel diff(npos):  9.3E-07
                                   8.886212078673683E-13                        a
vg decimal digits(ndif):  2.8 worst:  1.4
 RMS dustflx0100                      5.6811E-19            NORMALIZED  6.3931E-07

 dustflx0500   (x,y,time)  t_index =      1     1
          2   138600  (   139,   282,     1) (    68,    11,     1) (    61,    24,     1) (    52,    32,     1)
               75163   1.245602093691289E-10   0.000000000000000E+00 1.2E-28  1.231007196650085E-26 4.5E-07  9.043855018191469E-28
               75163   1.245602093691289E-10   0.000000000000000E+00          1.218956267802065E-26          8.828225012722957E-28
              138600  (   139,   282,     1) (    68,    11,     1)
          avg abs field values:    1.483571769665508E-14    rms diff: 0.0E+00   avg rel diff(npos):  4.5E-07
                                   1.483571769665508E-14                        avg decimal digits(ndif):  1.8 worst:  1.6
 RMS dustflx0500                      0.0000E+00            NORMALIZED  0.0000E+00
```

#193