### PR TITLE
noresm3_0_028_cam6_4_121: Add a test for fates with initial conditions and update CTSM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -221,7 +221,7 @@
 [submodule "clm"]
     path = components/clm
     url = https://github.com/NorESMhub/CTSM
-    fxtag = ctsm5.3.045_noresm_v13
+    fxtag = ctsm5.4.002_noresm_v4
     fxrequired = ToplevelRequired
     fxDONOTUSEurl = https://github.com/NorESMhub/CTSM
 

--- a/bld/namelist_files/use_cases/hist_camnor_lt_osloaero.xml
+++ b/bld/namelist_files/use_cases/hist_camnor_lt_osloaero.xml
@@ -12,7 +12,7 @@
 
 <!-- Low top upper boundary conditions -->
 <ubc_specifier>'Q:H2O->UBC_FILE'</ubc_specifier>
-<ubc_file_path>atm/cam/chem/ubc/f.e21.FWHISTBgcCrop.f09_f09_mg17.CMIP6-AMIP-WACCM.ensAvg123.cam.h0zm.UBC.195001-201412_c220322.nc</ubc_file_path>
+<ubc_file_path>atm/cam/chem/ubc/b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensAvg123.cam.h0zm.H2O.1849-2014_c240604.nc</ubc_file_path>
 <ubc_file_input_type>'SERIAL'</ubc_file_input_type>
 
 <!-- ozone data -->

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -107,6 +107,15 @@
     </options>
   </test>
 
+  <test compset="NF1850fates-nocomp" grid="ne30pg3_ne30pg3_mtn14" name="ERS_Ld3" testmods="cam/outfrq9s_fatesini">
+    <machines>
+      <machine name="betzy" compiler="gnu" category="aux_cam_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">01:40:00</option>
+    </options>
+  </test>
+
   <test compset="NF1850" grid="ne3pg3_ne3pg3_mtn14" name="ERP_D_Ln9" testmods="cam/outfrq9s">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -7,7 +7,8 @@
 
   <test compset="NFLTHISTmam4" grid="ne30pg3_ne30pg3_mtn14" name="ERP_D_Ln9" testmods="cam/outfrq9s">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:40:00</option>
@@ -15,7 +16,8 @@
   </test>
   <test compset="NFLTHIST" grid="ne30pg3_ne30pg3_mtn14" name="ERP_D_Ln9" testmods="cam/outfrq9s">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:40:00</option>
@@ -24,7 +26,8 @@
 
   <test compset="NF2000" grid="ne30pg3_ne30pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:40:00</option>
@@ -32,7 +35,8 @@
   </test>
   <test compset="NF2000mam4" grid="ne30pg3_ne30pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:40:00</option>
@@ -41,7 +45,8 @@
 
   <test compset="NF1850fates-sp" grid="ne16pg3_ne16pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -50,7 +55,8 @@
 
   <test compset="NF1850" grid="ne30pg3_ne30pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -58,7 +64,8 @@
   </test>
   <test compset="NF1850" grid="ne30pg3_ne30pg3_mtn14" name="ERP_D_Ln9" testmods="cam/outfrq9s_aero_history">
     <machines>
-      <machine name="betzy" compiler="gnu" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="gnu" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="gnu" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -66,7 +73,8 @@
   </test>
   <test compset="NF1850mam4" grid="ne30pg3_ne30pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -74,7 +82,8 @@
   </test>
   <test compset="NF1850" grid="ne16pg3_ne16pg3_mtn14" name="ERP_Ln9" testmods="cam/secice">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -83,7 +92,8 @@
   </test>
   <test compset="NF1850" grid="ne16pg3_ne16pg3_mtn14" name="ERP_D_Ln18_P256" testmods="cam/outfrq9s_zm">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:30:00</option>
@@ -92,7 +102,8 @@
   </test>
   <test compset="NF1850ghg_fates-sp" grid="ne16pg3_ne16pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:40:00</option>
@@ -100,7 +111,8 @@
   </test>
   <test compset="NF1850ghg_fates-nocomp" grid="ne16pg3_ne16pg3_mtn14" name="ERP_Ld5" testmods="cam/outfrq9s">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:40:00</option>
@@ -109,7 +121,8 @@
 
   <test compset="NF1850fates-nocomp" grid="ne30pg3_ne30pg3_mtn14" name="ERS_Ld3" testmods="cam/outfrq9s_fatesini">
     <machines>
-      <machine name="betzy" compiler="gnu" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="gnu" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="gnu" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">01:40:00</option>
@@ -118,7 +131,8 @@
 
   <test compset="NF1850" grid="ne3pg3_ne3pg3_mtn14" name="ERP_D_Ln9" testmods="cam/outfrq9s">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -131,8 +145,8 @@
 
   <test compset="F1850" grid="f19_f19_mtn14" name="ERP_D_Ln9_P256" testmods="cam/outfrq9s">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
-      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
+      <machine name="betzy"  compiler="intel" category="prealpha_noresm"/>
+      <machine name="olivia" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -141,7 +155,8 @@
 
   <test compset="F2000climo" grid="ne30pg3_ne30pg3_mtn14" name="ERP_D_Ln9_P512" testmods="cam/outfrq9s">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:25:00</option>
@@ -150,7 +165,8 @@
 
   <test compset="FLTHIST" grid="ne3pg3_ne3pg3_mg37" name="ERP_D_Ln9_P36" testmods="cam/outfrq9s">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_cam_noresm"/>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
     </machines>
     <options>
       <option name="wallclock">00:10:00</option>

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_fatesini/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_fatesini/shell_commands
@@ -1,0 +1,2 @@
+./xmlchange ROF_NCPL=\$ATM_NCPL
+./xmlchange GLC_NCPL=\$ATM_NCPL

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_fatesini/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_fatesini/user_nl_cam
@@ -1,0 +1,5 @@
+mfilt=1,1,1,1,1,1
+ndens=1,1,1,1,1,1
+nhtfrq=9,9,9,9,9,9
+write_nstep0=.true.
+inithist='ENDOFRUN'

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_fatesini/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_fatesini/user_nl_clm
@@ -1,0 +1,5 @@
+hist_nhtfrq = 9
+hist_mfilt  = 1
+finidat='/cluster/work/users/mdeb/noresm/ne30ini/n1850.ne30pg3_tn14.noresm3_0_beta10-run8_yr121.20260131.clm2.r.0151-01-01-00000.nc'
+
+

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_fatesini/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_fatesini/user_nl_clm
@@ -1,5 +1,5 @@
 hist_nhtfrq = 9
 hist_mfilt  = 1
-finidat='/cluster/work/users/mdeb/noresm/ne30ini/n1850.ne30pg3_tn14.noresm3_0_beta10-run8_yr121.20260131.clm2.r.0151-01-01-00000.nc'
+finidat='$DIN_LOC_ROOT/lnd/clm2/initdata_esmf/ctsm5.4/n1850.ne30pg3_tn14.noresm3_0_beta10_beta_testing_20260131.nc'
 
 


### PR DESCRIPTION
Summary: Adding a test and a ctsm tag with fix for ERS tests when finidat is specified

Contributors: @mvdebolskiy 

Reviewers: @gold2718 

Purpose of changes: Add testing for restarting the model with fates-compset when it is not started from cold.

Github PR URL: https://github.com/NorESMhub/CAM/pull/265

Changes made to build system: None
Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Issues addressed by this PR:
NorESMhub/NorESM#770
NorESMhub/CTSM#200
fixes #263 