### PR TITLE
noresm3_0_002_cam6_4_070: Add two degree atmosphere model

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -571,8 +571,8 @@ my $prescribe_aerosols = $TRUE;
 if ($simple_phys) {$prescribe_aerosols = $FALSE;}
 
 if( $chem =~ /_oslo/){
+    # Oslo Aero does not support a prescribed aerosol mode
     $prescribe_aerosols = $FALSE;
-    print " ==> Using Oslo aerosols: PRESCRIBED AERO = FALSE (not yet implemented) \n"
 }
 
 # CTSM Dust emissions scheme

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -40,6 +40,7 @@
 <ncdata hgrid="mpasa60"  nlev="93" analytic_ic="1" >atm/cam/inic/mpas/mpasa60_L93_notopo_coords_c240814.nc</ncdata>
 
 <!-- Files with initial conditions -->
+<!-- Finite volume (Lin-Rood) dycore -->
 <ncdata dyn="fv"  hgrid="0.23x0.31" nlev="26" ic_ymd="101"      >atm/cam/inic/fv/cami_0000-01-01_0.23x0.31_L26_c100513.nc</ncdata>
 <ncdata dyn="fv"  hgrid="0.23x0.31" nlev="26" ic_ymd="901"      >atm/cam/inic/fv/cami_0000-09-01_0.23x0.31_L26_c061106.nc</ncdata>
 <ncdata dyn="fv"  hgrid="0.47x0.63" nlev="26" ic_ymd="101"      >atm/cam/inic/fv/cami_1980-01-01_0.47x0.63_L26_c071226.nc</ncdata>
@@ -104,20 +105,6 @@
 <ncdata dyn="fv" hgrid="1.9x2.5" nlev="30" chem="trop_strat_mam4_vbs" ic_ymd="101" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_1.9x2.5_L30_c121015.nc</ncdata>
 <ncdata dyn="fv" hgrid="1.9x2.5" nlev="30" chem="trop_strat_mam5_vbs" ic_ymd="101" >atm/cam/inic/fv/trop_strat_mam3_chem_2000-01-01_1.9x2.5_L30_c121015.nc</ncdata>
 
-<ncdata dyn="se" hgrid="ne30np4" nlev="32" chem="trop_strat_mam4_vbs">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
-<ncdata dyn="se" hgrid="ne30np4" nlev="32" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
-<ncdata dyn="se" hgrid="ne30np4" nlev="32" chem="trop_strat_mam4_ts2">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
-<ncdata dyn="se" hgrid="ne30np4" nlev="32" chem="trop_strat_mam5_ts2">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
-<ncdata dyn="se" hgrid="ne30np4" npg="3" nlev="32" chem="trop_strat_mam4_vbs">atm/cam/inic/se/f.e22.FC2010climo.ne30pg3_ne30pg3_mg17.cam6_2_032.001.cam.i.0007-01-01-00000_c200623.nc</ncdata>
-<ncdata dyn="se" hgrid="ne30np4" npg="3" nlev="32" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.e22.FC2010climo.ne30pg3_ne30pg3_mg17.cam6_2_032.001.cam.i.0007-01-01-00000_c200623.nc</ncdata>
-<ncdata dyn="se" hgrid="ne0np4CONUS.ne30x8" nlev="32" chem="trop_strat_mam4_vbs">atm/cam/inic/se/f.e22.FCnudged.ne0CONUSne30x8_ne0CONUSne30x8_mt12.cam6_2_032.002.cam.i.2013-01-01-00000_c200623.nc</ncdata>
-<ncdata dyn="se" hgrid="ne0np4CONUS.ne30x8" nlev="32" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.e22.FCnudged.ne0CONUSne30x8_ne0CONUSne30x8_mt12.cam6_2_032.002.cam.i.2013-01-01-00000_c200623.nc</ncdata>
-<ncdata dyn="se" hgrid="ne30np4" nlev="58" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.e22.FCnudged.ne30_ne30_mg17.release-cesm2.2.0_spinup.2010_2020.001.cam.i.2011-01-01-00000_L58_c220310.nc</ncdata>
-<ncdata dyn="se" hgrid="ne30np4" nlev="93" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.cam6_3_160.FCMT_ne30.moving_mtn.001.cam.i.1996-01-01-00000_c240618.nc</ncdata>
-
-<ncdata dyn="se" hgrid="ne30np4" npg="3" nlev="58">atm/cam/inic/se/FLT_L58_ne30pg3_IC_c220623.nc</ncdata>
-<ncdata dyn="se" hgrid="ne30np4" npg="3" nlev="93">atm/cam/inic/se/c153_ne30pg3_FMTHIST_x02.cam.i.1990-01-01-00000_c240618.nc</ncdata>
-
 <ncdata dyn="fv"  hgrid="4x5"       nlev="26"  chem="trop_mozart" ic_ymd="901" >atm/cam/chem/trop_mozart/ic/cami_0000-09-01_4x5_L26_c060217.nc</ncdata>
 <ncdata dyn="fv"  hgrid="10x15"     nlev="26"  chem="trop_mozart" ic_ymd="901" >atm/cam/chem/trop_mozart/ic/cami_0000-09-01_10x15_L26_c060216.nc</ncdata>
 
@@ -149,15 +136,12 @@
 <ncdata dyn="fv"  hgrid="0.47x0.63" nlev="130" waccmx="1">atm/waccm/ic/FC6X2000_f05_spinup01.cam.i.0002-01-01-00000_c190711.nc</ncdata>
 <ncdata dyn="fv"  hgrid="4x5"       nlev="130" waccmx="1"  ic_ymd="101" aquaplanet="1">atm/waccm/ic/waccmx_mam4_aqua_4x5_L130_c180803.nc</ncdata>
 <ncdata dyn="fv"  hgrid="1.9x2.5"   nlev="130" waccmx="1"  ic_ymd="101" aquaplanet="1">atm/waccm/ic/waccmx_mam4_aqua_1.9x2.5_L130_c180803.nc</ncdata>
-<ncdata dyn="se"  hgrid="ne5np4"    nlev="126" waccmx="1"               >atm/waccm/ic/waccmx_aqua_ne5np4_126L_c210304.nc</ncdata>
-<ncdata dyn="se"  hgrid="ne16np4"   nlev="126" waccmx="1"               >atm/waccm/ic/waccmx_ne16np4_126L_c200108.nc</ncdata>
-<ncdata dyn="se"  hgrid="ne16np4"   nlev="130" waccmx="1"               >atm/waccm/ic/fx2000_phys-ionos-cpl_ne16_spinup03.cam.i.0002-01-01-00000_c201005.nc</ncdata>
-<ncdata dyn="se"  hgrid="ne16np4"   nlev="126" waccmx="1" aquaplanet="1">atm/waccm/ic/waccmx_aqua_ne16np4_126L_c191108.nc</ncdata>
-<ncdata dyn="se"  hgrid="ne16np4"   nlev="126" waccmx="1" aquaplanet="1" ionosphere="none">atm/waccm/ic/waccmx4_neutral_aquap_ne16np4_126lev_c200827.nc</ncdata>
-<ncdata dyn="se"  hgrid="ne30np4"   nlev="130" waccmx="1"               >atm/waccm/ic/fx2000_phys-ionos-cpl_ne30_spinup01.cam.i.0002-01-01-00000_c201014.nc</ncdata>
-<ncdata dyn="se"  hgrid="ne30np4" npg="3" nlev="130" waccmx="1"         >atm/waccm/ic/waccmx_ne30pg3_c231005.nc</ncdata>
 
