### PR TITLE
noresm3_0_016_cam6_4_085: Secondary ice bug fix

### DIFF
--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -15,7 +15,7 @@
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
-      <option name="wallclock">00:30:00</option>
+      <option name="wallclock">00:40:00</option>
     </options>
   </test>
   <test compset="NFLTHIST" grid="ne30pg3_ne30pg3_mtn14" name="ERP_D_Ln9" testmods="cam/outfrq9s">
@@ -23,7 +23,7 @@
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
-      <option name="wallclock">00:30:00</option>
+      <option name="wallclock">00:40:00</option>
     </options>
   </test>
 
@@ -32,7 +32,7 @@
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
-      <option name="wallclock">00:30:00</option>
+      <option name="wallclock">00:40:00</option>
     </options>
   </test>
   <test compset="NF2000mam4" grid="ne30pg3_ne30pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
@@ -40,7 +40,7 @@
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
-      <option name="wallclock">00:30:00</option>
+      <option name="wallclock">00:40:00</option>
     </options>
   </test>
 
@@ -91,7 +91,7 @@
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
-      <option name="wallclock">00:20:00</option>
+      <option name="wallclock">00:30:00</option>
       <option name="comment">Test ZM modifications from Tomas Tonazzio</option>
     </options>
   </test>


### PR DESCRIPTION
Summary: Update PUMAS tag with secondary ice bug fix

Contributors: oyvindseland, gold2718

Reviewers: oyvindseland

Purpose of changes: NorESMhub/NorESM#718

Github PR URL: https://github.com/NorESMhub/CAM/pull/237

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

PUMAS was updated with a bug fix in the secondary ice production code.

aux_cam_noresm: All pass except for expected baseline difference for secondary ice test
- FAIL ERP_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-secice BASELINE noresm3_0_beta02a: DIFF
- FAIL ERP_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-secice TPUTCOMP Error: TPUTCOMP: Throughput changed by 71.27%: baseline=0.529 sypd, tolerance=25%, current=0.152 sypd


fixes NorESMhub/NorESM#718