### PR TITLE
noresm3_0_044_cam6_4_121: new nearest_lat mapalgo in cdeps - does not requre a mesh

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -717,13 +717,18 @@ if (!($simple_phys or $aqua_mode)) {
     add_default($nl, 'co2_surface_source');
     if ($nl->get_value('co2_surface_source') =~ /$TRUE/io) {
         if ( !(defined $nl->get_value('stream_co2_surface_source_mesh_filename') and
-               defined $nl->get_value('stream_co2_surface_source_data_filename') and
+	       defined $nl->get_value('stream_co2_surface_source_data_filename') and
                defined $nl->get_value('stream_co2_surface_source_data_varname') and
                defined $nl->get_value('stream_co2_surface_source_year_first') and
                defined $nl->get_value('stream_co2_surface_source_year_last') and
                defined $nl->get_value('stream_co2_surface_source_year_align') and
+               defined $nl->get_value('stream_co2_surface_source_year_align') and
+               defined $nl->get_value('stream_co2_surface_source_mapalgo') and
+               defined $nl->get_value('stream_co2_surface_source_lat_dimname') and
                defined $nl->get_value('stream_co2_surface_source_taxmode') ) ) {
              die "$ProgName - ERROR: if co2_surface_source is .true. then the following must be defined:
+             stream_co2_surface_source_mapalgo,
+             stream_co2_surface_source_lat_dimname,
              stream_co2_surface_source_mesh_filename,
              stream_co2_surface_source_data_filename,
              stream_co2_surface_source_data_varname,
@@ -732,6 +737,11 @@ if (!($simple_phys or $aqua_mode)) {
              stream_co2_surface_source_year_last,
              stream_co2_surface_source_year_align\n";
         }
+	if (($nl->get_value('stream_co2_surface_source_mapalgo') eq 'nearest_lat') and
+	    ($nl->get_value('stream_co2_surface_source_mesh_filename') ne 'none')) {   
+             die "$ProgName - ERROR: if stream_co2_surface_source_mesh_filename must equal none if \n
+    	     	 stream_co2_surface_source_mapalgo is nearest_lat"
+	}
     }
 }
 

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -736,8 +736,9 @@ if (!($simple_phys or $aqua_mode)) {
              stream_co2_surface_source_year_last,
              stream_co2_surface_source_year_align\n";
         }
-	if (($nl->get_value('stream_co2_surface_source_mapalgo') eq 'nearest_lat') and
-	    ($nl->get_value('stream_co2_surface_source_mesh_filename') ne 'none')) {
+	my $mapalgo = $nl->get_value('stream_co2_surface_source_mapalgo');
+	my $mesh    = $nl->get_value('stream_co2_surface_source_mesh_filename');
+	if (($mapalgo eq 'nearest_lat') and ($mesh ne 'none')) {
 	    die "$ProgName - ERROR: stream_co2_surface_source_mesh_filename must be set to 'none' " .
 		"when stream_co2_surface_source_mapalgo is 'nearest_lat'\n";
 	}

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -722,7 +722,6 @@ if (!($simple_phys or $aqua_mode)) {
                defined $nl->get_value('stream_co2_surface_source_year_first') and
                defined $nl->get_value('stream_co2_surface_source_year_last') and
                defined $nl->get_value('stream_co2_surface_source_year_align') and
-               defined $nl->get_value('stream_co2_surface_source_year_align') and
                defined $nl->get_value('stream_co2_surface_source_mapalgo') and
                defined $nl->get_value('stream_co2_surface_source_lat_dimname') and
                defined $nl->get_value('stream_co2_surface_source_taxmode') ) ) {
@@ -738,9 +737,9 @@ if (!($simple_phys or $aqua_mode)) {
              stream_co2_surface_source_year_align\n";
         }
 	if (($nl->get_value('stream_co2_surface_source_mapalgo') eq 'nearest_lat') and
-	    ($nl->get_value('stream_co2_surface_source_mesh_filename') ne 'none')) {   
-             die "$ProgName - ERROR: if stream_co2_surface_source_mesh_filename must equal none if \n
-    	     	 stream_co2_surface_source_mapalgo is nearest_lat"
+	    ($nl->get_value('stream_co2_surface_source_mesh_filename') ne 'none')) {
+	    die "$ProgName - ERROR: stream_co2_surface_source_mesh_filename must be set to 'none' " .
+		"when stream_co2_surface_source_mapalgo is 'nearest_lat'\n";
 	}
     }
 }

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -741,6 +741,10 @@ if (!($simple_phys or $aqua_mode)) {
 	    die "$ProgName - ERROR: stream_co2_surface_source_mesh_filename must be set to 'none' " .
 		"when stream_co2_surface_source_mapalgo is 'nearest_lat'\n";
 	}