+<!-- Spectral Element (SE) dycore -->
+
+<!-- NE3 -->
 <ncdata dyn="se" hgrid="ne3np4" nlev="93" chem="trop_strat_mam5_ts4" >atm/cam/inic/se/FCts4MTHIST_ne3pg3_spinup02.cam.i.1980-01-01_c240702.nc</ncdata>
+<ncdata dyn="se" hgrid="ne3np4"   nlev="93"             ic_ymd="101" >atm/cam/inic/se/cam6_FMTHIST_ne3pg3_mg37_L93_79-02-01_c240517.nc</ncdata>
 <ncdata dyn="se" hgrid="ne3np4"   nlev="32"             ic_ymd="101" >atm/cam/inic/se/cam6_QPC6_topo_ne3pg3_mg37_L32_01-01-31_c221214.nc</ncdata>
 <ncdata dyn="se" hgrid="ne3np4"   nlev="32"             ic_ymd="901" >atm/cam/inic/se/CESM2.F2000climo.ne3np4.cam.i.0003-09-01-00000.nc</ncdata>
 <ncdata dyn="se" hgrid="ne3np4"   nlev="30"             ic_ymd="101" >atm/cam/inic/se/cami_0000-01-01_ne3np4_L30_c120315.nc</ncdata>
@@ -165,27 +149,54 @@
 <ncdata dyn="se" hgrid="ne3np4"   nlev="26"             ic_ymd="101" >atm/cam/inic/se/cami_0000-01-01_ne3np4_L26_c120525.nc</ncdata>
 <ncdata dyn="se" hgrid="ne3np4"   nlev="26"             ic_ymd="901" >atm/cam/inic/se/cami_0000-01-01_ne3np4_L26_c120525.nc</ncdata>
 <ncdata dyn="se" hgrid="ne3np4"   nlev="58"             ic_ymd="101" >atm/cam/inic/se/cam6_QPC6_topo_ne3pg3_mg37_L58_01-01-31_c221214.nc</ncdata>
-<ncdata dyn="se" hgrid="ne3np4"   nlev="93"             ic_ymd="101" >atm/cam/inic/se/cam6_FMTHIST_ne3pg3_mg37_L93_79-02-01_c240517.nc</ncdata>
+<!-- NE5 -->
 <ncdata dyn="se" hgrid="ne5np4"   nlev="30"             ic_ymd="101" >atm/cam/inic/homme/cami-mam3_0000-01_ne5np4_L30.140707.nc</ncdata>
 <ncdata dyn="se" hgrid="ne5np4"   nlev="32"             ic_ymd="101" >atm/cam/inic/se/F2000climo_ne5pg3_mg37_L32_01-01-31_c230520.nc</ncdata>
 <ncdata dyn="se" hgrid="ne5np4"   nlev="58"             ic_ymd="101" >atm/cam/inic/se/F2000climo_ne5pg3_mg37_L58_01-01-31_c230520.nc</ncdata>
+<!-- NE16 -->
 <ncdata dyn="se" hgrid="ne16np4"  nlev="26"             ic_ymd="101" >atm/cam/inic/se/ape_topo_cam4_ne16np4_L26_c171020.nc</ncdata>
 <ncdata dyn="se" hgrid="ne16np4"  nlev="30"             ic_ymd="101" >atm/cam/inic/se/ape_topo_cam4_ne16np4_L30_c171020.nc</ncdata>
 <ncdata dyn="se" hgrid="ne16np4"  nlev="32"             ic_ymd="101" >atm/cam/inic/se/ape_topo_cam4_ne16np4_L32_c171020.nc</ncdata>
+<ncdata dyn="se" hgrid="ne16np4" npg="3" nlev="58">atm/cam/inic/se/FLT_L58_ne16pg3_IC_NF1850_c250411.nc</ncdata>
+<!-- NE30 -->
+<ncdata dyn="se" hgrid="ne30np4" nlev="32" chem="trop_strat_mam4_vbs">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
+<ncdata dyn="se" hgrid="ne30np4" nlev="32" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
+<ncdata dyn="se" hgrid="ne30np4" nlev="32" chem="trop_strat_mam4_ts2">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
+<ncdata dyn="se" hgrid="ne30np4" nlev="32" chem="trop_strat_mam5_ts2">atm/cam/inic/se/f.e22.FC2010climo.ne30_ne30_mg17.cam6_2_032.001.cam.i.0006-01-01-00000_c200623.nc</ncdata>
+<ncdata dyn="se" hgrid="ne30np4" npg="3" nlev="32" chem="trop_strat_mam4_vbs">atm/cam/inic/se/f.e22.FC2010climo.ne30pg3_ne30pg3_mg17.cam6_2_032.001.cam.i.0007-01-01-00000_c200623.nc</ncdata>
+<ncdata dyn="se" hgrid="ne30np4" npg="3" nlev="32" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.e22.FC2010climo.ne30pg3_ne30pg3_mg17.cam6_2_032.001.cam.i.0007-01-01-00000_c200623.nc</ncdata>
+<ncdata dyn="se" hgrid="ne30np4" nlev="58" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.e22.FCnudged.ne30_ne30_mg17.release-cesm2.2.0_spinup.2010_2020.001.cam.i.2011-01-01-00000_L58_c220310.nc</ncdata>
+<ncdata dyn="se" hgrid="ne30np4" nlev="93" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.cam6_3_160.FCMT_ne30.moving_mtn.001.cam.i.1996-01-01-00000_c240618.nc</ncdata>
+
+<ncdata dyn="se" hgrid="ne30np4" npg="3" nlev="58">atm/cam/inic/se/FLT_L58_ne30pg3_IC_c220623.nc</ncdata>
+<ncdata dyn="se" hgrid="ne30np4" npg="3" nlev="93">atm/cam/inic/se/c153_ne30pg3_FMTHIST_x02.cam.i.1990-01-01-00000_c240618.nc</ncdata>
+<ncdata dyn="se"  hgrid="ne5np4"    nlev="126" waccmx="1"               >atm/waccm/ic/waccmx_aqua_ne5np4_126L_c210304.nc</ncdata>
+<ncdata dyn="se"  hgrid="ne30np4"   nlev="130" waccmx="1"               >atm/waccm/ic/fx2000_phys-ionos-cpl_ne30_spinup01.cam.i.0002-01-01-00000_c201014.nc</ncdata>
+<ncdata dyn="se"  hgrid="ne30np4" npg="3" nlev="130" waccmx="1"         >atm/waccm/ic/waccmx_ne30pg3_c231005.nc</ncdata>
 <ncdata dyn="se" hgrid="ne30np4"  nlev="26"             ic_ymd="101" >atm/cam/inic/se/ape_topo_cam4_ne30np4_L26_c171020.nc</ncdata>
 <ncdata dyn="se" hgrid="ne30np4"  nlev="30"             ic_ymd="101" >atm/cam/inic/se/ape_topo_cam4_ne30np4_L30_c171020.nc</ncdata>
 <ncdata dyn="se" hgrid="ne30np4"  nlev="32"             ic_ymd="101" >atm/cam/inic/se/F2000climo_ne30pg3_mg17_01-01-00000_c200424.nc</ncdata>
