### PR TITLE
noresm3_0_036_cam6_4_121: CAM aerosol optical depth tuning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,7 +85,7 @@
 [submodule "oslo_aero"]
     path = src/chemistry/oslo_aero
     url = https://github.com/NorESMhub/OSLO_AERO
-    fxtag = oslo_aero_3_0a011
+    fxtag = oslo_aero_3_0a012
     fxrequired = AlwaysRequired
     fxDONOTUSEurl = https://github.com/NorESMhub/OSLO_AERO.git
 

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -3290,6 +3290,7 @@ $nl->set_variable_value('phys_ctl_nl', 'use_simple_phys', $use_simple_phys);
 
 #Cam-Oslo options
 add_default($nl, 'use_aerocom', 'ver'=>$aer_model);
+add_default($nl, 'rh_fine_aer_scale_fact_optics');
 add_default($nl, 'volc_fraction_coarse');
 add_default($nl, 'aerotab_table_dir');
 add_default($nl, 'ocean_filepath');

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -4107,6 +4107,7 @@
 <!-- CAM-Oslo variables -->
 <use_aerocom>.false.</use_aerocom>
 <use_aerocom ver="oslo">.true.</use_aerocom>
+<rh_fine_aer_scale_fact_optics>1.0</rh_fine_aer_scale_fact_optics>
 <dme_energy_adjust>.true.</dme_energy_adjust>
 <volc_fraction_coarse   >0.0</volc_fraction_coarse>
 <aerotab_table_dir>noresm-only/atm/cam/camoslo/AeroTab_8jun17/</aerotab_table_dir>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -10162,7 +10162,9 @@ Default: false
 
 <entry id="rh_fine_aer_scale_fact_optics" type="real" category="cam_oslo"
        group="oslo_ctl_nl" valid_values="" >
-Scales the relative humidity in the optical calculations within OSLO_AERO for modes 1-5 
+- Scales the relative humidity in the optical calculations
+  within OSLO_AERO for modes 1-5 
+- RH not scaled for dust (modes 6-7) or seasalt (modes 8-10)
 Default: 1.0
 </entry>
 

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -10160,6 +10160,13 @@ If true, turn on aerocom output
 Default: false
 </entry>
 
+<entry id="rh_fine_aer_scale_fact_optics" type="real" category="cam_oslo"
+       group="oslo_ctl_nl" valid_values="" >
+Scales the relative humidity in the optical calculations within OSLO_AERO for modes 1-5 
+Default: 1.0
+</entry>
+
+
 <entry id="volc_fraction_coarse" type="real" category="cam_oslo"
        group="oslo_ctl_nl" valid_values="" >
 Fraction of volcanic aerosols which will end up in coarse mode


### PR DESCRIPTION

Summary: Tuning of aerosol optical depth by increasing the sensitivity of optical depth to relative humidity. 

Contributors: @Ovewh @DirkOlivie 

Reviewers: @gold2718 @DirkOlivie 

Purpose of changes: Improve negative bias of aerosol optical depth over land

Github PR URL: [#280](https://github.com/NorESMhub/CAM/pull/280)

Changes made to build system:  None

Changes made to the namelist: introduce a new namelist variable `rh_fine_aer_scale_fact_optics` that is multiplied by relative humidity given as input to the interpolation routines of AeroTab for modes 1-5 ,excluding Sea-salt and dust.

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: Not checked

Adds a new namelist parameter `rh_fine_aer_scale_fact_optics` (default 1.0, i.e. no change) that scales the effective relative humidity seen by fine aerosol modes during look-up table interpolation. This provides a tuning handle for aerosol optical depth without modifying the underlying aerosol state.

The scaling is applied to SO4/SOA, BC, and OC modes (modes 1–5) in both the main optics routine (oslo_aero_optical_params.F90) and the AeroCom diagnostics routine (oslo_aero_aerocom.F90). Mineral dust (modes 6–7) and sea salt (modes 8–10) are intentionally set to the unscaled RH, as their hygroscopicity growth is less uncertain and that we mainly would like to increase the optical depth over land.

Issues addressed by this PR: see [discussion #410](https://github.com/NorESMhub/noresm3_dev_simulations/discussions/410) and Oslo_Aero [PR #73 ](https://github.com/NorESMhub/OSLO_AERO/pull/73)

### Testing 
Testing done: Checked that with `rh_fine_aer_scale_fact_optics`  at default then output is bit for bit with noresm_develop

Case with rh_fine_aer_scale_fact_optics implemented: `/cluster/work/users/ovewh/noresm/ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom.20260529_142603_phi9tp`

Case CAM noresm_develop: `/cluster/work/users/ovewh/noresm/ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom.20260529_150039_tbilz3`


 `/cluster/projects/nn2345k/ovewh/CAM/cime/CIME/Tools/bless_test_results   -t phi9tp   -r /cluster/work/users/ovewh/noresm   --baseline-root /cluster/work/users/ovewh/noresm/baselines   -g aerocom_v1`


`/cluster/projects/nn2345k/ovewh/CAM/cime/CIME/Tools/compare_test_results   -t tbilz3   -r /cluster/work/users/ovewh/noresm   --baseline-root /cluster/work/users/ovewh/noresm/baselines   -b aerocom_v1   --hist-only -d
`
```
RUN: /cluster/shared/noresm/tools/cprnc-iompi-2022a/bin/cprnc -m /cluster/work/users/ovewh/noresm/
ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom.20260529_150039_tbilz3/run/
ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-
outfrq9s_aerocom.20260529_150039_tbilz3.cam.h0a.0001-01-01-16200.nc /cluster/work/users/ovewh/noresm/
baselines/aerocom_v1/ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom/
cam.h0a.0001-01-01-16200.nc
```

Test status of ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom.20260529_142603_phi9tp
```
PASS ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom CREATE_NEWCASE
PASS ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom XML
PASS ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom SETUP
PASS ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom SHAREDLIB_BUILD time=254
PASS ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom MODEL_BUILD time=406
PASS ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom SUBMIT
PASS ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom RUN time=678
PASS ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom COMPARE_base_rest
PASS ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom MEMLEAK insufficient data for memleak test
PASS ERP_D_Ln9.ne16pg3_ne16pg3_mtn14.NF1850.betzy_intel.cam-outfrq9s_aerocom SHORT_TERM_ARCHIVER
```