### PR TITLE
noresm3_0_012_cam6_4_085: Introduce new history flags to contain all CAM output in noresm3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -77,7 +77,7 @@
 [submodule "oslo_aero"]
     path = src/chemistry/oslo_aero
     url = https://github.com/NorESMhub/OSLO_AERO
-    fxtag = oslo_aero_3_0a005
+    fxtag = oslo_aero_3_0a006
     fxrequired = AlwaysRequired
     fxDONOTUSEurl = https://github.com/NorESMhub/OSLO_AERO.git
 

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -4537,6 +4537,12 @@ add_default($nl, 'history_chemistry');
 add_default($nl, 'history_chemspecies_srf');
 add_default($nl, 'history_clubb');
 add_default($nl, 'history_dust');
+add_default($nl, 'history_aerosol_base');
+add_default($nl, 'history_aerosol_decomposed');
+add_default($nl, 'history_gas');
+add_default($nl, 'history_aerosol_forcing');
+add_default($nl, 'history_aerosol_radiation');
+add_default($nl, 'history_aerosol_debug_output');
 
 # The history output for the AMWG variability diagnostics assumes that auxilliary history
 # files h1, h2, and h3 contain daily, 6-hrly, and 3-hrly output respectively.  If this output

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2978,6 +2978,12 @@ See https://github.com/NorESMhub/noresm3_dev_simulations/discussions/78
 <history_chemspecies_srf>      .true.   </history_chemspecies_srf>
 <history_clubb>                .true.   </history_clubb>
 <history_dust>                 .false.  </history_dust>
+<history_aerosol_base>         .true.   </history_aerosol_base>
+<history_aerosol_decomposed>   .false.  </history_aerosol_decomposed>
+<history_gas>                  .false.  </history_gas>
+<history_aerosol_forcing>      .false.  </history_aerosol_forcing>
+<history_aerosol_radiation>    .false.  </history_aerosol_radiation>
+<history_aerosol_debug_output> .false.  </history_aerosol_debug_output>
 
 <cam_snapshot_before_num>  -1 </cam_snapshot_before_num>
 <cam_snapshot_after_num>   -1 </cam_snapshot_after_num>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -5734,6 +5734,47 @@ Switch to turn on/off default output chemical species mixing ratios in the surfa
 Default: .false.
 </entry>
 
+<entry id="history_aerosol_base" type="logical" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch to turn on/off output of; mass mixing ratios and column burdens for compounded aerosols (BC, DUST, OM, SALT, SULFATE) 
+and gas-phase column burdens from OsloAero; summation fields for emission/source, wet and dry deposition.
+Also controls output of other key aerosol-specific output fields.
+Default: .true.
+</entry>
+
+<entry id="history_aerosol_decomposed" type="logical" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch to turn on/off output of decomposed aerosols from OsloAero.
+Default: .false.
+</entry>
+
+<entry id="history_gas" type="logical" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch to turn on/off output of 3D gasphase aerosols from OsloAero.
+NOTE; the 2D column burdens are triggered by history_aerosol_base.
+Default: .false.
+</entry>
+
+<entry id="history_aerosol_forcing" type="logical" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch to turn on/off output of forcing specific species in OsloAero.
+Default: .false.
+</entry>
+
+<entry id="history_aerosol_radiation" type="logical" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch to turn on/off output of aerosol radiative properties.
+Default: .false.
+</entry>
+
+<entry id="history_aerosol_debug_output" type="logical" category="diagnostics"
+       group="phys_ctl_nl" valid_values="" >
+Switch to turn on/off output for debugging summation from OsloAero. Some summation fields are compounded of variables passed through
+the physics buffer. This flag provides the lagged output of these variables. Also controls summations used across multiple
+summation fields.
+Default: .false.
+</entry>
+
 <entry id="offline_driver" type="logical" category="offline_unit_driver"
        group="phys_ctl_nl" valid_values="" >
 True when model is configured to use an offline driver.

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -30,6 +30,13 @@
 
   <!-- aux_cam_noresm test suite failures -->
 
