### PR TITLE
noresm3_0_006_cam6_4_085: Update Oslo Aero tag

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -77,7 +77,7 @@
 [submodule "oslo_aero"]
     path = src/chemistry/oslo_aero
     url = https://github.com/NorESMhub/OSLO_AERO
-    fxtag = oslo_aero_3_0a003
+    fxtag = oslo_aero_3_0a004
     fxrequired = AlwaysRequired
     fxDONOTUSEurl = https://github.com/NorESMhub/OSLO_AERO.git
 

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -2275,7 +2275,7 @@ Default: 0,-24,-24,-24,-24,-24,-24,-24,-24,-24
     group="cam_history_nl" valid_values="">
 If interpolate_output(k) = .true., then the k'th history file will be
 interpolated to a lat/lon grid before output.
-Default: .false.
+Default: .false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.,.false.
 </entry>
 
 <entry id="interpolate_nlat" type="integer(10)" category="history"


### PR DESCRIPTION
Update Oslo Aero tag

Summary: Update Oslo Aero tag with fix for #214 

Contributors: gold2718, oyvindseland

Reviewers: mvertens, oyvindseland

Purpose of changes: #214 

Github PR URL: [ add this once PR is open but erase this text first ]

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Remove BC_AX from list of aerosol species mixed in ndrop.
Improve namelist documentation

Testing: See simulations and discussion in #214 

Fixes #214 