### PR TITLE
noresm3_0_039_cam6_4_121: Adjust namelist defaults for N(F)1850 experiments

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -3290,7 +3290,7 @@ $nl->set_variable_value('phys_ctl_nl', 'use_simple_phys', $use_simple_phys);
 
 #Cam-Oslo options
 add_default($nl, 'use_aerocom', 'ver'=>$aer_model);
-add_default($nl, 'rh_fine_aer_scale_fact_optics');
+add_default($nl, 'rh_fine_aer_scale_fact_optics', 'ver'=>$aer_model);
 add_default($nl, 'volc_fraction_coarse');
 add_default($nl, 'aerotab_table_dir');
 add_default($nl, 'ocean_filepath');

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -4119,20 +4119,22 @@
 </rad_climate>
 
 <!-- CAM-Oslo variables -->
-<use_aerocom>.false.</use_aerocom>
-<use_aerocom ver="oslo">.false.</use_aerocom>
-<rh_fine_aer_scale_fact_optics>1.0</rh_fine_aer_scale_fact_optics>
-<dme_energy_adjust>.true.</dme_energy_adjust>
-<volc_fraction_coarse   >0.0</volc_fraction_coarse>
-<aerotab_table_dir>noresm-only/atm/cam/camoslo/AeroTab_8jun17/</aerotab_table_dir>
-<dms_source>lana</dms_source>
-<dms_source_type>CYCLICAL</dms_source_type>
-<dms_cycle_year>2000</dms_cycle_year>
-<opom_source>odowd</opom_source>
-<opom_source_type>CYCLICAL</opom_source_type>
-<opom_cycle_year>2000</opom_cycle_year>
-<ocean_filename>Lana_ocean_1849_2006.nc</ocean_filename>
-<ocean_filepath>noresm-only/atm/cam/camoslo</ocean_filepath>
+<use_aerocom                              > .false.                     </use_aerocom>
+<use_aerocom                   ver="oslo" > .false.                     </use_aerocom>
+<rh_fine_aer_scale_fact_optics            > 1.0                         </rh_fine_aer_scale_fact_optics>
+<rh_fine_aer_scale_fact_optics ver="oslo" > 1.1                         </rh_fine_aer_scale_fact_optics>
+<dme_energy_adjust                        > .true.                      </dme_energy_adjust>
+<volc_fraction_coarse                     > 0.0                         </volc_fraction_coarse>
+<dms_source                               > lana                        </dms_source>
+<dms_source_type                          > CYCLICAL                    </dms_source_type>
+<dms_cycle_year                           > 2000                        </dms_cycle_year>
+<opom_source                              > odowd                       </opom_source>
+<opom_source_type                         > CYCLICAL                    </opom_source_type>
+<opom_cycle_year                          > 2000                        </opom_cycle_year>
+<ocean_filename                           > Lana_ocean_1849_2006.nc     </ocean_filename>
+<ocean_filepath                           > noresm-only/atm/cam/camoslo </ocean_filepath>
+
+<aerotab_table_dir                        > noresm-only/atm/cam/camoslo/AeroTab_8jun17/ </aerotab_table_dir>
 
 <!-- sub-column switches for physics packages -->
 <use_subcol_microp                  >.false.</use_subcol_microp>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2116,6 +2116,8 @@
 <clubb_C7b                                        > 0.5     </clubb_C7b>
 <clubb_C8                                         > 4.2     </clubb_C8>
 <clubb_C8 phys="cam7"                             > 4.2     </clubb_C8>
+<clubb_C8 phys="cam7" hgrid="ne16np4"  npg="3"    > 4.95    </clubb_C8>
+<clubb_C8 phys="cam7" hgrid="ne30np4"  npg="3"    > 4.70    </clubb_C8>
 <clubb_C8b                                        > 0.0     </clubb_C8b>
 <clubb_C_invrs_tau_bkgnd                          > 1.0     </clubb_C_invrs_tau_bkgnd>
 <clubb_C_invrs_tau_sfc                            > 0.1     </clubb_C_invrs_tau_sfc>
@@ -2307,6 +2309,8 @@
 
 <micro_mg_berg_eff_factor                  >  1.D0    </micro_mg_berg_eff_factor>
 <micro_mg_berg_eff_factor microphys="mg2"  >  1.D0    </micro_mg_berg_eff_factor>