+  <test name="ERP_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aero_history">
+    <phase name="COMPARE_base_rest">
+      <status>FAIL</status>
+      <issue>NorESMhub/CAM#180</issue>
+    </phase>
+  </test>
+
   <test name="ERP_Ln9.ne16pg3_ne16pg3_mtn14.NF1850ghg_fates-nocomp.betzy_intel.cam-outfrq9s">
     <phase name="COMPARE_base_rest">
       <status>FAIL</status>

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -27,14 +27,6 @@
     </options>
   </test>
 
-  <test compset="NF2000" grid="ne30pg3_ne30pg3_mtn14" name="SMS_D_Ln9" testmods="cam/outfrq9s">
-    <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
-    </machines>
-    <options>
-      <option name="wallclock">00:30:00</option>
-    </options>
-  </test>
   <test compset="NF2000" grid="ne30pg3_ne30pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
@@ -62,6 +54,14 @@
   </test>
 
   <test compset="NF1850" grid="ne30pg3_ne30pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+    </options>
+  </test>
+  <test compset="NF1850" grid="ne30pg3_ne30pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s_aero_history">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
     </machines>
@@ -103,21 +103,20 @@
     </options>
   </test>
 
-<!--              @@@@@@@@@@@@@@@@@@@@@@@@@@@                 -->
-<!--              CAM test-supported COMPSETS                 -->
-<!--              @@@@@@@@@@@@@@@@@@@@@@@@@@@                 -->
-
-  <test compset="F1850" grid="f19_f19_mtn14" name="ERP_D_Ln9_P256" testmods="cam/outfrq9s">
+  <test compset="NF1850" grid="ne3pg3_ne3pg3_mtn14" name="ERP_D_Ln9" testmods="cam/outfrq9s">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
-      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
 
-  <test compset="F2000climo" grid="ne30pg3_ne30pg3_mtn14" name="SMS_D_Ln9_P256" testmods="cam/outfrq9s">
+<!--              @@@@@@@@@@@@@@@@@@@@@@@@@@@                 -->
+<!--              CAM test-supported COMPSETS                 -->
+<!--              @@@@@@@@@@@@@@@@@@@@@@@@@@@                 -->
+
+  <test compset="F1850" grid="f19_f19_mtn14" name="ERP_D_Ln9_P256" testmods="cam/outfrq9s">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
       <machine name="betzy" compiler="intel" category="prealpha_noresm"/>

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aero_history/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aero_history/shell_commands
@@ -1,0 +1,2 @@
+./xmlchange ROF_NCPL=\$ATM_NCPL
+./xmlchange GLC_NCPL=\$ATM_NCPL

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aero_history/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aero_history/user_nl_cam
@@ -1,0 +1,13 @@
+mfilt=1,1,1,1,1,1
+ndens=1,1,1,1,1,1
+nhtfrq=9,9,9,9,9,9
+write_nstep0=.true.
+inithist='ENDOFRUN'
+history_chemspecies_srf = .true.
+history_aerosol = .true.
+history_aerosol_base = .true.
+history_aerosol_decomposed = .true.
+history_aerosol_forcing = .true.
+history_aerosol_radiation = .true.
+history_aerosol_debug_output = .true.
+history_gas = .true.

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aero_history/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aero_history/user_nl_clm
@@ -1,0 +1,27 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes below in the form of 
+! namelist_var = new_namelist_value 
+!
+! Include namelist variables for drv_flds_in ONLY if -megan and/or -drydep options
+! are set in the CLM_NAMELIST_OPTS env variable.
+!
+! EXCEPTIONS: 
+! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting
+! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting
+! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting
+! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting
+! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting
+! Set irrigate           by the CLM_BLDNML_OPTS -irrig           setting
+! Set dtime              with L_NCPL                             option
+! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options
+! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases
+!                        (includes $inst_string for multi-ensemble cases)
+! Set glc_grid           with CISM_GRID                          option
+! Set glc_smb            with GLC_SMB                            option
+! Set maxpatch_glcmec    with GLC_NEC                            option
+! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable
+!----------------------------------------------------------------------------------
+hist_nhtfrq = 9
+hist_mfilt  = 1
+hist_ndens  = 1
+

