### PR TITLE
cam_noresm2_3_v1.0.0g : part 1 of default tunings settings for noresm2.3

### DIFF
--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -1257,7 +1257,7 @@
 <use_hetfrz_classnuc chem="trop_mam_oslo">.true.</use_hetfrz_classnuc>
 
 <hetfrz_aer_scalfac           >1.0D0</hetfrz_aer_scalfac>
-<hetfrz_aer_scalfac camnor="1">0.001D0</hetfrz_aer_scalfac>
+<hetfrz_aer_scalfac camnor="1">1.0D0</hetfrz_aer_scalfac>
 
 <use_preexisting_ice            >.false.</use_preexisting_ice>
 <use_preexisting_ice phys="cam6">.true.</use_preexisting_ice>
@@ -1268,7 +1268,7 @@
 <nucleate_ice_use_troplev            >.true.</nucleate_ice_use_troplev>
 
 <!-- Secondary ice production -->
-<rafsip_on>.false.</rafsip_on>
+<rafsip_on>.true.</rafsip_on>
 <forestfileALL>atm/cam/RaFSIP/forestALL.txt</forestfileALL>
 <forestfileBRDS>atm/cam/RaFSIP/forestBRDS.txt</forestfileBRDS>
 <forestfileBRHM>atm/cam/RaFSIP/forestBRHM.txt</forestfileBRHM>


### PR DESCRIPTION
Summary: The tuning of noresm2.3 consists of 3 modifications :  (1) rafsip_on = .true., (2) hetfrz_aer_scalfac = 1.0D0, and (3) SOAyield=0.025.  Here we introduce the first part of the tuning, .i.e., (1) and (2).

Contributors: Dirk Olivié (@DirkOlivie)

Reviewers: Steve Goldhaber (@gold2718)

Purpose of changes: contributing to the tuning of NorESM2.3

Github PR URL: 

Changes made to build system: None

Changes made to the namelist: the namelist will have two different default settings for CAM-Nor compsets.

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Issues addressed by this PR: there is no issue related to this pullrequest.