+<!-- NE60 -->
 <ncdata dyn="se" hgrid="ne60np4"  nlev="26"             ic_ymd="101" >atm/cam/inic/se/ape_topo_cam4_ne60np4_L26_c171018.nc</ncdata>
 <ncdata dyn="se" hgrid="ne60np4"  nlev="30"             ic_ymd="101" >atm/cam/inic/se/ape_topo_cam4_ne60np4_L30_c171020.nc</ncdata>
 <ncdata dyn="se" hgrid="ne60np4"  nlev="32"             ic_ymd="101" >atm/cam/inic/se/ape_topo_cam4_ne60np4_L32_c171020.nc</ncdata>
+<!-- NE120 -->
 <ncdata dyn="se" hgrid="ne120np4" nlev="26"             ic_ymd="101" >atm/cam/inic/se/ape_topo_cam4_ne120np4_L26_c171018.nc</ncdata>
 <ncdata dyn="se" hgrid="ne120np4" nlev="30"             ic_ymd="101" >atm/cam/inic/se/ape_topo_cam4_ne120np4_L30_c171024.nc</ncdata>
 <ncdata dyn="se" hgrid="ne120np4" nlev="32"             ic_ymd="101" >atm/cam/inic/se/F2000climo_ne120pg3_mt13_01-01-00000_c200420.nc</ncdata>
+<!-- NE240 -->
 <ncdata dyn="se" hgrid="ne240np4" nlev="26"             ic_ymd="101" >atm/cam/inic/homme/cami_1850-01-01_ne240np4_L26_c110314.nc</ncdata>
 <ncdata dyn="se" hgrid="ne240np4" nlev="26"             ic_ymd="901" >atm/cam/inic/homme/cami_0000-09-01_ne240np4_L26_c061106.nc</ncdata>
 
 <ncdata dyn="se" hgrid="ne240np4" nlev="30"             ic_ymd="101" >atm/cam/inic/homme/cami-mam3_0000-01-ne240np4_L30_c111004.nc</ncdata>
-
+<!-- SE Refined grid, CONUS -->
+<ncdata dyn="se" hgrid="ne0np4CONUS.ne30x8" nlev="32" chem="trop_strat_mam4_vbs">atm/cam/inic/se/f.e22.FCnudged.ne0CONUSne30x8_ne0CONUSne30x8_mt12.cam6_2_032.002.cam.i.2013-01-01-00000_c200623.nc</ncdata>
+<ncdata dyn="se" hgrid="ne0np4CONUS.ne30x8" nlev="32" chem="trop_strat_mam5_vbs">atm/cam/inic/se/f.e22.FCnudged.ne0CONUSne30x8_ne0CONUSne30x8_mt12.cam6_2_032.002.cam.i.2013-01-01-00000_c200623.nc</ncdata>
+<ncdata dyn="se" hgrid="ne0np4CONUS.ne30x8"       nlev="32" ic_ymd="101">atm/cam/inic/se/F2000climo_CONUS_30x8_mt12_mg3_01-01-00000_c200421.nc</ncdata>
+<!-- SE Refined grid, ARCTIC -->
+<ncdata dyn="se" hgrid="ne0np4.ARCTIC.ne30x4"     nlev="32" ic_ymd="101">atm/cam/inic/se/FHIST_ARCTIC_ne30x4_mt12_1979bc-mg3_01-01-00000_c200424.nc</ncdata>
+<ncdata dyn="se" hgrid="ne0np4.ARCTICGRIS.ne30x8" nlev="32" ic_ymd="101">atm/cam/inic/se/FHIST_ARCTICGRIS_ne30x8_mt12_1979bc-mg3_01-01-00000_c200428.nc</ncdata>
+<!-- SE aquaplanet -->
 <ncdata dyn="se" hgrid="ne5np4"   nlev="26"  aquaplanet="1" ic_ymd="101" >atm/cam/inic/se/ape_cam4_ne5np4_L26_c170517.nc</ncdata>
 <ncdata dyn="se" hgrid="ne16np4"  nlev="26"  aquaplanet="1" ic_ymd="101" >atm/cam/inic/se/ape_cam4_ne16np4_L26_c170417.nc</ncdata>
 <ncdata dyn="se" hgrid="ne30np4"  nlev="26"  aquaplanet="1" ic_ymd="101" >atm/cam/inic/se/ape_cam4_ne30np4_L26_c170417.nc</ncdata>
@@ -205,10 +216,6 @@
 <ncdata dyn="se" hgrid="ne120np4"  nlev="32"  aquaplanet="1" ic_ymd="101" >atm/cam/inic/se/ape_cam6_ne120np4_L32_c170908.nc</ncdata>
 <ncdata dyn="se" hgrid="ne240np4"  nlev="32"  aquaplanet="1" ic_ymd="101" >atm/cam/inic/se/ape_cam6_ne240np4_L32_c170908.nc</ncdata>
 
-<ncdata dyn="se" hgrid="ne0np4CONUS.ne30x8"       nlev="32" ic_ymd="101">atm/cam/inic/se/F2000climo_CONUS_30x8_mt12_mg3_01-01-00000_c200421.nc</ncdata>
-<ncdata dyn="se" hgrid="ne0np4.ARCTIC.ne30x4"     nlev="32" ic_ymd="101">atm/cam/inic/se/FHIST_ARCTIC_ne30x4_mt12_1979bc-mg3_01-01-00000_c200424.nc</ncdata>
-<ncdata dyn="se" hgrid="ne0np4.ARCTICGRIS.ne30x8" nlev="32" ic_ymd="101">atm/cam/inic/se/FHIST_ARCTICGRIS_ne30x8_mt12_1979bc-mg3_01-01-00000_c200428.nc</ncdata>
-
 <ncdata dyn="se" hgrid="ne5np4"   nlev="66"           ic_ymd="101">atm/waccm/ic/wa3_ne5np4_1950_spinup.cam2.i.1960-01-01-00000_c150810.nc</ncdata>
 <ncdata dyn="se" hgrid="ne30np4"  nlev="70"           ic_ymd="101">atm/waccm/ic/FW2000_ne30_L70_01-01-0001_c200602.nc</ncdata>
 <ncdata dyn="se" hgrid="ne30np4"  nlev="70"  npg="3" chem="waccm_sc_mam4">atm/waccm/ic/FWsc2000climo_ne30pg3_L70_0002-01-01_c221103.nc</ncdata>
