### PR TITLE
noresm3_0_011_cam6_4_085: Remove namelist option for local ice limiter

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -3466,8 +3466,6 @@ if ($cfg->get('microphys') =~ /^mg/) {
 	add_default($nl, 'micro_mg_implicit_fall');
         add_default($nl, 'pumas_stochastic_tau_kernel_filename', 'val'=>"$cfgdir/../src/physics/pumas/KBARF_tau_kernel.dat");
 
-        add_default($nl, 'micro_mg_shofer_ice_limiter');
-
         #set path for stochastic_tau_kernel_filename
         my $cam_dir = $cfg->get('cam_dir');
         add_default($nl, 'pumas_stochastic_tau_kernel_filename');

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2343,8 +2343,6 @@
 <micro_mg_warm_rain        phys="cam7" > kk2000 </micro_mg_warm_rain>
 <micro_mg_precip_fall_corr phys="cam7" > .true. </micro_mg_precip_fall_corr>
 
-<micro_mg_shofer_ice_limiter phys="cam7"> .true. </micro_mg_shofer_ice_limiter>
-
 <cld_macmic_num_steps>                                            1 </cld_macmic_num_steps>
 <cld_macmic_num_steps microphys="mg2" clubb_sgs="1"             > 3 </cld_macmic_num_steps>
 <cld_macmic_num_steps microphys="mg2" clubb_sgs="1" silhs="1"   > 6 </cld_macmic_num_steps>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -2900,13 +2900,6 @@ If true, then the autoconverted liquid is added to rain and removed from cloud b
 Default: .true.
 </entry>
 
-<entry id="micro_mg_shofer_ice_limiter" type="logical" category="microphys"
-       group="micro_mg_nl" valid_values="" >
-If .true., use the Shofer local ice limiter
-If .false. use the standard global PUMAS ice limiter
-Default: .false.
-</entry>
-
 
 <!-- Aerosol microphysics -->
 <entry id="microp_aero_bulk_scale" type="real" category="microphys"

--- a/src/physics/cam/micro_pumas_cam.F90
+++ b/src/physics/cam/micro_pumas_cam.F90
@@ -115,7 +115,6 @@ logical  ::  micro_mg_evap_rhthrsh_ifs = .false.  ! Evap RH threhold following I
 logical  ::  micro_mg_rainfreeze_ifs = .false.    ! Rain freezing at 0C following IFS
 logical  ::  micro_mg_ifs_sed = .false.           ! Snow sedimentation = 1 m/s following IFS
 logical  ::  micro_mg_precip_fall_corr = .false.    ! Precip fall speed following IFS
-logical  :: micro_mg_shofer_ice_limiter = .false. ! Use shofer local ice limiter
 
 character(len=10), parameter :: &      ! Constituent names
    cnst_names(10) = (/'CLDLIQ', 'CLDICE','NUMLIQ','NUMICE', &
@@ -275,8 +274,7 @@ subroutine micro_pumas_cam_readnl(nlfile)
        micro_do_massless_droplet_destroyer, &
        micro_mg_evap_sed_off, micro_mg_icenuc_rh_off, micro_mg_icenuc_use_meyers, &
        micro_mg_evap_scl_ifs, micro_mg_evap_rhthrsh_ifs, &
-       micro_mg_rainfreeze_ifs, micro_mg_ifs_sed, micro_mg_precip_fall_corr, &
-       micro_mg_shofer_ice_limiter
+       micro_mg_rainfreeze_ifs, micro_mg_ifs_sed, micro_mg_precip_fall_corr
 
 
   !-----------------------------------------------------------------------------
@@ -470,8 +468,6 @@ subroutine micro_pumas_cam_readnl(nlfile)
 
   call mpi_bcast(micro_mg_precip_fall_corr, 1, mpi_logical, mstrid, mpicom, ierr)
   if (ierr /= 0) call endrun(sub//": FATAL: mpi_bcast: micro_mg_precip_fall_corr")
-  call mpi_bcast(micro_mg_shofer_ice_limiter, 1, mpi_logical, mstrid, mpicom, ierr)
-  if (ierr /= 0) call endrun(sub//": Fatal: mpi_bcast: micro_mg_shofer_ice_limiter")
 
   if(micro_mg_berg_eff_factor == unset_r8) call endrun(sub//": FATAL: micro_mg_berg_eff_factor is not set")
   if(micro_mg_accre_enhan_fact == unset_r8) call endrun(sub//": FATAL: micro_mg_accre_enhan_fact is not set")
@@ -527,8 +523,7 @@ subroutine micro_pumas_cam_readnl(nlfile)
      write(iulog,*) '  micro_mg_evap_rhthrsh_ifs   = ', micro_mg_evap_rhthrsh_ifs
      write(iulog,*) '  micro_mg_rainfreeze_ifs     = ', micro_mg_rainfreeze_ifs
      write(iulog,*) '  micro_mg_ifs_sed            = ', micro_mg_ifs_sed
-     write(iulog,*) '  micro_mg_precip_fall_corr   = ', micro_mg_precip_fall_corr
-     write(iulog,*) '  micro_mg_shofer_ice_limiter = ', micro_mg_shofer_ice_limiter
+     write(iulog,*) '  micro_mg_precip_fall_corr     = ', micro_mg_precip_fall_corr
   end if
 
 contains
@@ -922,7 +917,6 @@ subroutine micro_pumas_cam_init(pbuf2d)
            micro_mg_evap_sed_off, micro_mg_icenuc_rh_off, micro_mg_icenuc_use_meyers, &
            micro_mg_evap_scl_ifs, micro_mg_evap_rhthrsh_ifs, &
            micro_mg_rainfreeze_ifs,  micro_mg_ifs_sed, micro_mg_precip_fall_corr,&
-           micro_mg_shofer_ice_limiter, &
            micro_mg_nccons, micro_mg_nicons, micro_mg_ncnst, &
            micro_mg_ninst, micro_mg_ngcons, micro_mg_ngnst, &
            micro_mg_nrcons,  micro_mg_nrnst, micro_mg_nscons, micro_mg_nsnst, errstring)


### PR DESCRIPTION
Summary: Remove namelist option for local ice limiter

Contributors: gold2718

Reviewers: TomasTorsvik

Purpose of changes: Fix namelist mismatch causing namelist read errors

Github PR URL: https://github.com/NorESMhub/CAM/pull/231

Changes made to build system: Remove namelist option

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: 'None

Remove namelist option for local ice limiter

SMS_D_Ln9_P256.ne30pg3_ne30pg3_mtn14.NFLTHIST.betzy_intel.cam-outfrq9s