--- a/src/physics/cam/phys_control.F90
+++ b/src/physics/cam/phys_control.F90
@@ -71,6 +71,12 @@ logical           :: history_cesm_forcing = .false.
 logical           :: history_dust         = .false.
 logical           :: history_scwaccm_forcing = .false.
 logical           :: history_chemspecies_srf = .false.
+logical, public, protected :: history_aerosol_base          = .true.
+logical, public, protected :: history_aerosol_decomposed    = .false.
+logical, public, protected :: history_gas                   = .false.
+logical, public, protected :: history_aerosol_forcing       = .false.
+logical, public, protected :: history_aerosol_radiation     = .false.
+logical, public, protected :: history_aerosol_debug_output  = .false.
 
 logical           :: do_clubb_sgs
 logical           :: do_hb_above_clubb       = .false. ! enable HB vertical mixing above clubb top
@@ -135,7 +141,8 @@ subroutine phys_ctl_readnl(nlfile)
       history_eddy, history_budget,  history_budget_histfile_num, history_waccm, &
       history_waccmx, history_chemistry, history_carma, history_carma_srf_flx, &
       history_clubb, history_dust, &
-      history_cesm_forcing, history_scwaccm_forcing, history_chemspecies_srf, &
+      history_cesm_forcing, history_scwaccm_forcing, history_chemspecies_srf, history_aerosol_base, history_aerosol_debug_output, &
+      history_aerosol_decomposed, history_gas, history_aerosol_forcing, history_aerosol_radiation, &
       do_clubb_sgs, state_debug_checks, use_hetfrz_classnuc, use_gw_oro, use_gw_front, &
       use_gw_front_igw, use_gw_convect_dp, use_gw_convect_sh, use_gw_movmtn_pbl, cld_macmic_num_steps, &
       offline_driver, convproc_do_aer, cam_snapshot_before_num, cam_snapshot_after_num, &
@@ -185,6 +192,12 @@ subroutine phys_ctl_readnl(nlfile)
    call mpi_bcast(history_clubb,               1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(history_cesm_forcing,        1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(history_chemspecies_srf,     1,                     mpi_logical,   masterprocid, mpicom, ierr)
+   call mpi_bcast(history_aerosol_base,        1,                     mpi_logical,   masterprocid, mpicom, ierr)
+   call mpi_bcast(history_aerosol_decomposed,  1,                     mpi_logical,   masterprocid, mpicom, ierr)
+   call mpi_bcast(history_gas,                 1,                     mpi_logical,   masterprocid, mpicom, ierr)
+   call mpi_bcast(history_aerosol_forcing,     1,                     mpi_logical,   masterprocid, mpicom, ierr)
+   call mpi_bcast(history_aerosol_radiation,   1,                     mpi_logical,   masterprocid, mpicom, ierr)
+   call mpi_bcast(history_aerosol_debug_output,1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(history_dust,                1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(history_scwaccm_forcing,     1,                     mpi_logical,   masterprocid, mpicom, ierr)
    call mpi_bcast(do_clubb_sgs,                1,                     mpi_logical,   masterprocid, mpicom, ierr)


### PR DESCRIPTION
Summary: Control all output from CAM-Oslo

Contributors: Johannes Fjeldså

Reviewers: Steve Goldhaber

Purpose of changes: Contain output from CAM-Oslo that is always outputted to be namelist options. Changes in CAM will allow for changes in OsloAero to take place.

Github PR URL: https://github.com/NorESMhub/CAM/pull/232

Changes made to build system: 'None'

Changes made to the namelist: build-namelist, namelist_definitions and namelist_defaults_cam has six new namelist flags.

Changes to the defaults for the boundary datasets: 'None'

Substantial timing or memory changes: 'None'

Introduce six new history flags to contain output that is always outputted from OsloAero. Similar work as done for noresm2.3 (see https://github.com/NorESMhub/CAM/pull/198#discussion_r2109029874). In addition these flags will govern summation fields aggregated by OsloAero as opposed to performing this aggregation in diagnostics or post processing. Should remain a draft PR until https://github.com/NorESMhub/OSLO_AERO/pull/60 is merged. 

fixes: #195 

Testing: aux_cam_noresm
Expected fails due to:
#180
NorESMhub/NorESM#695