@@ -217,6 +224,7 @@
 
 <ncdata dyn="se" hgrid="ne0np4CONUS.ne30x8"       nlev="70" ic_ymd="101">atm/waccm/ic/FW2000_CONUS_30x8_L70_01-01-0001_c200602.nc</ncdata>
 
+<!-- MPAS dycore -->
 <ncdata hgrid="mpasa120" nlev="70" waccm_phys="1">atm/waccm/ic/mpasa120_L70.waccm_topography_SC_c240904.nc</ncdata>
 
 <ncdata hgrid="mpasa480" nlev="32" >atm/cam/inic/mpas/cami_01-01-2000_00Z_mpasa480_L32_CFSR_c240508.nc</ncdata>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -61,6 +61,14 @@
     <alias>NF1850mam4</alias>
     <lname>1850_CAM70%LT%NORESM%GHGMAM4_CLM60%SP_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV</lname>
   </compset>
+  <compset>
+    <alias>NF1850fates-sp</alias>
+    <lname>1850_CAM70%LT%NORESM%CAMoslo_CLM60%FATES-SP_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
+  </compset>
+  <compset>
+    <alias>NF1850fates-nocomp</alias>
+    <lname>1850_CAM70%LT%NORESM%CAMoslo_CLM60%FATES-NOCOMP_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
+  </compset>
 
   <compset>
     <alias>NFLTHIST</alias>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -74,6 +74,41 @@
         </rootpe>
       </pes>
     </mach>
+    <mach name="betzy">
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
   </grid>
   <grid name="a%ne3np4">
     <mach name="any">
@@ -150,7 +185,7 @@
     </mach>
   </grid>
   <grid name="a%ne30" >
-    <mach name="hobart|izumi">
+    <mach name="betzy|izumi">
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
@@ -186,101 +221,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne30" >
-    <mach name="bluewaters">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-40</ntasks_atm>
-	  <ntasks_lnd>-40</ntasks_lnd>
-	  <ntasks_rof>-40</ntasks_rof>
-	  <ntasks_ice>-40</ntasks_ice>
-	  <ntasks_ocn>-40</ntasks_ocn>
-	  <ntasks_glc>-40</ntasks_glc>
-	  <ntasks_wav>-40</ntasks_wav>
-	  <ntasks_cpl>-40</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne30" >
-    <mach name="mira">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>2048</ntasks_atm>
-	  <ntasks_lnd>2048</ntasks_lnd>
-	  <ntasks_rof>2048</ntasks_rof>
-	  <ntasks_ice>2048</ntasks_ice>
-	  <ntasks_ocn>2048</ntasks_ocn>
-	  <ntasks_glc>2048</ntasks_glc>
-	  <ntasks_wav>2048</ntasks_wav>
-	  <ntasks_cpl>2048</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_ocn>8</nthrds_ocn>
-	  <nthrds_glc>8</nthrds_glc>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_cpl>8</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%mpasa120">
-    <mach name="cheyenne">
-      <pes pesize="any" compset="_CAM60%WCSC">
-	<ntasks>
-	  <ntasks_atm>360</ntasks_atm>
-	  <ntasks_lnd>360</ntasks_lnd>
-	  <ntasks_rof>360</ntasks_rof>
-	  <ntasks_ice>360</ntasks_ice>
-	  <ntasks_ocn>360</ntasks_ocn>
-	  <ntasks_cpl>360</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-      </pes>
-    </mach>
     <mach name="derecho">
       <pes pesize="any" compset="_CAM60%WCSC">
 	<ntasks>
@@ -303,18 +244,18 @@
     </mach>
   </grid>
   <grid name="a%ne16" >
-    <mach name="cheyenne">
+    <mach name="betzy">
       <pes pesize="any" compset="_CAM\d0%WX">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>720</ntasks_atm>
-	  <ntasks_lnd>720</ntasks_lnd>
-	  <ntasks_rof>720</ntasks_rof>
-	  <ntasks_ice>720</ntasks_ice>
-	  <ntasks_ocn>720</ntasks_ocn>
-	  <ntasks_glc>720</ntasks_glc>
-	  <ntasks_wav>720</ntasks_wav>
-	  <ntasks_cpl>720</ntasks_cpl>
+	  <ntasks_atm>-4</ntasks_atm>
+	  <ntasks_lnd>-4</ntasks_lnd>
+	  <ntasks_rof>-4</ntasks_rof>
+	  <ntasks_ice>-4</ntasks_ice>
+	  <ntasks_ocn>-4</ntasks_ocn>
+	  <ntasks_glc>-4</ntasks_glc>
+	  <ntasks_wav>-4</ntasks_wav>
+	  <ntasks_cpl>-4</ntasks_cpl>
 	</ntasks>
 	<nthrds>
 	  <nthrds_atm>1</nthrds_atm>
@@ -361,18 +302,18 @@
     </mach>
   </grid>
   <grid name="a%ne30" >
-    <mach name="cheyenne">
+    <mach name="betzy">
       <pes pesize="any" compset="_CAM\d0%WX">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>1728</ntasks_atm>
-	  <ntasks_lnd>1728</ntasks_lnd>
-	  <ntasks_rof>1728</ntasks_rof>
-	  <ntasks_ice>1728</ntasks_ice>
-	  <ntasks_ocn>1728</ntasks_ocn>
-	  <ntasks_glc>1728</ntasks_glc>
-	  <ntasks_wav>1728</ntasks_wav>
-	  <ntasks_cpl>1728</ntasks_cpl>
+	  <ntasks_atm>-14</ntasks_atm>
+	  <ntasks_lnd>-14</ntasks_lnd>
+	  <ntasks_rof>-14</ntasks_rof>
+	  <ntasks_ice>-14</ntasks_ice>
+	  <ntasks_ocn>-14</ntasks_ocn>
+	  <ntasks_glc>-14</ntasks_glc>
+	  <ntasks_wav>-14</ntasks_wav>
+	  <ntasks_cpl>-14</ntasks_cpl>
 	</ntasks>
 	<nthrds>
 	  <nthrds_atm>1</nthrds_atm>
@@ -457,8 +398,35 @@
     </mach>
   </grid>
   <grid name="a%ne30" >
-    <mach name="cheyenne">
+    <mach name="betzy">
       <pes pesize="any" compset="_CAM70%LT%GHGMAM4_">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-8</ntasks_atm>
+	  <ntasks_lnd>-8</ntasks_lnd>
+	  <ntasks_rof>-8</ntasks_rof>
+	  <ntasks_ice>-8</ntasks_ice>
+	  <ntasks_ocn>-8</ntasks_ocn>
+	  <ntasks_cpl>-8</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+      <pes pesize="any" compset="_CAM70%LT%OSLO">
 	<comment>none</comment>
 	<ntasks>
 	  <ntasks_atm>-8</ntasks_atm>
@@ -542,41 +510,6 @@
     </mach>
   </grid>
   <grid name="a%ne120">
