### PR TITLE
noresm3_0_009_cam6_4_085: Update tests for NF1850ghg with FATES

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -70,6 +70,10 @@
     <lname>1850_CAM70%LT%NORESM%CAMoslo_CLM60%FATES-NOCOMP_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
   </compset>
   <compset>
+    <alias>NF1850ghg_fates-sp</alias>
+    <lname>1850_CAM70%LT%NORESM%GHGCAMoslo_CLM60%FATES-SP_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
+  </compset>
+  <compset>
     <alias>NF1850ghg_fates-nocomp</alias>
     <lname>1850_CAM70%LT%NORESM%GHGCAMoslo_CLM60%FATES-NOCOMP_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
   </compset>

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -1,0 +1,39 @@
+<?xml version= "1.0"?>
+
+<expectedFails version="1.1">
+
+  <!-- Notes about the format of this file:
+
+       The required elements for a given failure are just:
+
+         <test name="...">
+           <phase name="...">
+             <status>...</status>
+           </phase>
+         </test>
+
+       There can be multiple phase blocks in a given test block.
+
+       In addition, a number of optional elements are allowed, which
+       currently are just for human consumption (not parsed by any
+       scripts):
+
+       - A phase block can contain an "issue" element, which gives the
+       issue number associated with this failure. (#123 refers to issue
+       #123 in the ESCOMP/ctsm repository. Issues in other repositories
+       should be specified as ORG/repo#123 - e.g., ESMCI/cime#123.)
+
+       - A phase block can contain a "comment" element, which gives any
+       sort of comment you desire.
+  -->
+
+
+  <!-- aux_cam_noresm test suite failures -->
+
+  <test name="ERP_Ln9.ne16pg3_ne16pg3_mtn14.NF1850ghg_fates-nocomp.betzy_intel.cam-outfrq9s">
+    <phase name="COMPARE_base_rest">
+      <status>FAIL</status>
+      <issue>NorESMhub/NorESM#695</issue>
+    </phase>
+  </test>
+</expectedFails>

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -86,6 +86,14 @@
       <option name="comment">Test of secondary ice microphysics</option>
     </options>
   </test>
+  <test compset="NF1850ghg_fates-sp" grid="ne16pg3_ne16pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:40:00</option>
+    </options>
+  </test>
   <test compset="NF1850ghg_fates-nocomp" grid="ne16pg3_ne16pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>


### PR DESCRIPTION
Summary: Update tests for NF1850ghg with FATES

Contributors: @TomasTorsvik 

Reviewers: @gold2718 , @DirkOlivie , @oyvindseland 

Purpose of changes:
Include working test for `NF1850ghg` with FATES, replacing `fates-nocomp` with `fates-sp`. The failing `fates-nocomp` is kept as a reminder to fix the CAM <-> CLM interface for this compset at a later date.

Github PR URL: https://github.com/NorESMhub/CAM/pull/229

Changes made to build system: NONE

Changes made to the namelist: NONE

Changes to the defaults for the boundary datasets: NONE

Substantial timing or memory changes: NONE

**Detailed description of changes**

- Include a new compset `NF1850ghg_fates-sp`
- Include a test for the compset `NF1850ghg_fates-sp`
- Include a new file `ExpectedTestFails.xml` wit a listing of the failing test using the compset `NF1850ghg_fates-nocomp`
- Tested with `aux_cam_noresm` test suite.