### PR TITLE
noresm3_0_021_cam6_4_121: Add energy transport diagnostics

### DIFF
--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aero_history/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aero_history/user_nl_cam
@@ -11,3 +11,4 @@ history_aerosol_forcing = .true.
 history_aerosol_radiation = .true.
 history_aerosol_debug_output = .true.
 history_gas = .true.
+fincl3 = 'IntHeatTr:I', 'PotEnerTr:I', 'LatHeatTr:I', 'KinEnerTr:I', 'TotEnerTr:I'

--- a/src/physics/cam/cam_diagnostics.F90
+++ b/src/physics/cam/cam_diagnostics.F90
@@ -308,6 +308,11 @@ contains
     call addfld ('ZBOT',       horiz_only,  'A', 'm','Lowest model level height')
 
     call addfld ('ATMEINT',    horiz_only,  'A', 'J/m2','Vertically integrated total atmospheric energy ')
+    call addfld ('IntHeatTr', horiz_only,  'A', 'W/m3', 'Meridional transport of internal energy')
+    call addfld ('PotEnerTr', horiz_only,  'A', 'W/m3', 'Meridional transport of potential energy')
+    call addfld ('LatHeatTr', horiz_only,  'A', 'W/m3', 'Meridional transport of latent energy')
+    call addfld ('KinEnerTr', horiz_only,  'A', 'W/m3', 'Meridional transport of kinetic energy')
+    call addfld ('TotEnerTr', horiz_only,  'A', 'W/m3', 'Meridional transport of total energy')
 
     if (history_amwg) then
       call add_default ('PHIS    '  , 1, ' ')
@@ -1253,6 +1258,8 @@ contains
     real(r8) :: ftem(pcols,pver) ! temporary workspace
     real(r8) :: ftem1(pcols,pver) ! another temporary workspace
     real(r8) :: ftem2(pcols,pver) ! another temporary workspace
+    real(r8) :: ftem3(pcols)       ! another temporary workspace
+    real(r8) :: z3(pcols,pver)   ! geo-potential height including surface geopotential
     real(r8) :: p_surf(pcols)    ! data interpolated to a pressure surface
     real(r8) :: p_surf_q1(pcols)    ! data interpolated to a pressure surface
     real(r8) :: p_surf_q2(pcols)    ! data interpolated to a pressure surface
@@ -1414,6 +1421,69 @@ contains
       ftem(:ncol,1) = ftem(:ncol,1) + ftem(:ncol,k)
     end do
     call outfld ('ATMEINT   ', ftem(:ncol,1), ncol, lchnk)
+
+    ! Add energy transport diagnostics
+    !
+    do k = 1, pver
+      z3(:ncol,k) = state%zm(:ncol,k) + state%phis(:ncol)*rga
+    end do
+
+    !! calculate the atmospheric energy transport terms:
+    !! internal energy transport Cp*T*v*dp/g
+    if (hist_fld_active('IntHeatTr')) then
+      ftem(:ncol,:) = (cpair*state%t(:ncol,:)*state%v(:ncol,:))*(state%pdel(:ncol,:)*rga)
+      !! vertically integrate
+      ftem3(:ncol)=ftem(:ncol,1)
+      do k=2,pver
+        ftem3(:ncol) = ftem3(:ncol) + ftem(:ncol,k)
+      end do
+      call outfld ('IntHeatTr', ftem3(:ncol), ncol   ,lchnk)
+    end if
+
+    !! latent energy transport Lv*Q*v*dp/g
+    if (hist_fld_active('LatHeatTr')) then
+      ftem(:ncol,:) = (latvap*state%q(:ncol,:,ixq)*state%v(:ncol,:))*(state%pdel(:ncol,:)*rga)
+      !! vertically integrate
+      ftem3(:ncol)=ftem(:ncol,1)
+      do k=2,pver
+        ftem3(:ncol) = ftem3(:ncol) + ftem(:ncol,k)
+      end do
+      call outfld ('LatHeatTr', ftem3(:ncol)  ,ncol   ,lchnk    )
+    end if
+
+    !! potential energy transport g*z*v*dp/g 
+    if (hist_fld_active('PotEnerTr')) then
+      ftem(:ncol,:) = z3(:ncol,:)*state%v(:ncol,:)*state%pdel(:ncol,:)
+      !! vertically integrate
+      ftem3(:ncol)=ftem(:ncol,1)
+      do k=2,pver
+        ftem3(:ncol) = ftem3(:ncol) + ftem(:ncol,k)
+      end do
+      call outfld ('PotEnerTr',ftem3(:ncol)  ,ncol   ,lchnk   )
+    end if
+
+    !! kinetic energy transport 0.5*(u²+v²)*v*dp/g
+    if (hist_fld_active('KinEnerTr')) then
+      ftem(:ncol,:) = ((0.5_r8*(state%u(:ncol,:)**2+state%v(:ncol,:)**2))*state%v(:ncol,:))*(state%pdel(:ncol,:)*rga)
+      !! vertically integrate
+      ftem3(:ncol)=ftem(:ncol,1)
+      do k=2,pver
+        ftem3(:ncol) = ftem3(:ncol) + ftem(:ncol,k)
+      end do
+      call outfld ('KinEnerTr',ftem3(:ncol) ,ncol   ,lchnk   )
+    end if
+
+    !! Total energy transport Cp*T*v*dp/g + Lv*Q*v*dp/g + g*z*v*dp/g + 0.5*(u²+v²)*v*dp/g
+    if (hist_fld_active('TotEnerTr')) then
+      ftem(:ncol,:) = (cpair*state%t(:ncol,:) + latvap*state%q(:ncol,:,ixq) + gravit*z3(:ncol,:) + &
+                    (0.5_r8*(state%u(:ncol,:)**2+state%v(:ncol,:)**2)))*state%v(:ncol,:)*(state%pdel(:ncol,:)*rga)
+      !! vertically integrate
+      ftem3(:ncol)=ftem(:ncol,1)
+      do k=2,pver
+        ftem3(:ncol) = ftem3(:ncol) + ftem(:ncol,k)
+      end do
+      call outfld ('TotEnerTr',ftem3(:ncol)  ,ncol   ,lchnk   )
+    end if
 
     !! Boundary layer atmospheric stability, temperature, water vapor diagnostics
 