-    <mach name="cheyenne">
-      <pes pesize="any" compset="_CAM6|_CAM7">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>1800</ntasks_atm>
-	  <ntasks_lnd>1800</ntasks_lnd>
-	  <ntasks_rof>1800</ntasks_rof>
-	  <ntasks_ice>1800</ntasks_ice>
-	  <ntasks_ocn>1800</ntasks_ocn>
-	  <ntasks_glc>1800</ntasks_glc>
-	  <ntasks_wav>1800</ntasks_wav>
-	  <ntasks_cpl>1800</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
     <mach name="any">
       <pes pesize="any" compset="any">
 	<comment>none</comment>
@@ -613,117 +546,6 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne120">
-    <mach name="bluewaters">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>4800</ntasks_atm>
-	  <ntasks_lnd>4800</ntasks_lnd>
-	  <ntasks_rof>4800</ntasks_rof>
-	  <ntasks_ice>4800</ntasks_ice>
-	  <ntasks_ocn>4800</ntasks_ocn>
-	  <ntasks_glc>4800</ntasks_glc>
-	  <ntasks_wav>4800</ntasks_wav>
-	  <ntasks_cpl>4800</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne120">
-    <mach name="mira">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>16384</ntasks_atm>
-	  <ntasks_lnd>16384</ntasks_lnd>
-	  <ntasks_rof>16384</ntasks_rof>
-	  <ntasks_ice>16384</ntasks_ice>
-	  <ntasks_ocn>16384</ntasks_ocn>
-	  <ntasks_glc>16384</ntasks_glc>
-	  <ntasks_wav>16384</ntasks_wav>
-	  <ntasks_cpl>16384</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_ocn>8</nthrds_ocn>
-	  <nthrds_glc>8</nthrds_glc>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_cpl>8</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%ne120">
-    <mach name="stampede|titan">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>8192</ntasks_atm>
-	  <ntasks_lnd>8192</ntasks_lnd>
-	  <ntasks_rof>8192</ntasks_rof>
-	  <ntasks_ice>8192</ntasks_ice>
-	  <ntasks_ocn>8192</ntasks_ocn>
-	  <ntasks_glc>8192</ntasks_glc>
-	  <ntasks_wav>8192</ntasks_wav>
-	  <ntasks_cpl>8192</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>
-	  <nthrds_lnd>2</nthrds_lnd>
-	  <nthrds_rof>2</nthrds_rof>
-	  <nthrds_ice>2</nthrds_ice>
-	  <nthrds_ocn>2</nthrds_ocn>
-	  <nthrds_glc>2</nthrds_glc>
-	  <nthrds_wav>2</nthrds_wav>
-	  <nthrds_cpl>2</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%ne240">
     <mach name="any">
       <pes pesize="any" compset="any">
@@ -737,43 +559,6 @@
 	  <ntasks_glc>-32</ntasks_glc>
 	  <ntasks_wav>-32</ntasks_wav>
 	  <ntasks_cpl>-32</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%T31">
-    <mach name="hera|sierra" >
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>64</ntasks_atm>
-	  <ntasks_lnd>64</ntasks_lnd>
-	  <ntasks_rof>64</ntasks_rof>
-	  <ntasks_ice>64</ntasks_ice>
-	  <ntasks_ocn>64</ntasks_ocn>
-	  <ntasks_glc>64</ntasks_glc>
-	  <ntasks_wav>64</ntasks_wav>
-	  <ntasks_cpl>64</ntasks_cpl>
 	</ntasks>
 	<nthrds>
 	  <nthrds_atm>1</nthrds_atm>