+<micro_mg_berg_eff_factor microphys="mg3" hgrid="ne16np4" npg="3" >  1.00D0 </micro_mg_berg_eff_factor>
+<micro_mg_berg_eff_factor microphys="mg3" hgrid="ne30np4" npg="3" >  0.50D0 </micro_mg_berg_eff_factor>
 
 <micro_mg_accre_enhan_fact                  >  1.D0    </micro_mg_accre_enhan_fact>
 <micro_mg_accre_enhan_fact microphys="mg2"  >  1.D0    </micro_mg_accre_enhan_fact>
@@ -2317,8 +2321,10 @@
 <micro_mg_autocon_nd_exp                  >  -1.1D0    </micro_mg_autocon_nd_exp>
 <micro_mg_autocon_nd_exp microphys="mg2"  >  -1.1D0    </micro_mg_autocon_nd_exp>
 
-<micro_mg_autocon_lwp_exp                  >  2.47D0    </micro_mg_autocon_lwp_exp>
-<micro_mg_autocon_lwp_exp microphys="mg2"  >  2.47D0    </micro_mg_autocon_lwp_exp>
+<micro_mg_autocon_lwp_exp                                         > 2.47D0 </micro_mg_autocon_lwp_exp>
+<micro_mg_autocon_lwp_exp microphys="mg2"                         > 2.47D0 </micro_mg_autocon_lwp_exp>
+<micro_mg_autocon_lwp_exp microphys="mg3" hgrid="ne16np4" npg="3" > 2.47D0 </micro_mg_autocon_lwp_exp>
+<micro_mg_autocon_lwp_exp microphys="mg3" hgrid="ne30np4" npg="3" > 2.37D0 </micro_mg_autocon_lwp_exp>
 
 <microp_aero_bulk_scale                  >  2.D0    </microp_aero_bulk_scale>
 
@@ -2483,6 +2489,8 @@
 <dust_emis_fact dyn="fv"                   phys="cam5"   clubb_sgs="1"    >0.22D0</dust_emis_fact>
 <dust_emis_fact dyn="se"                   phys="cam6"                    >0.70D0</dust_emis_fact>
 <dust_emis_fact dyn="se"                   phys="cam7"                    >6.10D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne16np4"    phys="cam7" npg="3"           >3.30D0</dust_emis_fact>
+<dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam7"  npg="3"           >3.30D0</dust_emis_fact>
 <dust_emis_fact dyn="mpas"                 phys="cam7"                    >2.30D0</dust_emis_fact>
 <dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam6"             chem="trop_strat_mam4_vbs">0.8D0</dust_emis_fact>
 <dust_emis_fact dyn="se" hgrid="ne30np4"   phys="cam7"             chem="trop_strat_mam4_vbs">2.30D0</dust_emis_fact>
@@ -2737,61 +2745,67 @@
 <zmconv_momcd  clubb_sgs="1" microphys="mg2"                          > 0.7000D0 </zmconv_momcd>
 <zmconv_momcd  clubb_sgs="1" microphys="mg3"                          > 0.7000D0 </zmconv_momcd>
 