+	if (($mapalgo ne 'nearest_lat') and ($mesh eq 'none')) {
+	    die "$ProgName - ERROR: stream_co2_surface_source_mesh_filename must be a valid mesh file " .
+		"when stream_co2_surface_source_mapalgo is '$mapalgo'\n";
+	}
     }
 }
 

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -736,8 +736,11 @@ if (!($simple_phys or $aqua_mode)) {
              stream_co2_surface_source_year_last,
              stream_co2_surface_source_year_align\n";
         }
+	# get_value preserves the quotes from the namelist, so strip them before comparing
 	my $mapalgo = $nl->get_value('stream_co2_surface_source_mapalgo');
 	my $mesh    = $nl->get_value('stream_co2_surface_source_mesh_filename');
+	$mapalgo =~ s/^['"]+|['"]+$//g;
+	$mesh    =~ s/^['"]+|['"]+$//g;
 	if (($mapalgo eq 'nearest_lat') and ($mesh ne 'none')) {
 	    die "$ProgName - ERROR: stream_co2_surface_source_mesh_filename must be set to 'none' " .
 		"when stream_co2_surface_source_mapalgo is 'nearest_lat'\n";

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2012,6 +2012,9 @@
 
 <!-- co2 surface source (overwrite co2_diag sent to land and ocean) -->
 <co2_surface_source>.false.</co2_surface_source>
+<co2_surface_source_mapalgo>nearest_lat</co2_surface_source_mapalgo>
+<co2_surface_source_mesh_filename>none</co2_surface_source_mesh_filename>
+<co2_surface_source_lat_dimname>lat</co2_surface_source_lat_dimname>
 
 <!-- nitrogen deposition to surface components -->
 <stream_ndep_varlist>NDEP_NHx_month:NDEP_NOy_month</stream_ndep_varlist>

--- a/bld/namelist_files/namelist_defaults_cam.xml
+++ b/bld/namelist_files/namelist_defaults_cam.xml
@@ -2012,9 +2012,6 @@
 
 <!-- co2 surface source (overwrite co2_diag sent to land and ocean) -->
 <co2_surface_source>.false.</co2_surface_source>
-<co2_surface_source_mapalgo>nearest_lat</co2_surface_source_mapalgo>
-<co2_surface_source_mesh_filename>none</co2_surface_source_mesh_filename>
-<co2_surface_source_lat_dimname>lat</co2_surface_source_lat_dimname>
 
 <!-- nitrogen deposition to surface components -->
 <stream_ndep_varlist>NDEP_NHx_month:NDEP_NOy_month</stream_ndep_varlist>

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -10297,10 +10297,22 @@ Default: path
   If TRUE, set co2_diag sent to land and ocean to value read from co2_surface_source_data_filename
   Default: FALSE
 </entry>
+<entry id="co2_surface_source_mapalgo" type="char*256" category="CO2 surface source"
+       group="co2_surface_source_stream_nl" valid_values="nearest_lat,bilinear,consf" >
+  Mapping algorithm to map co2 data to model grid. Nearest lat assumes
+  that a mesh file is not needed and that the forcing data is lat/time or lat/lev/time.
+  In this case the mesh is set to none.
+  Default: nearest_lat
+</entry>
+<entry id="stream_co2_surface_source_lat_dimname" type="char*256" input_pathname="abs" category="CO2 surface source"
+       group="co2_surface_source_stream_nl" valid_values="" >
+  Latitude dimension name on stream_co2_surface_source_data_filename. Only used if co2_surface_source_mapalgo is 'nearest_lat'
+  Default: lat
+</entry>
 <entry id="stream_co2_surface_source_mesh_filename" type="char*256" input_pathname="abs" category="CO2 surface source"
        group="co2_surface_source_stream_nl" valid_values="" >
-  Grid mesh file corresponding to stream_co2_surface_source_data_filename.
-  Must be set by user.
+  Grid mesh file corresponding to stream_co2_surface_source_data_filename. 
+  Default: none
 </entry>
 <entry id="stream_co2_surface_source_data_filename" type="char*256" input_pathname="abs" category="CO2 surface source"
        group="co2_surface_source_stream_nl" valid_values="" >

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -10297,22 +10297,24 @@ Default: path
   If TRUE, set co2_diag sent to land and ocean to value read from co2_surface_source_data_filename
   Default: FALSE
 </entry>
-<entry id="co2_surface_source_mapalgo" type="char*256" category="CO2 surface source"
+<entry id="stream_co2_surface_source_mapalgo" type="char*256" category="CO2 surface source"
        group="co2_surface_source_stream_nl" valid_values="nearest_lat,bilinear,consf" >
   Mapping algorithm to map co2 data to model grid. Nearest lat assumes
   that a mesh file is not needed and that the forcing data is lat/time or lat/lev/time.
   In this case the mesh is set to none.
   Default: nearest_lat
 </entry>
-<entry id="stream_co2_surface_source_lat_dimname" type="char*256" input_pathname="abs" category="CO2 surface source"
+<entry id="stream_co2_surface_source_lat_dimname" type="char*256" category="CO2 surface source"
        group="co2_surface_source_stream_nl" valid_values="" >
-  Latitude dimension name on stream_co2_surface_source_data_filename. Only used if co2_surface_source_mapalgo is 'nearest_lat'
-  Default: lat
+  Latitude dimension name on stream_co2_surface_source_data_filename.
+  Only used if stream_co2_surface_source_mapalgo is 'nearest_lat'
+  Default: Must be set by user
 </entry>
 <entry id="stream_co2_surface_source_mesh_filename" type="char*256" input_pathname="abs" category="CO2 surface source"
        group="co2_surface_source_stream_nl" valid_values="" >
-  Grid mesh file corresponding to stream_co2_surface_source_data_filename. 
-  Default: none
+  Grid mesh file corresponding to stream_co2_surface_source_data_filename. If stream_co2_surface_source_map
+  If stream_co2_surface_source_mapalgo is 'nearest_lat' then this must be set to 'none'
+  Default: Must be set by user.
 </entry>
 <entry id="stream_co2_surface_source_data_filename" type="char*256" input_pathname="abs" category="CO2 surface source"
        group="co2_surface_source_stream_nl" valid_values="" >

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -10312,8 +10312,7 @@ Default: path
 </entry>
 <entry id="stream_co2_surface_source_mesh_filename" type="char*256" input_pathname="abs" category="CO2 surface source"
        group="co2_surface_source_stream_nl" valid_values="" >
-  Grid mesh file corresponding to stream_co2_surface_source_data_filename. If stream_co2_surface_source_map
-  If stream_co2_surface_source_mapalgo is 'nearest_lat' then this must be set to 'none'
+  Grid mesh file corresponding to stream_co2_surface_source_data_filename. If stream_co2_surface_source_mapalgo is 'nearest_lat' then this must be set to 'none'
   Default: Must be set by user.
 </entry>
 <entry id="stream_co2_surface_source_data_filename" type="char*256" input_pathname="abs" category="CO2 surface source"

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -10302,18 +10302,18 @@ Default: path
   Mapping algorithm to map co2 data to model grid. Nearest lat assumes
   that a mesh file is not needed and that the forcing data is lat/time or lat/lev/time.
   In this case the mesh is set to none.
-  Default: nearest_lat
+  Must be set by user 
 </entry>
 <entry id="stream_co2_surface_source_lat_dimname" type="char*256" category="CO2 surface source"
        group="co2_surface_source_stream_nl" valid_values="" >
   Latitude dimension name on stream_co2_surface_source_data_filename.
   Only used if stream_co2_surface_source_mapalgo is 'nearest_lat'
-  Default: Must be set by user
+  Must be set by user
 </entry>
 <entry id="stream_co2_surface_source_mesh_filename" type="char*256" input_pathname="abs" category="CO2 surface source"
        group="co2_surface_source_stream_nl" valid_values="" >
   Grid mesh file corresponding to stream_co2_surface_source_data_filename. If stream_co2_surface_source_mapalgo is 'nearest_lat' then this must be set to 'none'
-  Default: Must be set by user.
+  Must be set by user.
 </entry>
 <entry id="stream_co2_surface_source_data_filename" type="char*256" input_pathname="abs" category="CO2 surface source"
        group="co2_surface_source_stream_nl" valid_values="" >

--- a/bld/namelist_files/use_cases/1850_camnor_lt_ghgosloaero.xml
+++ b/bld/namelist_files/use_cases/1850_camnor_lt_ghgosloaero.xml
@@ -7,7 +7,7 @@
 <solar_data_type>    FIXED            </solar_data_type>
 
 <!-- LBC Files : -->
-<flbc_file>atm/waccm/lb/cmip7_ghg_version20260607/ghg_cmip7_CMIP_CR-CMIP-1-0-0_1850_monthly_gnz_0p5degLat_version20260207.nc</flbc_file>
+<flbc_file>atm/waccm/lb/cmip7_ghg_version20260727/ghg_cmip7_CMIP_CR-CMIP-1-0-0_1850_monthly_gnz_0p5degLat_version20260727.nc</flbc_file>
 <flbc_cycle_yr>1850</flbc_cycle_yr>
 <flbc_type>'CYCLICAL'</flbc_type>
 <flbc_list>'CO2','CH4','N2O','CFC11','CFC12','CFC11eq'</flbc_list>

--- a/bld/namelist_files/use_cases/1850_camnor_lt_osloaero.xml
+++ b/bld/namelist_files/use_cases/1850_camnor_lt_osloaero.xml
@@ -7,7 +7,7 @@
 <solar_data_type>    FIXED            </solar_data_type>
 
 <!-- LBC Files : -->
-<flbc_file>atm/waccm/lb/cmip7_ghg_version20260607/ghg_cmip7_CMIP_CR-CMIP-1-0-0_1850_monthly_gnz_0p5degLat_version20260207.nc</flbc_file>
+<flbc_file>atm/waccm/lb/cmip7_ghg_version20260727/ghg_cmip7_CMIP_CR-CMIP-1-0-0_1850_monthly_gnz_0p5degLat_version20260727.nc</flbc_file>
 <flbc_cycle_yr>1850</flbc_cycle_yr>
 <flbc_type>'CYCLICAL'</flbc_type>
 <flbc_list>'CO2','CH4','N2O','CFC11','CFC12','CFC11eq'</flbc_list>

--- a/bld/namelist_files/use_cases/1979-2022_camnor_lt_osloaero.xml
+++ b/bld/namelist_files/use_cases/1979-2022_camnor_lt_osloaero.xml
@@ -5,7 +5,7 @@
 <solar_irrad_data_file>atm/cam/solar/SolarForcingCMIP7-4.6_18491230-20240101_sumEPP_c20250630.nc</solar_irrad_data_file>
 
 <!-- LBC Files -->
-<flbc_file>atm/waccm/lb/cmip7_ghg_version20260607/ghg_cmip7_CMIP_CR-CMIP-1-0-0_1750-2023_monthly_gnz_0p5degLat_version20260207.nc</flbc_file>
+<flbc_file>atm/waccm/lb/cmip7_ghg_version20260727/ghg_cmip7_CMIP_CR-CMIP-1-0-0_1750-2023_monthly_gnz_0p5degLat_version20260727.nc</flbc_file>
 <flbc_type>'SERIAL'</flbc_type>
 <flbc_list>'CO2','CH4','N2O','CFC11','CFC12','CFC11eq'</flbc_list>
 

--- a/bld/namelist_files/use_cases/hist_camnor_lt_osloaero.xml
+++ b/bld/namelist_files/use_cases/hist_camnor_lt_osloaero.xml
@@ -5,7 +5,7 @@
 <solar_irrad_data_file>atm/cam/solar/SolarForcingCMIP7-4.6_18491230-20240101_sumEPP_c20250630.nc</solar_irrad_data_file>
 
 <!-- LBC Files -->
-<flbc_file>atm/waccm/lb/cmip7_ghg_version20260607/ghg_cmip7_CMIP_CR-CMIP-1-0-0_1750-2023_monthly_gnz_0p5degLat_version20260207.nc</flbc_file>
+<flbc_file>atm/waccm/lb/cmip7_ghg_version20260727/ghg_cmip7_CMIP_CR-CMIP-1-0-0_1750-2023_monthly_gnz_0p5degLat_version20260727.nc</flbc_file>
 <flbc_type>'SERIAL'</flbc_type>
 <flbc_list>'CO2','CH4','N2O','CFC11','CFC12','CFC11eq'</flbc_list>
 

--- a/src/cpl/nuopc/atm_stream_co2.F90
+++ b/src/cpl/nuopc/atm_stream_co2.F90
@@ -27,6 +27,8 @@ module atm_stream_co2
   type(shr_strdata_type) :: sdat_co2_surface_source     ! input data stream
 
   ! namelist variables
+  character(len=CL) :: stream_co2_surface_source_mapalgo
+  character(len=CL) :: stream_co2_surface_source_lat_dimname
   character(len=CL) :: stream_co2_surface_source_mesh_filename
   character(len=CL) :: stream_co2_surface_source_data_filename
   character(len=CL) :: stream_co2_surface_source_data_varname ! variable name for co2_surface_source on stream file(s)
@@ -72,6 +74,8 @@ contains
 
     ! Default values for namelist
     co2_surface_source = .false.
+    stream_co2_surface_source_mapalgo       = 'none'
+    stream_co2_surface_source_lat_dimname   = 'lat'
     stream_co2_surface_source_data_filename = ' '
     stream_co2_surface_source_mesh_filename = ' '
     stream_co2_surface_source_data_varname  = ' '
@@ -111,6 +115,12 @@ contains
     if (ierr /= 0) call endrun(trim(subname)//": FATAL: mpi_bcast: co2_surface_source")
 
     if (co2_surface_source) then
+       call mpi_bcast(stream_co2_surface_source_mapalgo, &
+            len(stream_co2_surface_source_mapalgo), mpi_character, masterprocid, mpicom, ierr)
+       if (ierr /= 0) call endrun(trim(subname)//": FATAL: mpi_bcast: stream_co2_surface_source_mapalgo")
+       call mpi_bcast(stream_co2_surface_source_lat_dimname, &
+            len(stream_co2_surface_source_lat_dimname), mpi_character, masterprocid, mpicom, ierr)
+       if (ierr /= 0) call endrun(trim(subname)//": FATAL: mpi_bcast: stream_co2_surface_source_lat_dimname")
        call mpi_bcast(stream_co2_surface_source_mesh_filename, &
             len(stream_co2_surface_source_mesh_filename), mpi_character, masterprocid, mpicom, ierr)
        if (ierr /= 0) call endrun(trim(subname)//": FATAL: mpi_bcast: stream_co2_surface_source_mesh_filename")
@@ -137,6 +147,10 @@ contains
        write(iulog,'(a)')  ' '
        if (co2_surface_source) then
           write(iulog,'(2a)')    subname,' co2 surface source override settings::'
+          write(iulog,'(3a)')    subname,'  stream_co2_surface_source_mapalgo       = ',&
+               trim(stream_co2_surface_source_mapalgo)
+          write(iulog,'(3a)')    subname,'  stream_co2_surface_source_lat_dimname   = ',&
+               trim(stream_co2_surface_source_lat_dimname)
           write(iulog,'(3a)')    subname,'  stream_co2_surface_source_data_filename = ',&
                trim(stream_co2_surface_source_data_filename)
           write(iulog,'(3a)')    subname,'  stream_co2_surface_source_mesh_filename = ',&
@@ -188,12 +202,13 @@ contains
             stream_fldlistFile  = (/stream_co2_surface_source_data_varname/),        &
             stream_fldListModel = (/stream_co2_surface_source_data_varname/),        &
             stream_lev_dimname  = 'null',                                            &
-            stream_mapalgo      = 'bilinear',                                        &
+            stream_mapalgo      = trim(stream_co2_surface_source_mapalgo),           &
             stream_offset       = 0,                                                 &
             stream_taxmode      = trim(stream_co2_surface_source_taxmode),           &
             stream_dtlimit      = 1.0e30_r8,                                         &
             stream_tintalgo     = 'linear',                                          &
             stream_name         = 'CO2_SURFACE_SOURCE data ',                        &
+            stream_lat_dimname  = trim(stream_co2_surface_source_lat_dimname),       & 
             rc                  = rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 

--- a/src/cpl/nuopc/atm_stream_co2.F90
+++ b/src/cpl/nuopc/atm_stream_co2.F90
@@ -27,8 +27,8 @@ module atm_stream_co2
   type(shr_strdata_type) :: sdat_co2_surface_source     ! input data stream
 
   ! namelist variables
-  character(len=CL) :: stream_co2_surface_source_mapalgo
-  character(len=CL) :: stream_co2_surface_source_lat_dimname
+  character(len=CS) :: stream_co2_surface_source_mapalgo
+  character(len=CS) :: stream_co2_surface_source_lat_dimname
   character(len=CL) :: stream_co2_surface_source_mesh_filename
   character(len=CL) :: stream_co2_surface_source_data_filename
   character(len=CL) :: stream_co2_surface_source_data_varname ! variable name for co2_surface_source on stream file(s)
@@ -64,6 +64,8 @@ contains
 
     namelist /co2_surface_source_stream_nl/       &
          co2_surface_source,                      &
+         stream_co2_surface_source_mapalgo,       &
+         stream_co2_surface_source_lat_dimname,   &
          stream_co2_surface_source_mesh_filename, &
          stream_co2_surface_source_data_filename, &
          stream_co2_surface_source_data_varname,  &
@@ -74,10 +76,10 @@ contains
 
     ! Default values for namelist
     co2_surface_source = .false.
-    stream_co2_surface_source_mapalgo       = 'none'
+    stream_co2_surface_source_mapalgo       = 'nearest_lat'
     stream_co2_surface_source_lat_dimname   = 'lat'
+    stream_co2_surface_source_mesh_filename = 'none'
     stream_co2_surface_source_data_filename = ' '
-    stream_co2_surface_source_mesh_filename = ' '
     stream_co2_surface_source_data_varname  = ' '
     stream_co2_surface_source_taxmode       = 'unset'
     stream_co2_surface_source_year_first    = -999 ! first year in stream to use

--- a/src/cpl/nuopc/atm_stream_co2.F90
+++ b/src/cpl/nuopc/atm_stream_co2.F90
@@ -76,11 +76,11 @@ contains
 
     ! Default values for namelist
     co2_surface_source = .false.
-    stream_co2_surface_source_mapalgo       = 'nearest_lat'
-    stream_co2_surface_source_lat_dimname   = 'lat'
-    stream_co2_surface_source_mesh_filename = 'none'
-    stream_co2_surface_source_data_filename = ' '
-    stream_co2_surface_source_data_varname  = ' '
+    stream_co2_surface_source_mapalgo       = 'unset'
+    stream_co2_surface_source_lat_dimname   = 'unset'
+    stream_co2_surface_source_mesh_filename = 'unset'
+    stream_co2_surface_source_data_filename = 'unset'
+    stream_co2_surface_source_data_varname  = 'unset'
     stream_co2_surface_source_taxmode       = 'unset'
     stream_co2_surface_source_year_first    = -999 ! first year in stream to use
     stream_co2_surface_source_year_last     = -999 ! last  year in stream to use


### PR DESCRIPTION
Summary

Added new nearest_lat mapping option for CO2 surface source override.  Previously the stream was always regridded with bilinear, which required a mesh file. The nearest_lat option lets forcing data that is purely latitude-based (lat/time or lat/lev/time) be mapped directly onto the model grid without a mesh file.

Changes

src/cpl/nuopc/atm_stream_co2.F90
- Added two new namelist variables: stream_co2_surface_source_mapalgo (defaults to nearest_lat) and stream_co2_surface_source_lat_dimname.
- If  tream_co2_surface_source_mapalgo is set to 'nearest_lat - then
  - The mesh file must be set to 'none'
  - The stream_co2_surface_source_lat_dimname must be set (currently should be 'lat') for the datasets that are being used

bld/build-namelist
- Requires the two new variables to be defined when co2_surface_source is .true..
- Adds a consistency check: if mapalgo is nearest_lat, the mesh filename must be none.

bld/namelist_files/namelist_definition.xml
- Documents the two new namelist entries and updates the mesh-filename entry to note it must be none for nearest_lat.

NOTE: - this PR requires the companion CDEPS change that implements the mesh-free nearest_lat mapalgo - https://github.com/NorESMhub/CDEPS/pull/40.

Testing: 
Using the following compset/resolution
```
--compset 1850_CAM70%LT%NORESM%CAMoslo_CLM60%FATES-NCFB%NORESM_CICE_BLOM%HYB%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP 
--res ne16pg3_tn14
```
And the following namelist setting in user_nl_cam
```
co2_surface_source = .true.
stream_co2_surface_source_data_filename = 
stream_co2_surface_source_data_filename = '$DIN_LOC_ROOT/atm/waccm/lb/cmip7_ghg_version20260727/ghg_cmip7_CMIP_CR-CMIP-1-0-0_1750-2023_monthly_gnz_0p5degLat_version20260727.nc'
stream_co2_surface_source_data_varname = 'CO2_LBC'
stream_co2_surface_source_mesh_filename = 'none'
stream_co2_surface_source_mapalgo = 'nearest_lat'
stream_co2_surface_source_lat_dimname = 'lat'
stream_co2_surface_source_taxmode = 'extend'
stream_co2_surface_source_year_first = 1850
stream_co2_surface_source_year_last = 2023
stream_co2_surface_source_year_align = 1
```
Verified that the resulting coupler history file looked correct.