### PR TITLE
Set correct DMS source for AMIP cases

### DIFF
--- a/src/cpl/nuopc/atm_comp_nuopc.F90
+++ b/src/cpl/nuopc/atm_comp_nuopc.F90
@@ -636,11 +636,12 @@ contains
     end if
 
     ! Check for DMS from ocean
-    call ESMF_StateGet(importState, 'Faoo_fdms_ocn', itemFlag, rc=rc)
-    if ( ChkErr(rc,__LINE__,u_FILE_u)) then
-       dms_from_ocn = .false.
+    call NUOPC_CompAttributeGet(gcomp, name='flds_dms', value=cvalue, ispresent=ispresent, isset=isset, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (ispresent .and. isset) then
+       read(cvalue,*) dms_from_ocn
     else
-       dms_from_ocn = (itemflag == ESMF_STATEITEM_NOTFOUND)
+       dms_from_ocn = .false.
     end if
 
     call cam_init( &

--- a/src/cpl/nuopc/atm_import_export.F90
+++ b/src/cpl/nuopc/atm_import_export.F90
@@ -62,7 +62,6 @@ module atm_import_export
   integer                :: megan_nflds = -huge(1)  ! number of MEGAN voc fields from lnd-> atm
   integer                :: emis_nflds = -huge(1)   ! number of fire emission fields from lnd-> atm
   logical                :: atm_provides_lightning = .false. ! cld to grnd lightning flash freq (min-1)
-  logical, public        :: dms_from_ocn = .false.   ! dms is obtained from ocean as atm import data
   logical, public        :: brf_from_ocn = .false.   ! brf is obtained from ocean as atm import data
   logical, public        :: n2o_from_ocn = .false.   ! n2o is obtained from ocean as atm import data
   logical, public        :: nh3_from_ocn = .false.   ! nh3 is obtained from ocean as atm import data
@@ -116,6 +115,7 @@ contains
     logical                :: flds_co2b      ! use case
     logical                :: flds_co2c      ! use case
     character(len=128)     :: fldname
+    logical                :: dms_from_ocn   ! dms is obtained from ocean as atm import data
     logical                :: ispresent
     logical                :: isset
     character(len=*), parameter :: subname='(atm_import_export:advertise_fields): '


### PR DESCRIPTION
Summary: Set DMS from ocean flag only when appropriate

Contributors: gold2718, mvertens

Reviewers: mvertens

Purpose of changes: #211 

Github PR URL: https://github.com/NorESMhub/CAM/pull/213

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Use correct information to set dms_from_ocn flag

Ran `SMS_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s` to verify that the model uses the correct DMS source for AMIP (`NF`) cases.

fixes #211 