### PR TITLE
noresm3_0_015_cam6_4_085: Adjust test length for FATES-nocomp compatibility

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -30,10 +30,4 @@
 
   <!-- aux_cam_noresm test suite failures -->
 
-  <test name="ERP_Ln9.ne16pg3_ne16pg3_mtn14.NF1850ghg_fates-nocomp.betzy_intel.cam-outfrq9s">
-    <phase name="COMPARE_base_rest">
-      <status>FAIL</status>
-      <issue>NorESMhub/NorESM#695</issue>
-    </phase>
-  </test>
 </expectedFails>

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -103,7 +103,7 @@
       <option name="wallclock">00:40:00</option>
     </options>
   </test>
-  <test compset="NF1850ghg_fates-nocomp" grid="ne16pg3_ne16pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
+  <test compset="NF1850ghg_fates-nocomp" grid="ne16pg3_ne16pg3_mtn14" name="ERP_Ld5" testmods="cam/outfrq9s">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
     </machines>


### PR DESCRIPTION
Summary: Adjust test length for FATES-nocomp compatibility

Contributors: @gold2718

Reviewers: @mvdebolskiy 

Purpose of changes: FAIL in aux_cam_noresm test: ERP_Ln9.ne16pg3_ne16pg3_mtn14.NF1850ghg_fates-nocomp.betzy_intel.cam-outfrq9s (NorESMhub/NorESM#695)

Github PR URL: https://github.com/NorESMhub/CAM/pull/236

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Because FATES-nocomp can only  restart on daily boundaries, this test needed to be converted into a multi-day test instead of a multi-timestep test.

Testing:
- Ran `ERP_Ld5.ne16pg3_ne16pg3_mtn14.NF1850ghg_fates-nocomp.betzy_intel.cam-outfrq9s` to ensure the new test length passes.
    - Test has an `NLCOMP` failure due to #235 and a `BFAIL` because this test did not `PASS` in Beta02.
- Ran `aux_cam_noresm`: Same result as in #235 except that the test above now passes restart compare.

addresses NorESMhub/NorESM#695