### PR TITLE
noresm3_0_004_cam6_4_085: New default dust emissions and scaling factor

### DIFF
--- a/bld/namelist_files/use_cases/1850_camnor_lt_osloaero.xml
+++ b/bld/namelist_files/use_cases/1850_camnor_lt_osloaero.xml
@@ -77,6 +77,10 @@
 <prescribed_volcaero_cycle_yr>1850</prescribed_volcaero_cycle_yr>
 <prescribed_volcaero_type>CYCLICAL</prescribed_volcaero_type>
 
+<!--Options for mineral dust -->
+<dust_emis_fact> 4.60D0  </dust_emis_fact>                   <!--dust_nl-->
+<dust_emis_method>Leung_2023</dust_emis_method>              <!--dust_emi--> 
+
 <!-- ================================================= -->
 <!-- noresm-physics -->
 <!-- ================================================= -->

--- a/bld/namelist_files/use_cases/2000_camnor_osloaero.xml
+++ b/bld/namelist_files/use_cases/2000_camnor_osloaero.xml
@@ -69,6 +69,10 @@
 <prescribed_volcaero_cycle_yr>1850</prescribed_volcaero_cycle_yr>
 <prescribed_volcaero_type>CYCLICAL</prescribed_volcaero_type>
 
+<!--Options for mineral dust -->
+<dust_emis_fact> 4.60D0  </dust_emis_fact>                   <!--dust_nl-->
+<dust_emis_method>Leung_2023</dust_emis_method>              <!--dust_emi--> 
+
 <!-- ================================================= -->
 <!-- noresm-physics -->
 <!-- ================================================= -->

--- a/bld/namelist_files/use_cases/hist_camnor_lt_osloaero.xml
+++ b/bld/namelist_files/use_cases/hist_camnor_lt_osloaero.xml
@@ -70,6 +70,10 @@
 <prescribed_volcaero_datapath>atm/cam/volc</prescribed_volcaero_datapath>
 <prescribed_volcaero_file>CMIP_CAM6_radiation_v3_reformatted.nc</prescribed_volcaero_file>
 
+<!--Options for mineral dust -->
+<dust_emis_fact> 4.60D0  </dust_emis_fact>                   <!--dust_nl-->
+<dust_emis_method>Leung_2023</dust_emis_method>              <!--dust_emi--> 
+
 <!-- ================================================= -->
 <!-- noresm-physics -->
 <!-- ================================================= -->


### PR DESCRIPTION
Summary: Make Leung dust parameterisation default in Oslo-Aero

Contributors: @oyvindseland 

Reviewers: @gold2718 

Purpose of changes: Use the changes in https://github.com/NorESMhub/OSLO_AERO/issues/42 as default

Github PR URL: https://github.com/NorESMhub/CAM/pull/212

Changes made to build system: None

Changes made to the namelist: Set Leung to default in all  oslo_aero namelists and modified value dust_emis_fact

Changes to the defaults for the boundary datasets: None as such but switching the default value made a CAM read in field superfluous.

Substantial timing or memory changes: None

Set Leung to default in all  oslo_aero namelists and modified value dust_emis_fact

Issues addressed by this PR:https://github.com/NorESMhub/OSLO_AERO/issues/42

Tested in NorESM3 development simulations:
- NorESMhub/noresm3_dev_simulations#133
- NorESMhub/noresm3_dev_simulations#138