### PR TITLE
noresm3_0_020_cam6_4_121: Fix interim restart capability

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -9,12 +9,14 @@
     <hist_file_extension>e</hist_file_extension>
     <rest_history_varname>nhfil</rest_history_varname>
     <rpointer>
-      <rpointer_file>rpointer.atm$NINST_STRING</rpointer_file>
+      <rpointer_file>rpointer.cam$NINST_STRING.$DATENAME</rpointer_file>
       <rpointer_content>$CASE.cam$NINST_STRING.r.$DATENAME.nc </rpointer_content>
     </rpointer>
     <test_file_names>
-      <tfile disposition="copy">rpointer.atm</tfile>
-      <tfile disposition="copy">rpointer.atm_9999</tfile>
+      <tfile disposition="copy">rpointer.cam.1976-01-01-00000</tfile>
+      <tfile disposition="copy">rpointer.cam_9999.1976-01-01-00000</tfile>
+      <tfile disposition="ignore">rpointer.cam.1976-02-01-00000</tfile>
+      <tfile disposition="ignore">rpointer.cam_9999.1976-01-02-00000</tfile>
       <tfile disposition="copy">casename.cam.r.1976-01-01-00000.nc</tfile>
       <tfile disposition="copy">casename.cam.rh4.1976-01-01-00000.nc</tfile>
       <tfile disposition="move">casename.cam.h0.1976-01-01-00000.nc</tfile>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -261,26 +261,6 @@
     </mach>
   </grid>
   <grid name="a%mpasa120">
-    <mach name="cheyenne">
-      <pes pesize="any" compset="_CAM60%WCSC">
-	<ntasks>
-	  <ntasks_atm>360</ntasks_atm>
-	  <ntasks_lnd>360</ntasks_lnd>
-	  <ntasks_rof>360</ntasks_rof>
-	  <ntasks_ice>360</ntasks_ice>
-	  <ntasks_ocn>360</ntasks_ocn>
-	  <ntasks_cpl>360</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-      </pes>
-    </mach>
     <mach name="derecho">
       <pes pesize="any" compset="_CAM60%WCSC">
 	<ntasks>
@@ -303,41 +283,6 @@
     </mach>
   </grid>
   <grid name="a%ne16" >
-    <mach name="cheyenne">
-      <pes pesize="any" compset="_CAM\d0%WX">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>720</ntasks_atm>
-	  <ntasks_lnd>720</ntasks_lnd>
-	  <ntasks_rof>720</ntasks_rof>
-	  <ntasks_ice>720</ntasks_ice>
-	  <ntasks_ocn>720</ntasks_ocn>
-	  <ntasks_glc>720</ntasks_glc>
-	  <ntasks_wav>720</ntasks_wav>
-	  <ntasks_cpl>720</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
     <mach name="derecho">
       <pes pesize="any" compset="_CAM\d0%W(X|A)">
 	<comment>none</comment>
@@ -361,41 +306,6 @@
     </mach>
   </grid>
   <grid name="a%ne30" >
-    <mach name="cheyenne">
-      <pes pesize="any" compset="_CAM\d0%WX">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>1728</ntasks_atm>
-	  <ntasks_lnd>1728</ntasks_lnd>
-	  <ntasks_rof>1728</ntasks_rof>
-	  <ntasks_ice>1728</ntasks_ice>
-	  <ntasks_ocn>1728</ntasks_ocn>
-	  <ntasks_glc>1728</ntasks_glc>
-	  <ntasks_wav>1728</ntasks_wav>
-	  <ntasks_cpl>1728</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
     <mach name="derecho">
       <pes pesize="any" compset="_CAM\d0%W(X|A)">
 	<comment>none</comment>
@@ -456,127 +366,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne30" >
-    <mach name="cheyenne">
-      <pes pesize="any" compset="_CAM70%LT%GHGMAM4_">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-8</ntasks_atm>
-	  <ntasks_lnd>-8</ntasks_lnd>
-	  <ntasks_rof>-8</ntasks_rof>
-	  <ntasks_ice>-8</ntasks_ice>
-	  <ntasks_ocn>-8</ntasks_ocn>
-	  <ntasks_cpl>-8</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-      <pes pesize="any" compset="_CAM70%MT%GHGMAM4_">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-12</ntasks_atm>
-	  <ntasks_lnd>-12</ntasks_lnd>
-	  <ntasks_rof>-12</ntasks_rof>
-	  <ntasks_ice>-12</ntasks_ice>
-	  <ntasks_ocn>-12</ntasks_ocn>
-	  <ntasks_cpl>-12</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-      <pes pesize="any" compset="_CAM.*%(CT|WC|CV|CF)">
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>-50</ntasks_atm>
-          <ntasks_lnd>-50</ntasks_lnd>
-          <ntasks_rof>-50</ntasks_rof>
-          <ntasks_ice>-50</ntasks_ice>
-          <ntasks_ocn>-50</ntasks_ocn>
-          <ntasks_cpl>-50</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_cpl>1</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%ne120">
-    <mach name="cheyenne">
-      <pes pesize="any" compset="_CAM6|_CAM7">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>1800</ntasks_atm>
-	  <ntasks_lnd>1800</ntasks_lnd>
-	  <ntasks_rof>1800</ntasks_rof>
-	  <ntasks_ice>1800</ntasks_ice>
-	  <ntasks_ocn>1800</ntasks_ocn>
-	  <ntasks_glc>1800</ntasks_glc>
-	  <ntasks_wav>1800</ntasks_wav>
-	  <ntasks_cpl>1800</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
     <mach name="any">
       <pes pesize="any" compset="any">
 	<comment>none</comment>
