### PR TITLE
noresm3_0_043_cam6_4_121: Changes to start date and ozone forcing

### DIFF
--- a/bld/namelist_files/use_cases/hist_camnor_lt_osloaero.xml
+++ b/bld/namelist_files/use_cases/hist_camnor_lt_osloaero.xml
@@ -16,7 +16,10 @@
 
 <!-- ozone data -->
 <prescribed_ozone_datapath> 'atm/cam/ozone_strataero'                                                                                             </prescribed_ozone_datapath>
+<!-- starts at 6. January instead of 1. January
 <prescribed_ozone_file    > 'ozone_strataero_b.e30_alpha08o.BHISTC_MTt4s.ne30_t232_wgx3.330_branch_1850_1850_2021_transient_zm_5day_c20260625.nc' </prescribed_ozone_file>
+    -->
+<prescribed_ozone_file    > 'ozone_strataero_b.e30_alpha08o.BHISTC_MTt4s.ne30_t232_wgx3.330_branch_1850_1850_2021_transient_zm_5day_c20260722.nc' </prescribed_ozone_file>
 <prescribed_ozone_name    > 'O3'                                                                                                                  </prescribed_ozone_name>
 <prescribed_ozone_type    > SERIAL                                                                                                                </prescribed_ozone_type>
 

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -29,11 +29,11 @@
     ALL data models must have a %phys option that corresponds to the data  model mode
 
     Each compset node is associated with the following elements
-      - lname
-      - alias
-      - support  (optional description of the support level for this compset)
+    - lname
+    - alias
+    - support  (optional description of the support level for this compset)
     Each compset node can also have the following attributes
-      - grid  (optional regular expression match for grid to work with the compset)
+    - grid  (optional regular expression match for grid to work with the compset)
   </help>
 
   <!-- NOTE: the NorESM physics does not work with cam60 - so must use
@@ -189,7 +189,7 @@
   </compset>
 
   <compset>
-      <alias>FSCAMCGILSS12</alias>
+    <alias>FSCAMCGILSS12</alias>
     <lname>2000_CAM60%SCAMCGILSS12_CLM50%SP_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>
 
@@ -384,30 +384,11 @@
   <entries>
     <entry id="RUN_STARTDATE">
       <values match="last">
-	<value  compset="HIST(C_|E_|_)CAM">1979-01-01</value>
-	<value  compset="HIST_CAM60%WCTS_CLM50%BGC-CROP">1950-01-01</value>
-        <value  compset="HIST_CAM40%WX">2000-01-01</value>
-	<value  compset="HIST_CAM60%WCMD">2005-01-01</value>
-	<value  compset="HIST_CAM60%WCMD%SDYN" grid="a%1.9x2.5">1980-01-01</value>
-	<value  compset="HIST_CAM60%WCSC">1850-01-01</value>
-	<value  compset="HIST_CAM60%CT[12]S">2010-01-01</value>
-	<value  compset="HIST_CAM60%GEOSCHEM">2015-01-01</value>
-	<value  compset="HIST_CAM60%CT[12]S" grid="a%ne0np4CONUS">2013-01-01</value>
-	<value  compset="HIST_CAM60%CVBSX">1995-01-01</value>
-	<value  compset="HIST_CAM60%CFIRE">1995-01-01</value>
-	<value  compset="RCP[2468]_CAM\d+">2005-01-01</value>
- 	<value  compset="_CAM.*%NUDG"                   >2010-01-01</value>
- 	<value  compset="CAM60%CARMA.*%NUDG"            >1990-01-01</value>
- 	<value  compset="_CAM.*%SDYN"                   >2005-01-01</value>
- 	<value  compset="_CAM.*%SDYN" grid="a%0.47x0.63">2010-01-01</value>
-	<value  compset="_CAM60%(CARMA|WCCM|WCTS|WXIE).*%SDYN">1980-01-01</value>
-	<value  compset="_CAM60%(WCCM|WCTS|WXIE).*%SDYN">1980-01-01</value>
- 	<value  compset="_CAM40%WX.*%SDYN">2000-01-01</value>
-        <value  compset="2000_CAM60%GEOSCHEM">2000-01-01</value>
-        <value  compset="2010_CAM60%GEOSCHEM">2010-01-01</value>
+        <value  compset="HIST_CAM">1850-01-01</value>
+        <value  compset="AMIP_CAM">1979-01-01</value>
+        <value  compset="1850_CAM">0001-01-01</value>
+        <value  compset="2000_CAM">0001-01-01</value>
 
-	<value  compset="C2R4_CAM">2004-01-01</value>
-	<value  compset="C2R[68]_CAM">1950-01-01</value>
         <value  compset="CAM.*%SCAMARM95">1995-07-18</value>
         <value  compset="CAM.*%SCAMARM97">1997-06-18</value>
         <value  compset="CAM.*%SCAMATEX">1969-02-15</value>
@@ -481,10 +462,10 @@
 	<value  compset="%SDYN">GREGORIAN</value>
 	<value  compset="%NUDG">GREGORIAN</value>
  	<value  compset="HIST_CAM\d0%WX">GREGORIAN</value>
-     </values>
+      </values>
     </entry>
 
-  <!-- single column compset must have pts_mode set to true -->
+    <!-- single column compset must have pts_mode set to true -->
 
     <entry id="PTS_MODE">
       <values match="first">


### PR DESCRIPTION
Summary: Patch for bad ozone forcing file and NFHIST start date adjustment

Contributors: @gold2718, @mvertens 

Reviewers: @mvertens 

Purpose of changes: #298 

Github PR URL: https://github.com/NorESMhub/CAM/pull/299

Changes made to build system: None

Changes made to the namelist: None

Changes to the defaults for the boundary datasets: None

Substantial timing or memory changes: None

Details:
- Change start date for NFHIST compsets to match NHIST (1850)
- Add correct start dates for NF1850, NF2000, and NFAMIP compsets
- Use a (temporary?) patched prescribed ozone file for HIST compsets

Testing:
- aux_cam_noresm on Olivia: All PASS except for expected baseline differences in NFHIST caused by date change.
- prealpha_noresm on Olivia: All PASS

fixes #298 