### PR TITLE
noresm3_0_024_cam6_4_121: Fix namelist defauts for co2flux_fuel and aircraft_co2

### DIFF
--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -658,28 +658,30 @@
 <!-- Time-variant CO2 fossil fuel emissions -->
 <co2flux_fuel_datafile>atm/cam/ggas/emissions-cmip6_CO2_anthro_surface_175001-201512_fv_0.9x1.25_c20181011.nc</co2flux_fuel_datafile>
 <co2flux_fuel_meshfile>share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</co2flux_fuel_meshfile>
+<co2flux_fuel_tintalgo>nearest</co2flux_fuel_tintalgo>
 <co2flux_fuel_year_first sim_year="2000">2000</co2flux_fuel_year_first>
-<co2flux_fuel_year_end   sim_year="2000">2000</co2flux_fuel_year_end>
+<co2flux_fuel_year_last  sim_year="2000">2000</co2flux_fuel_year_last>
 <co2flux_fuel_year_align sim_year="2000">1</co2flux_fuel_year_align>
 <co2flux_fuel_year_first sim_year="1850">1850</co2flux_fuel_year_first>
-<co2flux_fuel_year_end   sim_year="1850">1850</co2flux_fuel_year_end>
+<co2flux_fuel_year_last  sim_year="1850">1850</co2flux_fuel_year_last>
 <co2flux_fuel_year_align sim_year="1850">1</co2flux_fuel_year_align>
 <co2flux_fuel_year_first sim_year="1850-2015">1850</co2flux_fuel_year_first>
-<co2flux_fuel_year_end   sim_year="1850-2015">2015</co2flux_fuel_year_end>
+<co2flux_fuel_year_last  sim_year="1850-2015">2015</co2flux_fuel_year_last>
 <co2flux_fuel_year_align sim_year="1850-2015">1850</co2flux_fuel_year_align>
 
 <!-- Time-variant CO2 aircraft emissions -->
 <aircraft_co2_datafile>atm/cam/ggas/emissions-cmip6_CO2_anthro_ac_175001-201512_fv_0.9x1.25_c20181011.nc</aircraft_co2_datafile>
 <aircraft_co2_meshfile>share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</aircraft_co2_meshfile>
-<aircraft_co2_year_first sim_year="2000">2000</aircraft_co2_year_first>
-<aircraft_co2_year_end   sim_year="2000">2000</aircraft_co2_year_end>
-<aircraft_co2_year_align sim_year="2000">1</aircraft_co2_year_align>
-<aircraft_co2_year_first sim_year="1850">1850</aircraft_co2_year_first>
-<aircraft_co2_year_end   sim_year="1850">1850</aircraft_co2_year_end>
-<aircraft_co2_year_align sim_year="1850">1</aircraft_co2_year_align>
-<aircraft_co2_year_first sim_year="1850-2015">1850</aircraft_co2_year_first>
-<aircraft_co2_year_end   sim_year="1850-2015">2015</aircraft_co2_year_end>
-<aircraft_co2_year_align sim_year="1850-2015">1850</aircraft_co2_year_align>
+<aircraft_co2_tintalgo>nearest</aircraft_co2_tintalgo>
+<aircraft_co2_year_first  sim_year="2000">2000</aircraft_co2_year_first>
+<aircraft_co2_year_last   sim_year="2000">2000</aircraft_co2_year_last>
+<aircraft_co2_year_align  sim_year="2000">1</aircraft_co2_year_align>
+<aircraft_co2_year_first  sim_year="1850">1850</aircraft_co2_year_first>
+<aircraft_co2_year_last   sim_year="1850">1850</aircraft_co2_year_last>
+<aircraft_co2_year_align  sim_year="1850">1</aircraft_co2_year_align>
+<aircraft_co2_year_first  sim_year="1850-2015">1850</aircraft_co2_year_first>
+<aircraft_co2_year_last   sim_year="1850-2015">2015</aircraft_co2_year_last>
+<aircraft_co2_year_align  sim_year="1850-2015">1850</aircraft_co2_year_align>
 
 <!-- Greenhouse gas production/loss rates -->
 <bndtvg>atm/cam/ggas/noaamisc.r8.nc</bndtvg>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -1836,8 +1836,7 @@ Default set by build-namelist based on sim_year.
 <entry id="co2flux_fuel_tintalgo" type="char*16" category="co2_cycle"
        group="co2_ffuel_nl" valid_values="linear,lower,upper,nearest">
 Time interpolation algorithm to use for co2flux_fuel_datafile.
-If not set by user, then set to 'nearest' if the variable 'time_bnds' is in
-the forcing file otherwise, set to 'linear'
+Default: nearest
 </entry>
 
 <entry id="co2flux_fuel_taxmode" type="char*16" category="co2_cycle"
@@ -1894,8 +1893,7 @@ Default: set by build-namelist based on sim_year
 <entry id="aircraft_co2_tintalgo" type="char*16" category="co2_cycle"
        group="aircraft_emit_nl" valid_values="linear,lower,upper,nearest">
 Time interpolation algorithm to use for aircraft_co2_datafile.
-If not set by user, then set to 'nearest' if the variable 'time_bnds' is in
-the forcing file otherwise, set to 'linear'
+Default: nearest
 </entry>
 
 <entry id="aircraft_co2_taxmode" type="char*16" category="co2_cycle"


### PR DESCRIPTION
Summary: fixed namelist problems for co2flux_fuel and aircraft_co2fixed namelist problems for co2flux_fuel and aircraft_co2

Contributors: mvertens

Reviewers: @gold2718 

Purpose of changes: Fix #253 

Changes made to build system: None

Changes made to the namelist: Yes 

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None