-<zmconv_c0_lnd                                                        > 0.0030D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd                                    phys="cam5"         > 0.0059D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd                   hgrid="ne120np4" phys="cam5"         > 0.0035D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd                   hgrid="C384"     phys="cam5"         > 0.0035D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd  microphys="mg2"  clubb_sgs="1"    phys="cam5"         > 0.0075D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd  microphys="mg3"  clubb_sgs="1"    phys="cam5"         > 0.0075D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd                                    phys="cam6"         > 0.0059D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd                   hgrid="ne120np4" phys="cam6"         > 0.0035D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd                   hgrid="C384"     phys="cam6"         > 0.0035D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd  microphys="mg2"  clubb_sgs="1"    phys="cam6"         > 0.0075D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd  microphys="mg3"  clubb_sgs="1"    phys="cam6"         > 0.0075D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd                                    phys="cam7"         > 0.0059D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd                   hgrid="ne120np4" phys="cam7"         > 0.0035D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd                   hgrid="C384"     phys="cam7"         > 0.0035D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd  microphys="mg2"  clubb_sgs="1"    phys="cam7"         > 0.0075D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd  microphys="mg3"  clubb_sgs="1"    phys="cam7"         > 0.0075D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd  dyn="fv"                          phys="cam4"         > 0.0035D0 </zmconv_c0_lnd>
-<zmconv_c0_lnd  dyn="se"                          phys="cam4"         > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                                                       > 0.0030D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                                           phys="cam5" > 0.0059D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                   hgrid="ne120np4"        phys="cam5" > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                   hgrid="C384"            phys="cam5" > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg2"  clubb_sgs="1"           phys="cam5" > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg3"  clubb_sgs="1"           phys="cam5" > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                                           phys="cam6" > 0.0059D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                   hgrid="ne120np4"        phys="cam6" > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                   hgrid="C384"            phys="cam6" > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg2"  clubb_sgs="1"           phys="cam6" > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg3"  clubb_sgs="1"           phys="cam6" > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                                           phys="cam7" > 0.0059D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                   hgrid="ne120np4"        phys="cam7" > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd                   hgrid="C384"            phys="cam7" > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg2"  clubb_sgs="1"           phys="cam7" > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg3"  clubb_sgs="1"           phys="cam7" > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg3"  hgrid="ne16np4" npg="3" phys="cam7" > 0.0075D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  microphys="mg3"  hgrid="ne30np4" npg="3" phys="cam7" > 0.0150D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  dyn="fv"                                 phys="cam4" > 0.0035D0 </zmconv_c0_lnd>
+<zmconv_c0_lnd  dyn="se"                                 phys="cam4" > 0.0035D0 </zmconv_c0_lnd>
 
-<zmconv_c0_ocn                                                        > 0.0030D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn                                    phys="cam5"         > 0.0450D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn                   hgrid="ne120np4" phys="cam5"         > 0.0035D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn                   hgrid="C384"     phys="cam5"         > 0.0035D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn                                    phys="cam6"         > 0.0450D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn                   hgrid="ne120np4" phys="cam6"         > 0.0035D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn                   hgrid="C384"     phys="cam6"         > 0.0035D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn  microphys="mg2"  clubb_sgs="1"    phys="cam6"         > 0.0300D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn  microphys="mg3"  clubb_sgs="1"    phys="cam6"         > 0.0300D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn                                    phys="cam7"         > 0.0210D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn                   hgrid="ne120np4" phys="cam7"         > 0.0035D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn                   hgrid="C384"     phys="cam7"         > 0.0035D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn  microphys="mg2"  clubb_sgs="1"    phys="cam7"         > 0.0210D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn  microphys="mg3"  clubb_sgs="1"    phys="cam7"         > 0.0210D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn  dyn="fv"                          phys="cam4"         > 0.0035D0 </zmconv_c0_ocn>
-<zmconv_c0_ocn  dyn="se"                          phys="cam4"         > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                                                       > 0.0030D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                                           phys="cam5" > 0.0450D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                   hgrid="ne120np4"        phys="cam5" > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                   hgrid="C384"            phys="cam5" > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                                           phys="cam6" > 0.0450D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                   hgrid="ne120np4"        phys="cam6" > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                   hgrid="C384"            phys="cam6" > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  microphys="mg2"  clubb_sgs="1"           phys="cam6" > 0.0300D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  microphys="mg3"  clubb_sgs="1"           phys="cam6" > 0.0300D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                                           phys="cam7" > 0.0210D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                   hgrid="ne120np4"        phys="cam7" > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn                   hgrid="C384"            phys="cam7" > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  microphys="mg2"  clubb_sgs="1"           phys="cam7" > 0.0210D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  microphys="mg3"  clubb_sgs="1"           phys="cam7" > 0.0210D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  microphys="mg3"  hgrid="ne16np4" npg="3" phys="cam7" > 0.0050D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  microphys="mg3"  hgrid="ne30np4" npg="3" phys="cam7" > 0.0150D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  dyn="fv"                                 phys="cam4" > 0.0035D0 </zmconv_c0_ocn>
+<zmconv_c0_ocn  dyn="se"                                 phys="cam4" > 0.0035D0 </zmconv_c0_ocn>
 
-<zmconv_ke_lnd                                                        > 3.0E-6 </zmconv_ke_lnd>
-<zmconv_ke_lnd  clubb_sgs="1"  microphys="mg2"                        > 1.0E-5 </zmconv_ke_lnd>
-<zmconv_ke_lnd  clubb_sgs="1"  microphys="mg3"                        > 1.0E-5 </zmconv_ke_lnd>
+<zmconv_ke_lnd                                                       > 3.0E-6 </zmconv_ke_lnd>
+<zmconv_ke_lnd  clubb_sgs="1"  microphys="mg2"                       > 1.0E-5 </zmconv_ke_lnd>
+<zmconv_ke_lnd  clubb_sgs="1"  microphys="mg3"                       > 1.0E-5 </zmconv_ke_lnd>
 
