### PR TITLE
noresm3_0_038_cam6_4_121: Do not create two CO2 tracers

### DIFF
--- a/bld/configure
+++ b/bld/configure
@@ -34,7 +34,7 @@ use IO::Handle;
 
 use FindBin qw($Bin);
 use lib "$Bin/perl5lib";
-use Build::ChemPreprocess qw(chem_preprocess chem_number_adv);
+use Build::ChemPreprocess qw(chem_preprocess chem_number_adv get_species_list);
 use File::Copy;
 
 #-----------------------------------------------------------------------------------------------
@@ -1446,8 +1446,19 @@ else {
 
         # co2_cycle
         if ($co2_cycle) {
-            $nadv += 4;
-            if ($print>=2) { print "Advected constituents added by co2_cycle: 4$eol"; }
+            my $nco2;
+            my @species_list;
+            my %hash;
+            @species_list = get_species_list($chem_src_dir);
+            @hash{@species_list}=();
+            if (exists $hash{"CO2"}) {
+                # Do not double count CO2
+                $nco2 = 3;
+            } else {
+                $nco2 = 4;
+            }
+            $nadv += $nco2;
+            if ($print>=2) { print "Advected constituents added by co2_cycle: $nco2$eol"; }
         }
 
         # CARMA package:

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -126,7 +126,6 @@
     <default_value>fv</default_value>
     <values match="last">
       <value grid="a%ne[0-9]">se</value>
-      <value grid="a%C[0-9]" >fv3</value>
       <value grid="a%mpasa[0-9]">mpas</value>
     </values>
     <group>build_component_cam</group>
@@ -400,14 +399,12 @@
       <value compset="_CAM60%WCTS%1PCT"> flbc_cycle_yr=-1 </value>
       <value compset="_CAM60%WCTS%1PCT"> flbc_file='$DIN_LOC_ROOT/atm/waccm/lb/LBC_CMIP6_1pctCO2ramp_y1-165_0p5degLat_c180930.nc'</value>
       <value compset="_CAM60%WCTS%1PCT"> nlte_limit_co2=.true.</value>
-      <!-- BPRP? -->
-<!-- This should move to a CAM use case file
+      <!-- These values are set here since it is part of the compset
+           definition -->
+      <value compset="_BGC%BDRP"> co2_cycle_rad_passive=.false. </value>
       <value compset="_BGC%BDRD"> co2_cycle_rad_passive=.true. </value>
--->
       <!-- hemco (harmonized emissions component) option -->
       <value compset="_CAM.*%HEMCO"> use_hemco=.true. </value>
-      <!-- rearth provided by FMS for FV3 and must remain fixed to that value to maintain consistency between phys/dyn. -->
-      <value grid="a%C[0-9]"> rearth = 6.37122D6 </value>
     </values>
     <group>run_component_cam</group>
     <file>env_run.xml</file>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -401,7 +401,7 @@
       <value compset="_CAM60%WCTS%1PCT"> nlte_limit_co2=.true.</value>
       <!-- These values are set here since it is part of the compset
            definition -->
-      <value compset="_BGC%BDRP"> co2_cycle_rad_passive=.false. </value>
+      <value compset="_BGC%BPRP"> co2_cycle_rad_passive=.false. </value>
       <value compset="_BGC%BDRD"> co2_cycle_rad_passive=.true. </value>
       <!-- hemco (harmonized emissions component) option -->
       <value compset="_CAM.*%HEMCO"> use_hemco=.true. </value>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -60,6 +60,11 @@
     <lname>1850_CAM70%LT%NORESM%GHGCAMoslo_CLM60%FATES-NCFB%NORESM_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
   </compset>
 
+  <compset>
+    <alias>NF1850esmGhg</alias>
+    <lname>1850_CAM70%LT%NORESM%GHGCAMoslo_CLM60%FATES-NCFB%NORESM_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV_SESP_BGC%BPRP</lname>
+  </compset>
+
   <!-- CAM7 HIST -->
 
   <compset>
@@ -77,6 +82,11 @@
     <lname>HIST_CAM70%LT%NORESM%GHGCAMoslo_CLM60%FATES-NCFB%NORESM_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
   </compset>
 
+  <compset>
+    <alias>NFHISTesmGhg</alias>
+    <lname>HIST_CAM70%LT%NORESM%GHGCAMoslo_CLM60%FATES-NCFB%NORESM_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV_SESP_BGC%BPRP</lname>
+  </compset>
+
   <!-- CAM7 2000 -->
 
   <compset>
@@ -92,6 +102,11 @@
   <compset>
     <alias>NF2000ghg</alias>
     <lname>2000_CAM70%LT%NORESM%GHGCAMoslo_CLM60%FATES-NCFB%NORESM_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
+  </compset>
+
+  <compset>
+    <alias>NF2000esmGhg</alias>
+    <lname>2000_CAM70%LT%NORESM%GHGCAMoslo_CLM60%FATES-NCFB%NORESM_CICE%PRES_DOCN%DOM_MOSART_DGLC%NOEVOLVE_SWAV_SESP_BGC%BPRP</lname>
   </compset>
 
   <!-- CAM7 AMIP-style experiments -->

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -101,7 +101,7 @@
     </machines>
     <options>
       <option name="wallclock">00:45:00</option>
-      <option name="comment">Test of 2 degree FATES NOCOMP without DEBUG</option>
+      <option name="comment">Test of 1850 case at 2 degree in emissions mode without DEBUG</option>
     </options>
   </test>
 
@@ -112,7 +112,19 @@
     </machines>
     <options>
       <option name="wallclock">00:45:00</option>
-      <option name="comment">Test of 2 degree FATES NOCOMP without DEBUG</option>
+      <option name="comment">Test of 2 degree with GHG chemistry without DEBUG</option>
+    </options>
+  </test>
+
+  <test compset="NF1850esmGhg" grid="ne16pg3_ne16pg3_mtn14" name="ERP_Ld3" testmods="cam/outfrq1d">
+    <machines>
+      <machine name="betzy"  compiler="intel" category="aux_cam_noresm"/>
+      <machine name="olivia" compiler="intel" category="aux_cam_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:45:00</option>
+      <option name="comment">Test of 2 degree with GHG chemistry in
+      emissions mode without DEBUG</option>
     </options>
   </test>
 
@@ -123,7 +135,7 @@
     </machines>
     <options>
       <option name="wallclock">00:30:00</option>
-      <option name="comment">Test of 1850 compset at 1 degree with MAM chemistry</option>
+      <option name="comment">Test of 1850 compset at 2 degrees with MAM chemistry</option>
     </options>
   </test>
 

--- a/src/physics/cam/cam_diagnostics.F90
+++ b/src/physics/cam/cam_diagnostics.F90
@@ -958,7 +958,7 @@ contains
 
     do m = 1, pcnst
       if (cnst_cam_outfld(m)) then
-        call outfld(cnst_name(m), state%q(1,1,m), pcols, lchnk)
+        call outfld(cnst_name(m), state%q(:ncol,:,m), ncol, lchnk)
       end if
     end do
 
@@ -1006,6 +1006,7 @@ contains
     !
     ! Quadratic height fiels Z3*Z3
     !
+    ftem(ncol+1:,:) = 0.0_r8
     ftem(:ncol,:) = z3(:ncol,:)*z3(:ncol,:)
     call outfld('ZZ      ',ftem,pcols,lchnk)
 
@@ -1281,7 +1282,7 @@ contains
 
     if (co2_transport()) then
       do m = 1,4
-        call outfld(trim(cnst_name(c_i(m)))//'_BOT', state%q(1,pver,c_i(m)), pcols, lchnk)
+        call outfld(trim(cnst_name(c_i(m)))//'_BOT', state%q(:ncol,pver,c_i(m)), ncol, lchnk)
       end do
     end if
 
@@ -1351,7 +1352,7 @@ contains
           end do
           ftem(:ncol,:) = state%q(:ncol,:,ixq)/ftem(:ncol,:)*100._r8
        end if
-       call outfld ('RELHUM  ',ftem    ,pcols   ,lchnk     )
+       call outfld ('RELHUM  ',ftem(:ncol,:)    ,ncol   ,lchnk     )
     end if
 
     if (hist_fld_active('RHW') .or. hist_fld_active('RHI') .or. hist_fld_active('RHCFMIP') ) then
@@ -1361,7 +1362,7 @@ contains
          call qsat_water (state%t(1:ncol,k), state%pmid(1:ncol,k), esl(1:ncol,k), ftem(1:ncol,k), ncol)
       end do
       ftem(:ncol,:) = state%q(:ncol,:,ixq)/ftem(:ncol,:)*100._r8
-      call outfld ('RHW  ',ftem    ,pcols   ,lchnk     )
+      call outfld ('RHW  ',ftem(:ncol,:)    ,ncol   ,lchnk     )
 
       ! Convert to RHI (ice)
       do k=1,pver
@@ -1403,7 +1404,7 @@ contains
     !
     ! Output Q at bottom level
     !
-    call outfld ('QBOT    ', state%q(1,pver,ixq),  pcols, lchnk)
+    call outfld ('QBOT    ', state%q(:ncol,pver,ixq),  ncol, lchnk)
 
     ! Total energy of the atmospheric column for atmospheric heat storage calculations
 
@@ -1451,7 +1452,7 @@ contains
       call outfld ('LatHeatTr', ftem3(:ncol)  ,ncol   ,lchnk    )
     end if
 
-    !! potential energy transport g*z*v*dp/g 
+    !! potential energy transport g*z*v*dp/g
     if (hist_fld_active('PotEnerTr')) then
       ftem(:ncol,:) = z3(:ncol,:)*state%v(:ncol,:)*state%pdel(:ncol,:)
       !! vertically integrate
@@ -2204,16 +2205,16 @@ contains
     call cnst_get_ind('CLDICE', ixcldice, abort=.false.)
 
     if ( cnst_cam_outfld(       1) ) then
-      call outfld (apcnst(       1), state%q(1,1,       1), pcols, lchnk)
+      call outfld (apcnst(       1), state%q(:ncol,:,       1), ncol, lchnk)
     end if
     if (ixcldliq > 0) then
       if (cnst_cam_outfld(ixcldliq)) then
-        call outfld (apcnst(ixcldliq), state%q(1,1,ixcldliq), pcols, lchnk)
+        call outfld (apcnst(ixcldliq), state%q(:ncol,:,ixcldliq), ncol, lchnk)
       end if
     end if
     if (ixcldice > 0) then
       if ( cnst_cam_outfld(ixcldice) ) then
-        call outfld (apcnst(ixcldice), state%q(1,1,ixcldice), pcols, lchnk)
+        call outfld (apcnst(ixcldice), state%q(:ncol,:,ixcldice), ncol, lchnk)
       end if
     end if
 
@@ -2221,18 +2222,18 @@ contains
 
     if ( cnst_cam_outfld(       1) ) then
       ftem3(:ncol,:pver) = (state%q(:ncol,:pver,       1) - qini     (:ncol,:pver) )*rtdt
-      call outfld (ptendnam(       1), ftem3, pcols, lchnk)
+      call outfld (ptendnam(       1), ftem3(:ncol,:pver), ncol, lchnk)
     end if
     if (ixcldliq > 0) then
       if (cnst_cam_outfld(ixcldliq) ) then
         ftem3(:ncol,:pver) = (state%q(:ncol,:pver,ixcldliq) - cldliqini(:ncol,:pver) )*rtdt
-        call outfld (ptendnam(ixcldliq), ftem3, pcols, lchnk)
+        call outfld (ptendnam(ixcldliq), ftem3(:ncol,:pver), ncol, lchnk)
       end if
     end if
     if (ixcldice > 0) then
       if ( cnst_cam_outfld(ixcldice) ) then
         ftem3(:ncol,:pver) = (state%q(:ncol,:pver,ixcldice) - cldiceini(:ncol,:pver) )*rtdt
-        call outfld (ptendnam(ixcldice), ftem3, pcols, lchnk)
+        call outfld (ptendnam(ixcldice), ftem3(:ncol,:pver), ncol, lchnk)
       end if
     end if
 
@@ -2314,25 +2315,27 @@ contains
     !
     integer :: ixcldice, ixcldliq ! constituent indices for cloud liquid and ice water.
     integer :: lchnk              ! chunk index
+    integer :: ncol               ! number of columns in chunk
     !
     !-----------------------------------------------------------------------
     !
     lchnk = state%lchnk
+    ncol  = state%ncol
 
     call cnst_get_ind('CLDLIQ', ixcldliq, abort=.false.)
     call cnst_get_ind('CLDICE', ixcldice, abort=.false.)
 
     if ( cnst_cam_outfld(       1) ) then
-      call outfld (bpcnst(       1), state%q(1,1,       1), pcols, lchnk)
+      call outfld (bpcnst(       1), state%q(:ncol,:,       1), ncol, lchnk)
     end if
     if (ixcldliq > 0) then
       if (cnst_cam_outfld(ixcldliq)) then
-        call outfld (bpcnst(ixcldliq), state%q(1,1,ixcldliq), pcols, lchnk)
+        call outfld (bpcnst(ixcldliq), state%q(:ncol,:,ixcldliq), ncol, lchnk)
       end if
     end if
     if (ixcldice > 0) then
       if (cnst_cam_outfld(ixcldice)) then
-        call outfld (bpcnst(ixcldice), state%q(1,1,ixcldice), pcols, lchnk)
+        call outfld (bpcnst(ixcldice), state%q(:ncol,:,ixcldice), ncol, lchnk)
       end if
     end if
 

--- a/src/physics/cam/cam_diagnostics.F90
+++ b/src/physics/cam/cam_diagnostics.F90
@@ -1006,7 +1006,7 @@ contains
     !
     ! Quadratic height fiels Z3*Z3
     !
-    ftem(ncol+1:,:) = 0.0_r8
+    ftem(ncol+1:,:) = 0.0_r8 ! Ensure ftem fully initialized
     ftem(:ncol,:) = z3(:ncol,:)*z3(:ncol,:)
     call outfld('ZZ      ',ftem,pcols,lchnk)
 

--- a/src/physics/cam/co2_cycle.F90
+++ b/src/physics/cam/co2_cycle.F90
@@ -136,6 +136,12 @@ contains
       c_qmin = (/ 1.e-20_r8, 1.e-20_r8, 1.e-20_r8, 1.e-20_r8 /)
 
       ! register any new CO2 constiuents as dry tracers, set indices
+      ! This logic prevents duplicate CO2 tracers from being created.
+      ! If a CO2 tracer already exists do not attempt register one and local_co2
+      !   is set to .false. so that other code below (addfld calls,
+      !   co2_implements_cnst) does not do anything with that consitituent.
+      ! local_co2 = .true. means that the CO2 constituent was created by
+      !   and is manged by this module.
       local_co2 = .false.
       do icnst = 1, ncnst
          call cnst_get_ind(c_names(icnst), c_i(icnst), abort=.false.)

--- a/src/physics/cam/co2_cycle.F90
+++ b/src/physics/cam/co2_cycle.F90
@@ -118,6 +118,7 @@ contains
 
       use physconst,      only: mwco2, cpair
       use constituents,   only: cnst_get_ind, cnst_add
+      use cam_abortutils, only: endrun
 
       ! Local variables
       real(r8), dimension(ncnst) :: &
@@ -135,14 +136,17 @@ contains
       c_qmin = (/ 1.e-20_r8, 1.e-20_r8, 1.e-20_r8, 1.e-20_r8 /)
 
       ! register any new CO2 constiuents as dry tracers, set indices
+      local_co2 = .false.
       do icnst = 1, ncnst
          call cnst_get_ind(c_names(icnst), c_i(icnst), abort=.false.)
          if (c_i(icnst) < 0) then
             call cnst_add(c_names(icnst), c_mw(icnst), c_cp(icnst), c_qmin(icnst), &
                  c_i(icnst), longname=c_names(icnst), mixtype='dry')
-            local_co2 = .true.
-         else
-            local_co2 = .false.
+            if (trim(c_names(icnst)) == 'CO2') then
+               local_co2 = .true.
+            end if
+         else if (trim(c_names(icnst)) /= 'CO2') then
+            call endrun('co2_register: '//trim(c_names(icnst))//' already defined')
          end if
          select case (trim(c_names(icnst)))
          case ('CO2_FFF')

--- a/src/physics/cam/co2_cycle.F90
+++ b/src/physics/cam/co2_cycle.F90
@@ -1,6 +1,6 @@
 module co2_cycle
 
-   !-------------------------------------------------------------------------------
+   !----------------------------------------------------------------------------
    !
    ! Purpose:
    ! Provides distributions of CO2_LND, CO2_OCN, CO2_FF, CO2
@@ -10,7 +10,7 @@ module co2_cycle
    ! Author: Jeff Lee, Keith Lindsay
    !         Mariana Vertenstein, Refactored for NUOPC Stream functionality
    !
-   !-------------------------------------------------------------------------------
+   !----------------------------------------------------------------------------
 
    use shr_kind_mod,  only: r8=>shr_kind_r8
 
@@ -18,13 +18,13 @@ module co2_cycle
    private
 
    ! Public interfaces
-   public co2_cycle_readnl              ! read the namelist
-   public co2_register                  ! register consituents
-   public co2_transport                 ! turn on co2 tracers transport
-   public co2_implements_cnst           ! returns true if consituent is implemented by this package
-   public co2_init_cnst                 ! initialize mixing ratios if not read from initial file
-   public co2_init                      ! initialize (history) variables
-   public co2_cycle_set_ptend           ! set tendency from aircraft emissions
+   public co2_cycle_readnl    ! read the namelist
+   public co2_register        ! register consituents
+   public co2_transport       ! turn on co2 tracers transport
+   public co2_implements_cnst ! returns true if consituent is implemented by this package
+   public co2_init_cnst       ! initialize mixing ratios if not read from initial file
+   public co2_init            ! initialize (history) variables
+   public co2_cycle_set_ptend ! set tendency from aircraft emissions
 
    ! Namelist variables
    logical                    :: co2_flag              = .false. ! true => turn on co2 code, namelist variable
@@ -44,10 +44,11 @@ module co2_cycle
    integer :: co2_fff_glo_ind = -1 ! global index of 'CO2_FFF'
    integer :: co2_glo_ind = -1     ! global index of 'CO2'
    integer :: idx_ac_CO2 = -1      ! pbuf index of aircraft CO2 field
+   logical :: local_co2 = .false.  ! .true. if CO2 const. added in this module
 
-!===============================================================================
+!==============================================================================
 contains
-!===============================================================================
+!==============================================================================
 
    subroutine co2_cycle_readnl(nlfile)
 
@@ -74,7 +75,7 @@ contains
            co2_flag,                &
            co2_readFlux_aircraft,   & ! if true, read aircraft data
            co2_readFlux_fuel          ! if true, read fuel data
-      !----------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       if (masterproc) then
          open( newunit=unitn, file=trim(nlfile), status='old' )
@@ -107,16 +108,16 @@ contains
 
    end subroutine co2_cycle_readnl
 
-   !===============================================================================
+   !============================================================================
 
    subroutine co2_register
 
-      !-------------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
       ! Purpose: register advected constituents
-      !-------------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       use physconst,      only: mwco2, cpair
-      use constituents,   only: cnst_add
+      use constituents,   only: cnst_get_ind, cnst_add
 
       ! Local variables
       real(r8), dimension(ncnst) :: &
@@ -125,7 +126,7 @@ contains
            c_qmin    ! minimum mmr
 
       integer  :: icnst
-      !----------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       if (.not. co2_flag) return
 
@@ -133,12 +134,16 @@ contains
       c_cp   = (/     cpair,     cpair,     cpair,     cpair /)
       c_qmin = (/ 1.e-20_r8, 1.e-20_r8, 1.e-20_r8, 1.e-20_r8 /)
 
-      ! register CO2 constiuents as dry tracers, set indices
-
+      ! register any new CO2 constiuents as dry tracers, set indices
       do icnst = 1, ncnst
-         call cnst_add(c_names(icnst), c_mw(icnst), c_cp(icnst), c_qmin(icnst), c_i(icnst), &
-              longname=c_names(icnst), mixtype='dry')
-
+         call cnst_get_ind(c_names(icnst), c_i(icnst), abort=.false.)
+         if (c_i(icnst) < 0) then
+            call cnst_add(c_names(icnst), c_mw(icnst), c_cp(icnst), c_qmin(icnst), &
+                 c_i(icnst), longname=c_names(icnst), mixtype='dry')
+            local_co2 = .true.
+         else
+            local_co2 = .false.
+         end if
          select case (trim(c_names(icnst)))
          case ('CO2_FFF')
             co2_fff_glo_ind = c_i(icnst)
@@ -149,34 +154,35 @@ contains
 
    end subroutine co2_register
 
-   !===============================================================================
+   !============================================================================
 
    logical function co2_transport()
 
-      !-------------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
       ! Purpose: return true if this package is active
-      !-------------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
-      !----------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       co2_transport = co2_flag
 
    end function co2_transport
 
-   !===============================================================================
+   !============================================================================
 
    logical function co2_implements_cnst(name)
 
-      !-------------------------------------------------------------------------------
-      ! Purpose: return true if specified constituent is implemented by this package
-      !-------------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
+      ! Purpose: return true if specified constituent is
+      !           implemented by this package
+      !-------------------------------------------------------------------------
 
       ! Arguments
       character(len=*), intent(in) :: name  ! constituent name
 
       ! Local variables
       integer :: mind
-      !----------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       co2_implements_cnst = .false.
 
@@ -184,23 +190,25 @@ contains
 
       do mind = 1, ncnst
          if (name == c_names(mind)) then
-            co2_implements_cnst = .true.
+            if ((trim(name) /= 'CO2') .or. local_co2) then
+               co2_implements_cnst = .true.
+            end if
             return
          end if
       end do
 
    end function co2_implements_cnst
 
-   !===============================================================================
+   !============================================================================
 
    subroutine co2_init_cnst(name, latvals, lonvals, mask, q)
 
-      !-------------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
       ! Purpose:
       ! Set initial values of CO2_OCN, CO2_FFF, CO2_LND, CO2
       ! Need to be called from process_inidat in inidat.F90
       ! (or, initialize co2 in co2_timestep_init)
-      !-------------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       use chem_surfvals,  only: chem_surfvals_get
 
@@ -213,7 +221,7 @@ contains
 
       ! Local variables
       integer :: kindx
-      !----------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       if (.not. co2_flag) return
 
@@ -240,15 +248,15 @@ contains
 
    end subroutine co2_init_cnst
 
-   !===============================================================================
+   !============================================================================
 
    subroutine co2_init
 
-      !-------------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
       ! Purpose: initialize co2,
       !          declare history variables,
       !          read co2 flux form fuel, as data_flux_fuel
-      !-------------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       use cam_history,    only: addfld, add_default, horiz_only
       use constituents,   only: cnst_name, cnst_longname, sflxnam
@@ -256,7 +264,7 @@ contains
 
       ! Local variables
       integer :: m, mm
-      !----------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       if (.not. co2_flag) return
 
@@ -265,8 +273,10 @@ contains
          mm = c_i(m)
 
          call addfld(trim(cnst_name(mm))//'_BOT', horiz_only,  'A', 'kg/kg',   trim(cnst_longname(mm))//', Bottom Layer')
-         call addfld(cnst_name(mm),               (/ 'lev' /), 'A', 'kg/kg',   cnst_longname(mm))
-         call addfld(sflxnam(mm),                 horiz_only,  'A', 'kg/m2/s', trim(cnst_name(mm))//' surface flux')
+         if (co2_implements_cnst(cnst_name(mm))) then
+            call addfld(cnst_name(mm),            (/ 'lev' /), 'A', 'kg/kg',   cnst_longname(mm))
+            call addfld(sflxnam(mm),              horiz_only,  'A', 'kg/m2/s', trim(cnst_name(mm))//' surface flux')
+         end if
 
          call add_default(cnst_name(mm), 1, ' ')
          call add_default(sflxnam(mm),   1, ' ')
@@ -282,13 +292,13 @@ contains
 
    end subroutine co2_init
 
-   !===============================================================================
+   !============================================================================
    subroutine co2_cycle_set_ptend(state, pbuf, ptend)
 
-      !-------------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
       ! Purpose:
       ! Set ptend, using aircraft CO2 emissions in ac_CO2 from pbuf
-      !-------------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       use physics_types,  only: physics_state, physics_ptend, physics_ptend_init
       use physics_buffer, only: physics_buffer_desc, pbuf_get_field


### PR DESCRIPTION
Summary: Introduce change from NorESM2.3 to defer to chemistry when it has an active CO2 specie

Contributors: @gold2718 

Reviewers: @mvertens 

Purpose of changes: co2_cycle (for emission runs) creates a second CO2 tracer when chemistry when it has an active CO2 specie

Github PR URL: https://github.com/NorESMhub/CAM/pull/284

Changes made to build system: Adjust `pcnst` when both co2_cycle and a GHG chemistry are active

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Details:
- Only create one total CO2 tracer when a CO2 chemistry is running and co2_cycle is on
- When sharing total CO2 between co2_cycle and chemistry, do not create duplicate CO2 diagnostic fields
- Create NFxxxxesmGhg esm compsets (so that co2_cycle is turned on)
- Add test for an esm compset running ghg_mam_oslo chemistry

Testing:
- aux_cam_noresm on Olivia: All pass except for missing baseline for new test
- aux_cam_noresm on Betzy: All pass except for missing baseline for new test
