### PR TITLE
noresm3_0_027_cam6_4_121: Move to new topography for 2 degree runs (ne16pg3)

### DIFF
--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -277,7 +277,7 @@
 <bnd_topo hgrid="ne3np4"          >atm/cam/topo/se/ne3np4_gmted2010_modis_bedmachine_nc0540_Laplace1000_noleak_20230717.nc</bnd_topo>
 <bnd_topo hgrid="ne3np4"   npg="3">atm/cam/topo/se/ne3pg3_gmted2010_modis_bedmachine_nc0540_Laplace1000_noleak_20230209.nc</bnd_topo>
 <bnd_topo hgrid="ne5np4"   npg="3">atm/cam/topo/se/ne5pg3_nc3000_Co360_Fi001_MulG_PF_nullRR_Nsw064_20170516.nc</bnd_topo>
-<bnd_topo hgrid="ne16np4"  npg="3">atm/cam/topo/se/ne16pg3_gmted2010_modis_bedmachine_nc3000_Laplace0200_20230202.nc</bnd_topo>
+<bnd_topo hgrid="ne16np4"  npg="3">atm/cam/topo/se/ne16pg3_gmted2010_modis_bedmachine_nc3000_Laplace0200_noleak_greenlndantarcsgh30fac2.50_20250825.nc</bnd_topo>
 <bnd_topo hgrid="ne30np4" npg="3">atm/cam/topo/se/ne30pg3_gmted2010_modis_bedmachine_nc3000_Laplace0100_noleak_greenlndantarcsgh30fac2.50_20250828.nc</bnd_topo>
 <bnd_topo hgrid="ne60np4"  npg="3">atm/cam/topo/se/ne60pg3_nc3000_Co030_Fi001_PF_nullRR_Nsw021_20171012.nc</bnd_topo>
 <bnd_topo hgrid="ne120np4" npg="3">atm/cam/topo/se/ne120pg3_nc3000_Co015_Fi001_PF_nullRR_Nsw010_20171014.nc</bnd_topo>


### PR DESCRIPTION
Replace the current ne16pg3 topography with a new file from NCAR

Summary: Update the ne16pg3 topography as recommended by Peter Lauritzen

Contributors: gold2718

Reviewers: @oyvindseland

Purpose of changes: #258

Github PR URL: https://github.com/NorESMhub/CAM/pull/264

Changes made to build system: None

Changes made to the namelist: Updated the default `bnd_topo` for ne16pg3

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Testing: 
- aux_cam_noresm tests pass with baseline differences for ne16pg3 runs
- Comparison to a beta11 run: https://ns2345k.web.sigma2.no/datalake/diagnostics/ADF/goldy/n1850_ne16pg3_tn14_new_topo_586_595_vs_n1850_ne16pg3_tn14_beta11_586_595/

fixes #258 