-<zmconv_ke                                                            > 3.0E-6 </zmconv_ke>
-<zmconv_ke      dyn="fv"                                              > 5.0E-6 </zmconv_ke>
-<zmconv_ke      dyn="se"                                              > 5.0E-6 </zmconv_ke>
+<zmconv_ke                                                           > 3.0E-6 </zmconv_ke>
+<zmconv_ke      dyn="fv"                                             > 5.0E-6 </zmconv_ke>
+<zmconv_ke      dyn="se"                                             > 5.0E-6 </zmconv_ke>
 
-<zmconv_num_cin                                                       > 5       </zmconv_num_cin>
-<zmconv_num_cin                                       phys="cam6"     > 1       </zmconv_num_cin>
-<zmconv_num_cin                                       phys="cam7"     > 1       </zmconv_num_cin>
+<zmconv_num_cin                                                      > 5       </zmconv_num_cin>
+<zmconv_num_cin                                          phys="cam6" > 1       </zmconv_num_cin>
+<zmconv_num_cin                                          phys="cam7" > 1       </zmconv_num_cin>
 
-<zmconv_dmpdz                                                         > -1.0E-3 </zmconv_dmpdz>
-<zmconv_tiedke_add                                                    > 0.7     </zmconv_tiedke_add>
-<zmconv_capelmt                                                       > 70.0    </zmconv_capelmt>
-<zmconv_tau                                                           > 3600.0    </zmconv_tau>
+<zmconv_dmpdz                                                        > -1.0E-3 </zmconv_dmpdz>
+<zmconv_tiedke_add                                                   > 0.7     </zmconv_tiedke_add>
+<zmconv_tiedke_add hgrid="ne16np4"  npg="3"                          > 0.9     </zmconv_tiedke_add>
+<zmconv_tiedke_add hgrid="ne30np4"  npg="3"                          > 1.2     </zmconv_tiedke_add>
+<zmconv_capelmt                                                      > 70.0    </zmconv_capelmt>
+<zmconv_tau                                                          > 3600.0    </zmconv_tau>
 
-<zmconv_parcel_pbl                                                    > .false. </zmconv_parcel_pbl>
-<zmconv_parcel_hscale                                                 >  0.5    </zmconv_parcel_hscale>
+<zmconv_parcel_pbl                                                   > .false. </zmconv_parcel_pbl>
+<zmconv_parcel_hscale                                                >  0.5    </zmconv_parcel_hscale>
 
 <!-- CAMNOR thermo begin -->
 <zmconv_tiedke_lnd             > 1.0     </zmconv_tiedke_lnd>
@@ -4106,7 +4120,7 @@
 
 <!-- CAM-Oslo variables -->
 <use_aerocom>.false.</use_aerocom>
-<use_aerocom ver="oslo">.true.</use_aerocom>
+<use_aerocom ver="oslo">.false.</use_aerocom>
 <rh_fine_aer_scale_fact_optics>1.0</rh_fine_aer_scale_fact_optics>
 <dme_energy_adjust>.true.</dme_energy_adjust>
 <volc_fraction_coarse   >0.0</volc_fraction_coarse>


### PR DESCRIPTION
Summary: Adjust namelist default values for N(F)1850 experiments based on recent tuning experiments

Contributors: @oyvindseland, @DirkOlivie 

Reviewers: @oyvindseland, @DirkOlivie 

Purpose of changes: Interim update of namelist defaults, #283 

Github PR URL: https://github.com/NorESMhub/CAM/pull/285

Changes made to build system: None

Changes made to the namelist: New default 1 and 2 degree defaults for:
- clubb_c8
- micro_mg_berg_eff_factor
- micro_mg_autocon_lwp_exp
- dust_emis_fact
- zmconv_c0_lnd
- zmconv_c0_ocn
- zmconv_tiedke_add
- use_aerocom

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Details: See namelist changes above

Testing:
- aux_cam_noresm on Olivia: All PASS (expected namelist changes introduced in this PR)
- aux_cam_noresm on Betzy:  All PASS (expected namelist changes introduced in this PR)

addresses #283 