### PR TITLE
Add test of aerocom diagnostics

### DIFF
--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -60,6 +60,17 @@
     </options>
   </test>
 
+  <test compset="NF1850" grid="ne16pg3_ne16pg3_mtn14" name="ERP_D_Ln9" testmods="cam/outfrq9s_aerocom">
+  <machines>
+    <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+    <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
+  </machines>
+  <options>
+    <option name="wallclock">00:20:00</option>
+    <option name="comment">Test of aerocom diagnostics at 2 degree without DEBUG</option>
+  </options>
+  </test>
+
   <test compset="NF1850" grid="ne30pg3_ne30pg3_mtn14" name="ERP_Ln9" testmods="cam/outfrq9s">
     <machines>
       <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aerocom/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aerocom/shell_commands
@@ -1,0 +1,2 @@
+./xmlchange ROF_NCPL=\$ATM_NCPL
+./xmlchange GLC_NCPL=\$ATM_NCPL

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aerocom/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aerocom/user_nl_cam
@@ -1,0 +1,7 @@
+mfilt=1,1,1,1,1,1
+ndens=1,1,1,1,1,1
+nhtfrq=9,9,9,9,9,9
+write_nstep0=.true.
+inithist='ENDOFRUN'
+use_aerocom=.true.
+fincl3 = 'IntHeatTr:I', 'PotEnerTr:I', 'LatHeatTr:I', 'KinEnerTr:I', 'TotEnerTr:I'

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aerocom/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq9s_aerocom/user_nl_clm
@@ -1,0 +1,27 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes below in the form of 
+! namelist_var = new_namelist_value 
+!
+! Include namelist variables for drv_flds_in ONLY if -megan and/or -drydep options
+! are set in the CLM_NAMELIST_OPTS env variable.
+!
+! EXCEPTIONS: 
+! Set use_cndv           by the compset you use and the CLM_BLDNML_OPTS -dynamic_vegetation setting
+! Set use_vichydro       by the compset you use and the CLM_BLDNML_OPTS -vichydro           setting
+! Set use_cn             by the compset you use and CLM_BLDNML_OPTS -bgc  setting
+! Set use_crop           by the compset you use and CLM_BLDNML_OPTS -crop setting
+! Set spinup_state       by the CLM_BLDNML_OPTS -bgc_spinup      setting
+! Set irrigate           by the CLM_BLDNML_OPTS -irrig           setting
+! Set dtime              with L_NCPL                             option
+! Set fatmlndfrc         with LND_DOMAIN_PATH/LND_DOMAIN_FILE    options
+! Set finidat            with RUN_REFCASE/RUN_REFDATE/RUN_REFTOD options for hybrid or branch cases
+!                        (includes $inst_string for multi-ensemble cases)
+! Set glc_grid           with CISM_GRID                          option
+! Set glc_smb            with GLC_SMB                            option
+! Set maxpatch_glcmec    with GLC_NEC                            option
+! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable
+!----------------------------------------------------------------------------------
+hist_nhtfrq = 9
+hist_mfilt  = 1
+hist_ndens  = 1
+


### PR DESCRIPTION
**Testing of Aerocom diagnostics**

Summary: Currently there are no tests with `use_aerocom=.true.`. This PR add a basic NF1850 test with aerocom diagnostics enabled. 

Contributors: @Ovewh 

Reviewers: @gold2718 

Purpose of changes: Include tests of aerocom diagnostics

Github PR URL: 

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None