@@ -1043,146 +833,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%0.9x1.25">
-    <mach name="cheyenne">
-      <pes pesize="any" compset="any">
-        <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
-        <comment>none</comment>
-        <ntasks>
-          <ntasks_atm>360</ntasks_atm>
-          <ntasks_lnd>360</ntasks_lnd>
-          <ntasks_rof>360</ntasks_rof>
-          <ntasks_ice>360</ntasks_ice>
-          <ntasks_ocn>360</ntasks_ocn>
-          <ntasks_glc>360</ntasks_glc>
-          <ntasks_wav>360</ntasks_wav>
-          <ntasks_cpl>360</ntasks_cpl>
-        </ntasks>
-        <nthrds>
-          <nthrds_atm>3</nthrds_atm>
-          <nthrds_lnd>3</nthrds_lnd>
-          <nthrds_rof>3</nthrds_rof>
-          <nthrds_ice>3</nthrds_ice>
-          <nthrds_ocn>3</nthrds_ocn>
-          <nthrds_glc>3</nthrds_glc>
-          <nthrds_wav>3</nthrds_wav>
-          <nthrds_cpl>3</nthrds_cpl>
-        </nthrds>
-        <rootpe>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
-        </rootpe>
-      </pes>
-    </mach>
-  </grid>
   <grid name="a%1.9x2.5">
-    <mach name="cheyenne">
-      <pes pesize="any" compset="_CAM\d0%WX.*_SLND.*_DOCN%AQP">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>48</ntasks_atm>
-	  <ntasks_lnd>48</ntasks_lnd>
-	  <ntasks_rof>48</ntasks_rof>
-	  <ntasks_ice>48</ntasks_ice>
-	  <ntasks_ocn>48</ntasks_ocn>
-	  <ntasks_glc>48</ntasks_glc>
-	  <ntasks_wav>48</ntasks_wav>
-	  <ntasks_cpl>48</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>3</nthrds_atm>
-	  <nthrds_lnd>3</nthrds_lnd>
-	  <nthrds_rof>3</nthrds_rof>
-	  <nthrds_ice>3</nthrds_ice>
-	  <nthrds_ocn>3</nthrds_ocn>
-	  <nthrds_glc>3</nthrds_glc>
-	  <nthrds_wav>3</nthrds_wav>
-	  <nthrds_cpl>3</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-      <pes pesize="any" compset="_CAM\d0%WX.*_CLM.*_DOCN%DOM">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>144</ntasks_atm>
-	  <ntasks_lnd>144</ntasks_lnd>
-	  <ntasks_rof>144</ntasks_rof>
-	  <ntasks_ice>144</ntasks_ice>
-	  <ntasks_ocn>144</ntasks_ocn>
-	  <ntasks_glc>144</ntasks_glc>
-	  <ntasks_wav>144</ntasks_wav>
-	  <ntasks_cpl>144</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>3</nthrds_atm>
-	  <nthrds_lnd>3</nthrds_lnd>
-	  <nthrds_rof>3</nthrds_rof>
-	  <nthrds_ice>3</nthrds_ice>
-	  <nthrds_ocn>3</nthrds_ocn>
-	  <nthrds_glc>3</nthrds_glc>
-	  <nthrds_wav>3</nthrds_wav>
-	  <nthrds_cpl>3</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-      <pes pesize="any" compset="_CAM\d0%WC">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>288</ntasks_atm>
-	  <ntasks_lnd>288</ntasks_lnd>
-	  <ntasks_rof>288</ntasks_rof>
-	  <ntasks_ice>288</ntasks_ice>
-	  <ntasks_ocn>288</ntasks_ocn>
-	  <ntasks_glc>288</ntasks_glc>
-	  <ntasks_wav>288</ntasks_wav>
-	  <ntasks_cpl>288</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>3</nthrds_atm>
-	  <nthrds_lnd>3</nthrds_lnd>
-	  <nthrds_rof>3</nthrds_rof>
-	  <nthrds_ice>3</nthrds_ice>
-	  <nthrds_ocn>3</nthrds_ocn>
-	  <nthrds_glc>3</nthrds_glc>
-	  <nthrds_wav>3</nthrds_wav>
-	  <nthrds_cpl>3</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
     <mach name="casper">
       <pes pesize="any" compset="any">
         <comment>none</comment>