@@ -895,401 +680,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%1.9x2.5">
-    <mach name="pleiades-bro">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>224</ntasks_atm>
-	  <ntasks_lnd>224</ntasks_lnd>
-	  <ntasks_rof>224</ntasks_rof>
-	  <ntasks_ice>224</ntasks_ice>
-	  <ntasks_ocn>224</ntasks_ocn>
-	  <ntasks_glc>224</ntasks_glc>
-	  <ntasks_wav>224</ntasks_wav>
-	  <ntasks_cpl>224</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5">
-    <mach name="pleiades-has">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>192</ntasks_atm>
-	  <ntasks_lnd>192</ntasks_lnd>
-	  <ntasks_rof>192</ntasks_rof>
-	  <ntasks_ice>192</ntasks_ice>
-	  <ntasks_ocn>192</ntasks_ocn>
-	  <ntasks_glc>192</ntasks_glc>
-	  <ntasks_wav>192</ntasks_wav>
-	  <ntasks_cpl>192</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5">
-    <mach name="pleiades-san">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>192</ntasks_atm>
-	  <ntasks_lnd>192</ntasks_lnd>
-	  <ntasks_rof>192</ntasks_rof>
-	  <ntasks_ice>192</ntasks_ice>
-	  <ntasks_ocn>192</ntasks_ocn>
-	  <ntasks_glc>192</ntasks_glc>
-	  <ntasks_wav>192</ntasks_wav>
-	  <ntasks_cpl>192</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5">
-    <mach name="pleiades-ivy">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>240</ntasks_atm>
-	  <ntasks_lnd>240</ntasks_lnd>
-	  <ntasks_rof>240</ntasks_rof>
-	  <ntasks_ice>240</ntasks_ice>
-	  <ntasks_ocn>240</ntasks_ocn>
-	  <ntasks_glc>240</ntasks_glc>
-	  <ntasks_wav>240</ntasks_wav>
-	  <ntasks_cpl>240</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%0.9x1.25">
-    <mach name="cheyenne">
-      <pes pesize="any" compset="any">
-        <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>360</ntasks_atm>
-          <ntasks_lnd>360</ntasks_lnd>
-          <ntasks_rof>360</ntasks_rof>
-          <ntasks_ice>360</ntasks_ice>
-          <ntasks_ocn>360</ntasks_ocn>
-          <ntasks_glc>360</ntasks_glc>
-          <ntasks_wav>360</ntasks_wav>
-          <ntasks_cpl>360</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>3</nthrds_atm>
-          <nthrds_lnd>3</nthrds_lnd>
-          <nthrds_rof>3</nthrds_rof>
-          <nthrds_ice>3</nthrds_ice>
-          <nthrds_ocn>3</nthrds_ocn>
-          <nthrds_glc>3</nthrds_glc>
-          <nthrds_wav>3</nthrds_wav>
-          <nthrds_cpl>3</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%1.9x2.5">
-    <mach name="cheyenne">
-      <pes pesize="any" compset="_CAM\d0%WX.*_SLND.*_DOCN%AQP">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>48</ntasks_atm>
-	  <ntasks_lnd>48</ntasks_lnd>
-	  <ntasks_rof>48</ntasks_rof>
-	  <ntasks_ice>48</ntasks_ice>
-	  <ntasks_ocn>48</ntasks_ocn>
-	  <ntasks_glc>48</ntasks_glc>
-	  <ntasks_wav>48</ntasks_wav>
-	  <ntasks_cpl>48</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>3</nthrds_atm>
-	  <nthrds_lnd>3</nthrds_lnd>
-	  <nthrds_rof>3</nthrds_rof>
-	  <nthrds_ice>3</nthrds_ice>
-	  <nthrds_ocn>3</nthrds_ocn>
-	  <nthrds_glc>3</nthrds_glc>
-	  <nthrds_wav>3</nthrds_wav>
-	  <nthrds_cpl>3</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-      <pes pesize="any" compset="_CAM\d0%WX.*_CLM.*_DOCN%DOM">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>144</ntasks_atm>
-	  <ntasks_lnd>144</ntasks_lnd>
-	  <ntasks_rof>144</ntasks_rof>
-	  <ntasks_ice>144</ntasks_ice>
-	  <ntasks_ocn>144</ntasks_ocn>
-	  <ntasks_glc>144</ntasks_glc>
-	  <ntasks_wav>144</ntasks_wav>
-	  <ntasks_cpl>144</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>3</nthrds_atm>
-	  <nthrds_lnd>3</nthrds_lnd>
-	  <nthrds_rof>3</nthrds_rof>
-	  <nthrds_ice>3</nthrds_ice>
-	  <nthrds_ocn>3</nthrds_ocn>
-	  <nthrds_glc>3</nthrds_glc>
-	  <nthrds_wav>3</nthrds_wav>
-	  <nthrds_cpl>3</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-      <pes pesize="any" compset="_CAM\d0%WC">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>288</ntasks_atm>
-	  <ntasks_lnd>288</ntasks_lnd>
-	  <ntasks_rof>288</ntasks_rof>
-	  <ntasks_ice>288</ntasks_ice>
-	  <ntasks_ocn>288</ntasks_ocn>
-	  <ntasks_glc>288</ntasks_glc>
-	  <ntasks_wav>288</ntasks_wav>
-	  <ntasks_cpl>288</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>3</nthrds_atm>
-	  <nthrds_lnd>3</nthrds_lnd>
-	  <nthrds_rof>3</nthrds_rof>
-	  <nthrds_ice>3</nthrds_ice>
-	  <nthrds_ocn>3</nthrds_ocn>
-	  <nthrds_glc>3</nthrds_glc>
-	  <nthrds_wav>3</nthrds_wav>
-	  <nthrds_cpl>3</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-    <mach name="casper">
-      <pes pesize="any" compset="any">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>36</ntasks_atm>
-          <ntasks_lnd>36</ntasks_lnd>
-          <ntasks_rof>36</ntasks_rof>
-          <ntasks_ice>36</ntasks_ice>
-          <ntasks_ocn>36</ntasks_ocn>
-          <ntasks_glc>36</ntasks_glc>
-          <ntasks_wav>36</ntasks_wav>
-          <ntasks_cpl>36</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-    <mach name="hobart|izumi">
-      <pes pesize="any" compset="CAM\d+%W">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>192</ntasks_atm>
-	  <ntasks_lnd>192</ntasks_lnd>
-	  <ntasks_rof>192</ntasks_rof>
-	  <ntasks_ice>192</ntasks_ice>
-	  <ntasks_ocn>192</ntasks_ocn>
-	  <ntasks_glc>192</ntasks_glc>
-	  <ntasks_wav>192</ntasks_wav>
-	  <ntasks_cpl>192</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25">
-    <mach name="cheyenne">
-      <pes pesize="any" compset="_CAM\d0%WX">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>864</ntasks_atm>
-	  <ntasks_lnd>864</ntasks_lnd>
-	  <ntasks_rof>864</ntasks_rof>
-	  <ntasks_ice>864</ntasks_ice>
-	  <ntasks_ocn>864</ntasks_ocn>
-	  <ntasks_glc>864</ntasks_glc>
-	  <ntasks_wav>864</ntasks_wav>
-	  <ntasks_cpl>864</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
     <mach name="derecho">
       <pes pesize="any" compset="_CAM\d0%WX">
 	<comment>none</comment>
@@ -1351,72 +742,6 @@
     </mach>
   </grid>
   <grid name="a%0.9x1.25">
-    <mach name="mira">
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-208</ntasks_atm>
-	  <ntasks_lnd>-208</ntasks_lnd>
-	  <ntasks_rof>-208</ntasks_rof>
-	  <ntasks_ice>-208</ntasks_ice>
-	  <ntasks_ocn>-208</ntasks_ocn>
-	  <ntasks_glc>-208</ntasks_glc>
-	  <ntasks_wav>-208</ntasks_wav>
-	  <ntasks_cpl>-208</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>
-	  <nthrds_lnd>8</nthrds_lnd>
-	  <nthrds_rof>8</nthrds_rof>
-	  <nthrds_ice>8</nthrds_ice>
-	  <nthrds_ocn>8</nthrds_ocn>
-	  <nthrds_glc>8</nthrds_glc>
-	  <nthrds_wav>8</nthrds_wav>
-	  <nthrds_cpl>8</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.9x1.25">
-     <mach name="cheyenne">
-      <pes pesize="any" compset="_(CAM50|CAM60)%(CT|CV|CF|WC)">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>384</ntasks_atm>
-	  <ntasks_lnd>384</ntasks_lnd>
-	  <ntasks_rof>384</ntasks_rof>
-	  <ntasks_ice>384</ntasks_ice>
-	  <ntasks_ocn>384</ntasks_ocn>
-	  <ntasks_cpl>384</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>3</nthrds_atm>
-	  <nthrds_lnd>3</nthrds_lnd>
-	  <nthrds_rof>3</nthrds_rof>
-	  <nthrds_ice>3</nthrds_ice>
-	  <nthrds_ocn>3</nthrds_ocn>
-	  <nthrds_cpl>3</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
     <mach name="derecho">
       <pes pesize="any" compset="_(CAM50|CAM60)%(CT|CV|CF|WC)">
 	<comment>none</comment>
@@ -1452,111 +777,6 @@
 	  <ntasks_glc>-8</ntasks_glc>
 	  <ntasks_wav>-8</ntasks_wav>
 	  <ntasks_cpl>-8</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-    <mach name="cheyenne">