### PR DESCRIPTION
Added formulas for calculating different parts of the atmospheric energy transport along with new history fields, so they can be outputted when running NorESM3.

Contributors: Andrea Rosendahl @andrearosendahl

Reviewers: @gold2718 

Purpose of changes: Add optional energy transport diagnostics to CAM

Github PR URL: https://github.com/NorESMhub/CAM/pull/247

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Test run to verify that I am able to see the new diagnostics: /cluster/work/users/andrear/n1850.ne16pg3_tn14.noresm3_0_beta03b.entrans.2025-11-28

To have the option of outputting 5 atmospheric meridional energy transport variables. 
Top of README.case: 
 ./create_newcase --case /cluster/work/users/andrear/n1850.ne16pg3_tn14.noresm3_0_beta03b.entrans.2025-12-04 --compset 1850_CAM70%LT%NORESM%CAMoslo_CLM60%FATES-NOCOMP_CICE_BLOM%HYB%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP --res ne16pg3_tn14 --project nn9560k --machine betzy --compiler intel --run-unsupported --user-mods-dir /cluster/work/users/andrear/NorESM_3_0_beta03b/cime_config/usermods_dirs/reduced_out_devsim/

user_nl_cam:
! Users should add all user specific namelist changes below in the form of
! namelist_var = new_namelist_value

use_aerocom                = .false.
interpolate_nlat           = 96
interpolate_nlon           = 144
interpolate_output         = .true.,.true.
history_aerosol            = .false.
zmconv_c0_lnd              =  0.0075D0
zmconv_c0_ocn              =  0.0075D0
zmconv_ke                  =  5.0E-6
zmconv_ke_lnd              =  1.0E-5
clim_modal_aero_top_press  =  1.D-4
bndtvg                     = '/cluster/shared/noresm/inputdata/atm/cam/ggas/noaamisc.r8.nc'
dust_emis_method           = 'Leung_2023'
dust_emis_fact             = 6.1D0
rafsip_on                  = .true.
micro_mg_dcs               = 700.D-6
clubb_c8                   =  4.8
nhtfrq = 0, -24
mfilt  = 1,   30
ndens  = 2,   2
fincl1 = 'IntHeatTr', 'PotEnerTr', 'LatHeatTr', 'KinEnerTr', 'TotEnerTr'
fincl2 = 'Z500', 'T850', 'U850', 'V850'


Did a test with these changes, that show fail of NLCOMP and baseline, which is as expected because of the changes in user namelist and extra history file. 
Test: /cluster/work/users/andrear/ed_test/ERP_D_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_gnu.cam-outfrq9s_aero_history.C
