### PR TITLE
noresm3_0_017_cam6_4_085: Point to correct PUMAS tag in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -84,7 +84,7 @@
 [submodule "pumas"]
     path = src/physics/pumas
     url = https://github.com/NorESMhub/PUMAS
-    fxtag = noresm3_0_003_pumas_v1_38
+    fxtag = noresm3_0_004_pumas_v1_38
     fxrequired = AlwaysRequired
     fxDONOTUSEurl = https://github.com/NorESMhub/PUMAS
 


### PR DESCRIPTION
Summary: #237 had the correct submodule hash for PUMAS but the incorrect `fxtag` entry in .gitmodules

Contributors: gold2718

Reviewers: mvertens

Purpose of changes: Set PUMAS `fxtag` in .gitmodules to `noresm3_0_004_pumas_v1_38`

Github PR URL: https://github.com/NorESMhub/CAM/pull/238

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Changed PUMAS `fxtag` in .gitmodules to `noresm3_0_004_pumas_v1_38`

Tested that a checkout of the PR branch followed by git-fleximod update checks out correct tree.