-      <pes pesize="any" compset="_CAM60%(CT|WC)">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>768</ntasks_atm>
-	  <ntasks_lnd>768</ntasks_lnd>
-	  <ntasks_rof>768</ntasks_rof>
-	  <ntasks_ice>768</ntasks_ice>
-	  <ntasks_ocn>768</ntasks_ocn>
-	  <ntasks_glc>768</ntasks_glc>
-	  <ntasks_wav>768</ntasks_wav>
-	  <ntasks_cpl>768</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>3</nthrds_atm>
-	  <nthrds_lnd>3</nthrds_lnd>
-	  <nthrds_rof>3</nthrds_rof>
-	  <nthrds_ice>3</nthrds_ice>
-	  <nthrds_ocn>3</nthrds_ocn>
-	  <nthrds_glc>3</nthrds_glc>
-	  <nthrds_wav>3</nthrds_wav>
-	  <nthrds_cpl>3</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-      <pes pesize="any" compset="_CAM\d0%WX">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>1800</ntasks_atm>
-	  <ntasks_lnd>1800</ntasks_lnd>
-	  <ntasks_rof>1800</ntasks_rof>
-	  <ntasks_ice>1800</ntasks_ice>
-	  <ntasks_ocn>1800</ntasks_ocn>
-	  <ntasks_glc>1800</ntasks_glc>
-	  <ntasks_wav>1800</ntasks_wav>
-	  <ntasks_cpl>1800</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-  <grid name="a%0.47x0.63" >
-    <mach name="hera|sierra" >
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>480</ntasks_atm>
-	  <ntasks_lnd>480</ntasks_lnd>
-	  <ntasks_rof>480</ntasks_rof>
-	  <ntasks_ice>480</ntasks_ice>
-	  <ntasks_ocn>480</ntasks_ocn>
-	  <ntasks_glc>480</ntasks_glc>
-	  <ntasks_wav>480</ntasks_wav>
-	  <ntasks_cpl>480</ntasks_cpl>
 	</ntasks>
 	<nthrds>
 	  <nthrds_atm>1</nthrds_atm>
@@ -1618,44 +838,6 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%0.23x0.31" >
-    <mach name="hera|sierra" >
-      <pes pesize="any" compset="any">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>960</ntasks_atm>
-	  <ntasks_lnd>960</ntasks_lnd>
-	  <ntasks_rof>960</ntasks_rof>
-	  <ntasks_ice>960</ntasks_ice>
-	  <ntasks_ocn>960</ntasks_ocn>
-	  <ntasks_glc>960</ntasks_glc>
-	  <ntasks_wav>960</ntasks_wav>
-	  <ntasks_cpl>960</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-  </grid>
-
   <grid name="any">
     <mach name="any">
       <pes pesize="any" compset="AR9[57]">
@@ -1672,7 +854,6 @@
       </pes>
     </mach>
   </grid>
-
   <grid name="a%10x15" >
     <mach name="derecho" >
       <pes pesize="any" compset="any">
@@ -1710,233 +891,6 @@
       </pes>
     </mach>
   </grid>
-
-  <!-- CAM/FV3 grids -->
-  <grid name="a%C24" >
-    <mach name="any" >
-      <pes pesize="any" compset="any">
-        <comment>none</comment>
-	      <ntasks>
-	        <ntasks_atm>-1</ntasks_atm>
-	        <ntasks_lnd>-1</ntasks_lnd>
-	        <ntasks_rof>-1</ntasks_rof>
-	        <ntasks_ice>-1</ntasks_ice>
-	        <ntasks_ocn>-1</ntasks_ocn>
-	        <ntasks_glc>-1</ntasks_glc>
-	        <ntasks_wav>-1</ntasks_wav>
-	        <ntasks_cpl>-1</ntasks_cpl>
-	      </ntasks>
-	      <nthrds>
-	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd>
-	        <nthrds_rof>1</nthrds_rof>
-	        <nthrds_ice>1</nthrds_ice>
-	        <nthrds_ocn>1</nthrds_ocn>
-	        <nthrds_glc>1</nthrds_glc>
-	        <nthrds_wav>1</nthrds_wav>
-	        <nthrds_cpl>1</nthrds_cpl>
-	      </nthrds>
-	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm>
-	        <rootpe_lnd>0</rootpe_lnd>
-	        <rootpe_rof>0</rootpe_rof>
-	        <rootpe_ice>0</rootpe_ice>
-	        <rootpe_ocn>0</rootpe_ocn>
-	        <rootpe_glc>0</rootpe_glc>
-	        <rootpe_wav>0</rootpe_wav>
-	        <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
-
-  <grid name="a%C48" >
-    <mach name="any" >
-      <pes pesize="any" compset="any">
-        <comment>none</comment>
-	      <ntasks>
-	        <ntasks_atm>-4</ntasks_atm>
-	        <ntasks_lnd>-4</ntasks_lnd>
-	        <ntasks_rof>-4</ntasks_rof>
-	        <ntasks_ice>-4</ntasks_ice>
-	        <ntasks_ocn>-4</ntasks_ocn>
-	        <ntasks_glc>-4</ntasks_glc>
-	        <ntasks_wav>-4</ntasks_wav>
-	        <ntasks_cpl>-4</ntasks_cpl>
-	      </ntasks>
-	      <nthrds>
-	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd>
-	        <nthrds_rof>1</nthrds_rof>
-	        <nthrds_ice>1</nthrds_ice>
-	        <nthrds_ocn>1</nthrds_ocn>
-	        <nthrds_glc>1</nthrds_glc>
-	        <nthrds_wav>1</nthrds_wav>
-	        <nthrds_cpl>1</nthrds_cpl>
-	      </nthrds>
-	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm>
-	        <rootpe_lnd>0</rootpe_lnd>
-	        <rootpe_rof>0</rootpe_rof>
-	        <rootpe_ice>0</rootpe_ice>
-	        <rootpe_ocn>0</rootpe_ocn>
-	        <rootpe_glc>0</rootpe_glc>
-	        <rootpe_wav>0</rootpe_wav>
-	        <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
-
-  <grid name="a%C96" >
-    <mach name="derecho" >
-      <pes pesize="any" compset="any">
-        <comment>none</comment>
-	      <ntasks>
-	        <ntasks_atm>-3</ntasks_atm>
-	        <ntasks_lnd>-3</ntasks_lnd>
-	        <ntasks_rof>-3</ntasks_rof>
-	        <ntasks_ice>-3</ntasks_ice>
-	        <ntasks_ocn>-3</ntasks_ocn>
-	        <ntasks_glc>-3</ntasks_glc>
-	        <ntasks_wav>-3</ntasks_wav>
-	        <ntasks_cpl>-3</ntasks_cpl>
-	      </ntasks>
-	      <nthrds>
-	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd>
-	        <nthrds_rof>1</nthrds_rof>
-	        <nthrds_ice>1</nthrds_ice>
-	        <nthrds_ocn>1</nthrds_ocn>
-	        <nthrds_glc>1</nthrds_glc>
-	        <nthrds_wav>1</nthrds_wav>
-	        <nthrds_cpl>1</nthrds_cpl>
-	      </nthrds>
-	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm>
-	        <rootpe_lnd>0</rootpe_lnd>
-	        <rootpe_rof>0</rootpe_rof>
-	        <rootpe_ice>0</rootpe_ice>
-	        <rootpe_ocn>0</rootpe_ocn>
-	        <rootpe_glc>0</rootpe_glc>
-	        <rootpe_wav>0</rootpe_wav>
-	        <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-    <mach name="any" >
-      <pes pesize="any" compset="any">
-        <comment>none</comment>
-	      <ntasks>
-	        <ntasks_atm>-16</ntasks_atm>
-	        <ntasks_lnd>-16</ntasks_lnd>
-	        <ntasks_rof>-16</ntasks_rof>
-	        <ntasks_ice>-16</ntasks_ice>
-	        <ntasks_ocn>-16</ntasks_ocn>
-	        <ntasks_glc>-16</ntasks_glc>
-	        <ntasks_wav>-16</ntasks_wav>
-	        <ntasks_cpl>-16</ntasks_cpl>
-	      </ntasks>
-	      <nthrds>
-	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd>
-	        <nthrds_rof>1</nthrds_rof>
-	        <nthrds_ice>1</nthrds_ice>
-	        <nthrds_ocn>1</nthrds_ocn>
-	        <nthrds_glc>1</nthrds_glc>
-	        <nthrds_wav>1</nthrds_wav>
-	        <nthrds_cpl>1</nthrds_cpl>
-	      </nthrds>
-	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm>
-	        <rootpe_lnd>0</rootpe_lnd>
-	        <rootpe_rof>0</rootpe_rof>
-	        <rootpe_ice>0</rootpe_ice>
-	        <rootpe_ocn>0</rootpe_ocn>
-	        <rootpe_glc>0</rootpe_glc>
-	        <rootpe_wav>0</rootpe_wav>
-	        <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
-
-  <grid name="a%C192" >
-    <mach name="any" >
-      <pes pesize="any" compset="any">
-        <comment>none</comment>
-	      <ntasks>
-	        <ntasks_atm>-32</ntasks_atm>
-	        <ntasks_lnd>-32</ntasks_lnd>
-	        <ntasks_rof>-32</ntasks_rof>
-	        <ntasks_ice>-32</ntasks_ice>
-	        <ntasks_ocn>-32</ntasks_ocn>
-	        <ntasks_glc>-32</ntasks_glc>
-	        <ntasks_wav>-32</ntasks_wav>
-	        <ntasks_cpl>-32</ntasks_cpl>
-	      </ntasks>
-	      <nthrds>
-	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd>
-	        <nthrds_rof>1</nthrds_rof>
-	        <nthrds_ice>1</nthrds_ice>
-	        <nthrds_ocn>1</nthrds_ocn>
-	        <nthrds_glc>1</nthrds_glc>
-	        <nthrds_wav>1</nthrds_wav>
-	        <nthrds_cpl>1</nthrds_cpl>
-	      </nthrds>
-	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm>
-	        <rootpe_lnd>0</rootpe_lnd>
-	        <rootpe_rof>0</rootpe_rof>
-	        <rootpe_ice>0</rootpe_ice>
-	        <rootpe_ocn>0</rootpe_ocn>
-	        <rootpe_glc>0</rootpe_glc>
-	        <rootpe_wav>0</rootpe_wav>
-	        <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
-
-  <grid name="a%C384" >
-    <mach name="any" >
-      <pes pesize="any" compset="any">
-        <comment>none</comment>
-	      <ntasks>
-	        <ntasks_atm>-32</ntasks_atm>
-	        <ntasks_lnd>-32</ntasks_lnd>
-	        <ntasks_rof>-32</ntasks_rof>
-	        <ntasks_ice>-32</ntasks_ice>
-	        <ntasks_ocn>-32</ntasks_ocn>
-	        <ntasks_glc>-32</ntasks_glc>
-	        <ntasks_wav>-32</ntasks_wav>
-	        <ntasks_cpl>-32</ntasks_cpl>
-	      </ntasks>
-	      <nthrds>
-	        <nthrds_atm>1</nthrds_atm>
-	        <nthrds_lnd>1</nthrds_lnd>
-	        <nthrds_rof>1</nthrds_rof>
-	        <nthrds_ice>1</nthrds_ice>
-	        <nthrds_ocn>1</nthrds_ocn>
-	        <nthrds_glc>1</nthrds_glc>
-	        <nthrds_wav>1</nthrds_wav>
-	        <nthrds_cpl>1</nthrds_cpl>
-	      </nthrds>
-	      <rootpe>
-	        <rootpe_atm>0</rootpe_atm>
-	        <rootpe_lnd>0</rootpe_lnd>
-	        <rootpe_rof>0</rootpe_rof>
-	        <rootpe_ice>0</rootpe_ice>
-	        <rootpe_ocn>0</rootpe_ocn>
-	        <rootpe_glc>0</rootpe_glc>
-	        <rootpe_wav>0</rootpe_wav>
-	        <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
-
 
   <!-- SE RR grids -->
   <grid name="a%ne0np4.ARCTIC.ne30x4" >

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -52,6 +52,15 @@
     </options>
   </test>
 