@@ -1218,78 +869,8 @@
         </rootpe>
       </pes>
     </mach>
-    <mach name="hobart|izumi">
-      <pes pesize="any" compset="CAM\d+%W">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>192</ntasks_atm>
-	  <ntasks_lnd>192</ntasks_lnd>
-	  <ntasks_rof>192</ntasks_rof>
-	  <ntasks_ice>192</ntasks_ice>
-	  <ntasks_ocn>192</ntasks_ocn>
-	  <ntasks_glc>192</ntasks_glc>
-	  <ntasks_wav>192</ntasks_wav>
-	  <ntasks_cpl>192</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
   </grid>
   <grid name="a%0.9x1.25">
-    <mach name="cheyenne">
-      <pes pesize="any" compset="_CAM\d0%WX">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>864</ntasks_atm>
-	  <ntasks_lnd>864</ntasks_lnd>
-	  <ntasks_rof>864</ntasks_rof>
-	  <ntasks_ice>864</ntasks_ice>
-	  <ntasks_ocn>864</ntasks_ocn>
-	  <ntasks_glc>864</ntasks_glc>
-	  <ntasks_wav>864</ntasks_wav>
-	  <ntasks_cpl>864</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
     <mach name="derecho">
       <pes pesize="any" compset="_CAM\d0%WX">
 	<comment>none</comment>
@@ -1388,35 +969,6 @@
     </mach>
   </grid>
   <grid name="a%0.9x1.25">
-     <mach name="cheyenne">
-      <pes pesize="any" compset="_(CAM50|CAM60)%(CT|CV|CF|WC)">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>384</ntasks_atm>
-	  <ntasks_lnd>384</ntasks_lnd>
-	  <ntasks_rof>384</ntasks_rof>
-	  <ntasks_ice>384</ntasks_ice>
-	  <ntasks_ocn>384</ntasks_ocn>
-	  <ntasks_cpl>384</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>3</nthrds_atm>
-	  <nthrds_lnd>3</nthrds_lnd>
-	  <nthrds_rof>3</nthrds_rof>
-	  <nthrds_ice>3</nthrds_ice>
-	  <nthrds_ocn>3</nthrds_ocn>
-	  <nthrds_cpl>3</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
     <mach name="derecho">
       <pes pesize="any" compset="_(CAM50|CAM60)%(CT|CV|CF|WC|CARMA)">
 	<comment>none</comment>
@@ -1452,74 +1004,6 @@
 	  <ntasks_glc>-8</ntasks_glc>
 	  <ntasks_wav>-8</ntasks_wav>
 	  <ntasks_cpl>-8</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-    </mach>
-    <mach name="cheyenne">
-      <pes pesize="any" compset="_CAM60%(CT|WC)">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>768</ntasks_atm>
-	  <ntasks_lnd>768</ntasks_lnd>
-	  <ntasks_rof>768</ntasks_rof>
-	  <ntasks_ice>768</ntasks_ice>
-	  <ntasks_ocn>768</ntasks_ocn>
-	  <ntasks_glc>768</ntasks_glc>
-	  <ntasks_wav>768</ntasks_wav>
-	  <ntasks_cpl>768</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>3</nthrds_atm>
-	  <nthrds_lnd>3</nthrds_lnd>
-	  <nthrds_rof>3</nthrds_rof>
-	  <nthrds_ice>3</nthrds_ice>
-	  <nthrds_ocn>3</nthrds_ocn>
-	  <nthrds_glc>3</nthrds_glc>
-	  <nthrds_wav>3</nthrds_wav>
-	  <nthrds_cpl>3</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-      <pes pesize="any" compset="_CAM\d0%WX">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>1800</ntasks_atm>
-	  <ntasks_lnd>1800</ntasks_lnd>
-	  <ntasks_rof>1800</ntasks_rof>
-	  <ntasks_ice>1800</ntasks_ice>
-	  <ntasks_ocn>1800</ntasks_ocn>
-	  <ntasks_glc>1800</ntasks_glc>
-	  <ntasks_wav>1800</ntasks_wav>
-	  <ntasks_cpl>1800</ntasks_cpl>
 	</ntasks>
 	<nthrds>
 	  <nthrds_atm>1</nthrds_atm>


### PR DESCRIPTION
- fix interim restart capability (needs an update to CIME) and needs update to all components
- removed cheyenne from config_pes.xml 

