### PR TITLE
noresm3_0_033_cam6_4_121: Add namelist variables for dust and seasalt parameters

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,7 +85,7 @@
 [submodule "oslo_aero"]
     path = src/chemistry/oslo_aero
     url = https://github.com/NorESMhub/OSLO_AERO
-    fxtag = oslo_aero_3_0a009
+    fxtag = oslo_aero_3_0a010
     fxrequired = AlwaysRequired
     fxDONOTUSEurl = https://github.com/NorESMhub/OSLO_AERO.git
 

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -981,7 +981,7 @@ if ($chem =~ /_mam_oslo/) {
 if ($aer_model eq 'oslo') {
   add_default($nl, 'emis_fact_in_coarse_mode', 'ver'=>'oslo_aero');
   add_default($nl, 'seasalt_emis_scale',  'ver'=>'oslo_aero');
-  add_default($nl, 'dust_emis_fact', 'ver'=>'oslo_aero')
+  add_default($nl, 'dust_emis_fact', 'ver'=>'oslo_aero');
    #do nothing here
 
 } elsif ($aer_model eq 'mam' ) {

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -979,8 +979,8 @@ if ($chem =~ /_mam_oslo/) {
 }
 
 if ($aer_model eq 'oslo') {
-  add_default($nl, 'emis_fact_in_coarse_mode');
-  add_default($nl, 'seasalt_emis_scale');
+  add_default($nl, 'emis_fact_in_coarse_mode', 'ver'=>'oslo_aero');
+  add_default($nl, 'seasalt_emis_scale',  'ver'=>'oslo_aero');
    #do nothing here
 
 } elsif ($aer_model eq 'mam' ) {

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -981,8 +981,6 @@ if ($chem =~ /_mam_oslo/) {
 if ($aer_model eq 'oslo') {
   add_default($nl, 'emis_fact_in_coarse_mode', 'ver'=>'oslo_aero');
   add_default($nl, 'seasalt_emis_scale',  'ver'=>'oslo_aero');
-  add_default($nl, 'dust_emis_fact', 'ver'=>'oslo_aero');
-   #do nothing here
 
 } elsif ($aer_model eq 'mam' ) {
 
@@ -3971,7 +3969,9 @@ if ($cfg->get('microphys') eq 'rk') {
 
 # Dust emissions tuning factor
 # check whether turbulent mountain stress parameterization is on
-if ($nl->get_value('do_tms') =~ /$TRUE/io) {
+if ($aer_model eq 'oslo') {
+  add_default($nl, 'dust_emis_fact', 'ver'=>'oslo_aero');
+} elsif ($nl->get_value('do_tms') =~ /$TRUE/io) {
     add_default($nl, 'dust_emis_fact', 'tms'=>'1');
 } else {
     if ($chem =~ /trop_strat/ or $chem =~ /geoschem/ or $chem =~ /waccm_ma/ or $chem =~ /waccm_tsmlt/ or $chem =~ /trop_mozart/) {

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -979,7 +979,8 @@ if ($chem =~ /_mam_oslo/) {
 }
 
 if ($aer_model eq 'oslo') {
-
+  add_default($nl, 'emis_fact_in_coarse_mode');
+  add_default($nl, 'seasalt_emis_scale');
    #do nothing here
 
 } elsif ($aer_model eq 'mam' ) {

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -981,6 +981,7 @@ if ($chem =~ /_mam_oslo/) {
 if ($aer_model eq 'oslo') {
   add_default($nl, 'emis_fact_in_coarse_mode', 'ver'=>'oslo_aero');
   add_default($nl, 'seasalt_emis_scale',  'ver'=>'oslo_aero');
+  add_default($nl, 'dust_emis_fact', 'ver'=>'oslo_aero')
    #do nothing here
 
 } elsif ($aer_model eq 'mam' ) {

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2518,7 +2518,7 @@
 <dust_emis_fact hgrid="0.47x0.63" offline_dyn="1" phys="cam7"    ver="chem">2.30D0</dust_emis_fact>
 
 <!-- Oslo_Aero default-->
-<dust_emis_fact dyn="se" phys="cam7">  3.3D0 </dust_emis_fact> 
+<dust_emis_fact dyn="se" ver="oslo_aero">  3.3D0 </dust_emis_fact> 
 <emis_fact_in_coarse_mode>0.97D0</emis_fact_in_coarse_mode>
 <!-- dust emissions method -->
 <dust_emis_method>              Zender_2003</dust_emis_method>
@@ -2530,7 +2530,7 @@ See https://github.com/NorESMhub/noresm3_dev_simulations/discussions/78
 
 <!-- seasalt emission tuning factor -->
 <!-- Note that ver="strat" when modal_accum_coarse_exch=.true. -->
-<seasalt_emis_scale                                                      >1.D0</seasalt_emis_scale>
+<seasalt_emis_scale                                                      >1.35D0</seasalt_emis_scale>
 <seasalt_emis_scale ver="oslo_aero"                                      >1.D0</seasalt_emis_scale>
 <seasalt_emis_scale ver="mam7"                                           >1.62D0</seasalt_emis_scale>
 <seasalt_emis_scale ver="strat"                                          >0.90D0</seasalt_emis_scale>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2518,7 +2518,7 @@
 <dust_emis_fact hgrid="0.47x0.63" offline_dyn="1" phys="cam7"    ver="chem">2.30D0</dust_emis_fact>
 
 <!-- Oslo_Aero default-->
-<dust_emis_fact dyn="se" ver="oslo_aero">  3.3D0 </dust_emis_fact> 
+<dust_emis_fact dyn="se" ver="oslo_aero">  3.3D0 </dust_emis_fact>
 <emis_fact_in_coarse_mode>0.97D0</emis_fact_in_coarse_mode>
 <!-- dust emissions method -->
 <dust_emis_method>              Zender_2003</dust_emis_method>
@@ -2872,7 +2872,7 @@ See https://github.com/NorESMhub/noresm3_dev_simulations/discussions/78
   'T', 'bc_a1', 'bc_a4', 'dst_a1', 'dst_a2', 'dst_a3', 'ncl_a1', 'ncl_a2', 'ncl_a3',
   'num_a1', 'num_a2', 'num_a3', 'num_a4', 'pom_a1', 'pom_a4', 'so4_a1', 'so4_a2', 'so4_a3', 'soa_a1', 'soa_a2'
 </scm_relax_fincl>
-<scm_relax_fincl   phys="cam7"scam="1"  >
+<scm_relax_fincl   phys="cam7" scam="1"  >
   'T', 'bc_a1', 'bc_a4', 'dst_a1', 'dst_a2', 'dst_a3', 'ncl_a1', 'ncl_a2', 'ncl_a3',
   'num_a1', 'num_a2', 'num_a3', 'num_a4', 'pom_a1', 'pom_a4', 'so4_a1', 'so4_a2', 'so4_a3', 'soa_a1', 'soa_a2'
 </scm_relax_fincl>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2517,6 +2517,9 @@
 <dust_emis_fact hgrid="0.47x0.63" offline_dyn="1" phys="cam6"    ver="chem">0.9D0</dust_emis_fact>
 <dust_emis_fact hgrid="0.47x0.63" offline_dyn="1" phys="cam7"    ver="chem">2.30D0</dust_emis_fact>
 
+<!-- Oslo_Aero default-->
+<dust_emis_fact dyn="se" phys="cam7">  3.3D0 </dust_emis_fact> 
+<emis_fact_in_coarse_mode>0.97D0</emis_fact_in_coarse_mode>
 <!-- dust emissions method -->
 <dust_emis_method>              Zender_2003</dust_emis_method>
 <!-- gold2718: Temporarily not using Leung_2023 as default for CAM7
@@ -2527,7 +2530,7 @@ See https://github.com/NorESMhub/noresm3_dev_simulations/discussions/78
 
 <!-- seasalt emission tuning factor -->
 <!-- Note that ver="strat" when modal_accum_coarse_exch=.true. -->
-<seasalt_emis_scale                                                      >1.35D0</seasalt_emis_scale>
+<seasalt_emis_scale                                                      >1.D0</seasalt_emis_scale>
 <seasalt_emis_scale ver="mam7"                                           >1.62D0</seasalt_emis_scale>
 <seasalt_emis_scale ver="strat"                                          >0.90D0</seasalt_emis_scale>
 <seasalt_emis_scale ver="strat" clubb_sgs="1"                            >1.00D0</seasalt_emis_scale>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2531,6 +2531,7 @@ See https://github.com/NorESMhub/noresm3_dev_simulations/discussions/78
 <!-- seasalt emission tuning factor -->
 <!-- Note that ver="strat" when modal_accum_coarse_exch=.true. -->
 <seasalt_emis_scale                                                      >1.D0</seasalt_emis_scale>
+<seasalt_emis_scale ver="oslo_aero"                                      >1.D0</seasalt_emis_scale>
 <seasalt_emis_scale ver="mam7"                                           >1.62D0</seasalt_emis_scale>
 <seasalt_emis_scale ver="strat"                                          >0.90D0</seasalt_emis_scale>
 <seasalt_emis_scale ver="strat" clubb_sgs="1"                            >1.00D0</seasalt_emis_scale>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -6850,6 +6850,12 @@ Tuning parameter for dust emissions.
 Default: set by build-namelist.
 </entry>
 
+<entry id="emis_fact_in_coarse_mode" type="real" category="cam_chem"
+       group="dust_nl" valid_values="" >
+Tuning parameter for the fraction of total dust emissions but in the largest mode.
+Default: set by build-namelist.
+</entry>
+
 <entry id="steady_state_ion_elec_temp" type="logical" category="waccmx"
        group="ion_electron_temp_nl" valid_values="" >
 If TRUE a steady state solution is used to calculate electron and

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -6852,7 +6852,9 @@ Default: set by build-namelist.
 
 <entry id="emis_fact_in_coarse_mode" type="real" category="cam_chem"
        group="dust_nl" valid_values="" >
-Tuning parameter for the fraction of total dust emissions but in the largest mode.
+Tuning parameter for the fraction of total dust emissions in the coarse dust mode (Oslo_Aero). 
+Valid values are in the range [0, 1], where the remaining fraction (1 - emis_fact_in_coarse_mode) 
+is allocated to the dust accumulation mode.
 Default: set by build-namelist.
 </entry>
 


### PR DESCRIPTION
Summary: Additional Seasalt and dust namelist parameters

Contributors: @Ovewh @DirkOlivie 

Reviewers: @gold2718 

Purpose of changes: To tune aerosol parameters in order to improve on current aerosol biases

Github PR URL: https://github.com/NorESMhub/CAM/pull/273

Changes made to build system:  'None' 

Changes made to the namelist: New name list description and defaults

Changes to the defaults for the boundary datasets: 'None' 

Substantial timing or memory changes: 'None' 

Introduce new namelist defaults and namelist definitions for new namelist options introduced in [Oslo_Aero #70](https://github.com/NorESMhub/OSLO_AERO/pull/70)

```
PASS ERP_D_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_gnu.cam-outfrq9s_aero_history CREATE_NEWCASE
PASS ERP_D_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_gnu.cam-outfrq9s_aero_history XML
PASS ERP_D_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_gnu.cam-outfrq9s_aero_history SETUP
PASS ERP_D_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_gnu.cam-outfrq9s_aero_history SHAREDLIB_BUILD time=181
PASS ERP_D_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_gnu.cam-outfrq9s_aero_history MODEL_BUILD time=218
PASS ERP_D_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_gnu.cam-outfrq9s_aero_history SUBMIT
PASS ERP_D_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_gnu.cam-outfrq9s_aero_history RUN time=758
PASS ERP_D_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_gnu.cam-outfrq9s_aero_history COMPARE_base_rest
PASS ERP_D_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_gnu.cam-outfrq9s_aero_history MEMLEAK insufficient data for memleak test
PASS ERP_D_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.betzy_gnu.cam-outfrq9s_aero_history SHORT_TERM_ARCHIVER
```

test:
aux_cam_noresm tests pass with exception of expected NLCOMP and BASELINE differences