+  <test compset="NF1850fates-sp" grid="ne16pg3_ne16pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+    </options>
+  </test>
+
   <test compset="NF1850" grid="ne30pg3_ne30pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>

--- a/tools/interpic_new/Makefile
+++ b/tools/interpic_new/Makefile
@@ -7,7 +7,7 @@ EXENAME = interpic
 RM = rm
 
 .SUFFIXES:
-.SUFFIXES: .o .f90 .F90 
+.SUFFIXES: .o .f90 .F90
 
 # Check whether NetCDF library and include directories specified in environment
 # or on make commandline.
@@ -18,14 +18,14 @@ ifeq ($(strip $(INC_NETCDF)),)
   INC_NETCDF := /usr/local/include
 endif
 
-# Determine platform 
+# Determine platform
 UNAMES := $(shell uname -s)
 UNAMEM := $(findstring CRAY,$(shell uname -m))
 
 # Architecture-specific flags and rules
 #
 #------------------------------------------------------------------------
-# Cray 
+# Cray
 #------------------------------------------------------------------------
 
 ifeq ($(UNAMEM),CRAY)
@@ -81,7 +81,7 @@ endif
 ifeq ($(UNAMES),Linux)
 
 # g95
-#FC = g95 
+#FC = g95
 #FFLAGS =  -c -I$(INC_NETCDF) -g -ftrace=full
 
 # pgf90
@@ -96,7 +96,7 @@ ifeq ($(UNAMES),Linux)
 FC = ifort
 FFLAGS =  -c -I$(INC_NETCDF) -g -check all -fpe0 -traceback -ftz -convert big_endian -fp-model precise
 
-LDFLAGS = -L$(LIB_NETCDF) -lnetcdf
+LDFLAGS = -L$(LIB_NETCDF) -lnetcdf -L$(LIB_NETCDF_FTN) -lnetcdff
 endif
 
 #------------------------------------------------------------------------


### PR DESCRIPTION
Summary: Add two degree capability for CAM

Contributors: gold2718

Reviewers: mvertens

Purpose of changes: #205 

Github PR URL: https://github.com/NorESMhub/CAM/pull/206

Changes made to build system: None

Changes made to the namelist: 
- Initial data and topo files added as defaults for 2 degrees

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

- Add NF1850fates-sp and NF1850fates-sp compsets
- Set configuration and run parameters for NE16pg3 grid
- Add a 2 degree test (ne16pg3_ne16pg3_mtn14) of NF1850fates-sp compset
- Fix minor issue (#167)

aux_cam_noresm:
- `ERP_Ln9.ne16pg3_ne16pg3_mtn14.NF1850fates-sp.betzy_intel.cam-outfrq9s` fails restart compare due to differences in 2 FATES fields (see note below).

resolves #205 
fixes #167